### PR TITLE
Retrieve compressed logs by default

### DIFF
--- a/src/main/java/com/elastic/support/diagnostics/InputParams.java
+++ b/src/main/java/com/elastic/support/diagnostics/InputParams.java
@@ -41,7 +41,7 @@ public class InputParams {
    private boolean isBzip = false;
 
    @Parameter(names = {"--archivedLogs"}, description = "Get archived logs in addition to current ones if present - No value required, only the option.")
-   private boolean archivedLogs=false;
+   private boolean archivedLogs=true;
 
    @Parameter(names = {"--scrub"}, description = "Set to true to use the scrub.yml dictionary to scrub logs and config files.  See README for more info.")
    private boolean scrubFiles = false;


### PR DESCRIPTION
Starting in Elasticsearch 6.0.0, when logs are rolled they will be compressed by default. This means that a support diagnostics dump should obtain these compressed logs too, otherwise a support diagnostics dump could be missing valuable logs for diagnosing an issue.

Relates elastic/elasticsearch#25660
