### PR TITLE
Add Logstash Configuration directory.

### DIFF
--- a/elk/logstash/cat_shards.conf
+++ b/elk/logstash/cat_shards.conf
@@ -1,0 +1,85 @@
+# This is a Logstash configuration meant to ingest the output from _cat/shards.
+# Example usage:
+#
+#  cat path/to/support-diagnostics-dir/cat_shards.txt | bin/logstash agent -f path/to/cat_shards.conf
+#
+#  -OR-
+#
+#  bin/logstash agent -f path/to/cat_shards.conf
+#  <paste line-by-line>
+#
+# Dependencies:
+#  Elasticsearch 1.x (_cat/shards API)
+#
+# Tested Logstash version(s):
+#  Logstash 1.4.2
+
+# Currently, the easiest way to run this is to use a Unix system cat/pipe the cat_shards.txt file into the logstash process. Alternatively,
+# you can cherry pick your lines from the _cat/shards output and paste it on the command line directly after running.
+input {
+  stdin {}
+}
+
+# Parse the _cat/shards output
+filter {
+  # Ignore the header
+  if [message] =~ /^index\s+shard\s+prirep\s+state\s+docs\s+store\s+ip\s+node/ {
+    drop { }
+  }
+
+  # parse each line
+  grok {
+    match => {
+      "message" => '%{WORD:index_name}\s+%{NUMBER:shard:int}\s+%{WORD:pri_rep}\s+%{WORD:state}\s+%{NUMBER:docs:int}\s+%{NUMBER:size_on_disk}%{DATA:size_on_disk_units}\s+%{IPORHOST:ip}\s+%{GREEDYDATA:node}\s+?'
+    }
+  }
+
+  # turn the size on disk into sortable number
+  if [size_on_disk_units] == "pb" {
+    ruby {
+      code => "event['size_on_disk_bytes'] = Float(event['size_on_disk']) * 1024 * 1024 * 1024 * 1024 * 1024"
+    }
+  }
+  else if [size_on_disk_units] == "tb" {
+    ruby {
+      code => "event['size_on_disk_bytes'] = Float(event['size_on_disk']) * 1024 * 1024 * 1024 * 1024"
+    }
+  }
+  else if [size_on_disk_units] == "gb" {
+    ruby {
+      code => "event['size_on_disk_bytes'] = Float(event['size_on_disk']) * 1024 * 1024 * 1024"
+    }
+  }
+  else if [size_on_disk_units] == "mb" {
+    ruby {
+      code => "event['size_on_disk_bytes'] = Float(event['size_on_disk']) * 1024 * 1024"
+    }
+  }
+  else if [size_on_disk_units] == "kb" {
+    ruby {
+      code => "event['size_on_disk_bytes'] = Float(event['size_on_disk']) * 1024"
+    }
+  }
+  # currently pb is the largest output string coming from ES, so our last check is for bytes
+  else {
+    mutate { add_field => { "size_on_disk_bytes" => "%{size_on_disk}" } }
+  }
+
+  if [pri_rep] == "p" {
+    mutate { add_field => { "primary" => true } }
+  }
+
+  mutate {
+    convert => { "size_on_disk_bytes" => "float" }
+    strip => [ "node" ]
+    remove_field => "pri_rep"
+  }
+}
+
+output {
+#  stdout { codec => rubydebug }
+  elasticsearch {
+    protocol => "http"
+    host => "localhost"
+  }
+}


### PR DESCRIPTION
- Adds `_cat/shards` configuration for Logstash.

In the longer term it would be nice to have a script that we can point at a `tar`/`zip` from the support diagnostics, which could then auto-run all configurations, but it's easy enough to run them specifically for now.

It's probably useful to note that a lot of the results from the support-diagnostics script are from the same time, but this is not currently reflected in indexed results.

Closes #20 
