### PR TITLE
use _recovery and change cat_recovery.json to cat_recovery.txt

### DIFF
--- a/bin/es-plugin.properties
+++ b/bin/es-plugin.properties
@@ -1,2 +1,2 @@
 description=Support diagnostics plugin for elasticsearch
-version=1.0.0
+version=1.0.1

--- a/bin/support-diagnostics.ps1
+++ b/bin/support-diagnostics.ps1
@@ -136,8 +136,8 @@ If ($esVersion.StartsWith("0.9")) {
 
     Write-Host 'Getting indices stats'
     Invoke-WebRequest $esHost'/_stats?all&pretty&human' -OutFile $outputDir/indices_stats.json
+# API calls that only work with 1.0+
 } Else {
-    # API calls that only work with >1.0
     Write-Host 'Getting _nodes/stats'
     Invoke-WebRequest $esHost'/_nodes/stats?pretty&human' -OutFile $outputDir/nodes_stats.json
 
@@ -150,11 +150,18 @@ If ($esVersion.StartsWith("0.9")) {
     Write-Host 'Getting _cat/plugins'
     Invoke-WebRequest $esHost'/_cat/plugins?v' -OutFile $outputDir/plugins.txt
 
-    Write-Host 'Getting _cat/recovery'
-    Invoke-WebRequest $esHost'/_cat/recovery?v' -OutFile $outputDir/cat_recovery.json
-
     Write-Host 'Getting _cat/shards'
     Invoke-WebRequest $esHost'/_cat/shards?v' -OutFile $outputDir/cat_shards.txt
+
+    # API calls that only work with 1.1+
+    If (-Not $esVersion.StartsWith("1.0")) {
+        Write-Host 'Getting _recovery'
+        Invoke-WebRequest $esHost'/_recovery?detailed&pretty&human' -OutFile $outputDir/recovery.json
+    # API calls that only work with 1.0
+    } Else {
+        Write-Host 'Getting _cat/recovery'
+        Invoke-WebRequest $esHost'/_cat/recovery?v' -OutFile $outputDir/cat_recovery.txt
+    }
 }
 
 Write-Host 'Running netstat'

--- a/bin/support-diagnostics.sh
+++ b/bin/support-diagnostics.sh
@@ -227,8 +227,8 @@ if [[ $esVersion =~ 0.90.* ]]; then
     echo "Getting indices stats"
     curl -XGET "$eshost/_stats?all&pretty&human" >> $outputdir/indices_stats.json 2> /dev/null
 
+#api calls that only work with 1.0+
 else
-    #api calls that only work with >1.0
     echo "Getting _nodes/stats"
     curl -XGET "$eshost/_nodes/stats?pretty&human" >> $outputdir/nodes_stats.json 2> /dev/null
 
@@ -241,12 +241,18 @@ else
     echo "Getting _cat/plugins"
     curl -XGET "$eshost/_cat/plugins?v" >> $outputdir/plugins.txt 2> /dev/null
 
-    echo "Getting _/recovery"
-    curl -XGET "$eshost/_cat/recovery?v" >> $outputdir/cat_recovery.json 2> /dev/null
-
     echo "Getting _cat/shards"
     curl -XGET "$eshost/_cat/shards?v" >> $outputdir/cat_shards.txt 2> /dev/null
 
+    #api calls that only work with 1.1+
+    if [[ ! $esVersion =~ 1.0.* ]]; then
+        echo "Getting _recovery"
+        curl -XGET "$eshost/_recovery?detailed&pretty&human" >> $outputdir/recovery.json 2> /dev/null
+    #api calls that only work with 1.0
+    else
+        echo "Getting _cat/recovery"
+        curl -XGET "$eshost/_cat/recovery?v" >> $outputdir/cat_recovery.txt 2> /dev/null
+    fi
 fi
 
 


### PR DESCRIPTION
Changes `cat_recovery.json` to `cat_recovery.txt`, as it is not JSON-structured data. This also makes both echo statements match as `_cat/recovery`.
- Adds usage of `_recovery` (as `recovery.json`) when using ES version 1.1+.
- Limits usage of `_cat/recovery` to only be used on ES 1.0.x.
- Modified version to match current release.

Closes #16 
