### PR TITLE
Added call to the role mapping API

### DIFF
--- a/src/main/resources/diags.yml
+++ b/src/main/resources/diags.yml
@@ -140,6 +140,7 @@ restQueries-5:
   watcher_stats: "_watcher/stats/_all"
   shield_users: "_xpack/security/user?pretty"
   shield_roles: "_xpack/security/role?pretty"
+  shield_roles_mapping: "_xpack/security/role_mapping?pretty"
   templates: "_template?pretty"
   nodeattrs: "_cat/nodeattrs"
   tasks: "_tasks?pretty&human&detailed"


### PR DESCRIPTION
In 5.5 we introduced the [role mapping API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-role-mapping.html) in addition to the role_mapping file. This PR adds a call to grab the results of this API.