### PR TITLE
Flip hostname and timestamp in filename.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Files default to Unix line endings (\n)
+* text eol=lf
+
+# Windows line endings (\r\n)
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+

--- a/bin/support-diagnostics.ps1
+++ b/bin/support-diagnostics.ps1
@@ -24,7 +24,7 @@ Param(
 $esHost = 'http://localhost:9200/'
 $timestamp = Get-Date -format yyyyMMdd-HHmmss
 $hostName = [System.Net.Dns]::GetHostName()
-$outputDir = 'support-diagnostics'+'.'+$timestamp+'.'+$hostname
+$outputDir = 'support-diagnostics'+'.'+$hostname+'.'+$timestamp
 $targetNode = '_local'
 
 If ($H) {
@@ -53,7 +53,7 @@ If ($connectionTest.StatusCode -ne 200) {
     Write-Host Error connecting to $esHost
     Exit
 }
- 
+
 $nodenameStatus = (Invoke-WebRequest ($esHost+'_nodes/'+$targetNode+'/settings?pretty')).RawContent | Select-String '"nodes" : { }'
 If ($nodenameStatus) {
     Write-Host `n`nThe node/host name $hostName does not appear to be connected to your cluster.  This script will continue, however without gathering the log files or elasticsearch.yml`n`n

--- a/bin/support-diagnostics.sh
+++ b/bin/support-diagnostics.sh
@@ -12,17 +12,17 @@
 timestamp=$(date +"%Y%m%d-%H%M%S")
 
 # set defaults
-outputdir="support-diagnostics.$timestamp.$(hostname)"
+outputdir="support-diagnostics.$(hostname).$timestamp"
 eshost="localhost:9200"
 
 # pick up command line options
 while [ $# -gt 0 ]
 do
-    case "$1" in	
+    case "$1" in
 	-h | --h | --help)  cat <<EOM
 support-diagnostics.sh
 
-This script is used to gather diagnotistic information for elasticsearch support. 
+This script is used to gather diagnotistic information for elasticsearch support.
 In order to gather the elasticsearch config and logs you must run this on a node within your elasticsearch cluster.
 
   -h  This help message
@@ -148,18 +148,18 @@ then
     #Grab yml location from the API
     localNodeConfig=$(curl -s -S -XGET "$eshost/_nodes/$targetNode/settings?pretty" | grep -m1 -ohE "\"$configType\" : \".*?\"")
 
-    #Ensure the above curl succeeded 
+    #Ensure the above curl succeeded
     if [ $(echo $localNodeConfig |grep -q "\"$configType\" : \""; echo $?) -eq 0 ]
     then
 	#get just the config including full path
 	esConfigPath=$(echo $localNodeConfig | sed -e "s/\"$configType\" : \"//" -e 's/"//')
-	
+
 	echo "Getting config"
 	cpStatus=-1
 
 	#Check if the config directory we found exists
 	if [ -d "$esConfigPath" ]
-	then 
+	then
 	    mkdir $outputdir/config
 	    cp -r $esConfigPath/* $outputdir/config/
 
@@ -288,4 +288,3 @@ fi
 
 
 exit 0
-


### PR DESCRIPTION
Flips the parts within the filename for both the Unix and Windows scripts.

Added `.gitattributes` to guarantee Windows files get \r\n.

Closes #11 
