### PR TITLE
JDK 11 update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <name>Support Diagnostics Utilities</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <log4j.version>2.11.0</log4j.version>
-        <java.ee.extras>2.2.11</java.ee.extras>
+        <log4j.version>2.11.1</log4j.version>
+        <java.ee.extras>2.3.1</java.ee.extras>
     </properties>
 
     <dependencies>
@@ -18,7 +18,7 @@
        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>4.1.6.RELEASE</version>
+            <version>5.1.3.RELEASE</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.5</version>
+            <version>4.5.6</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -42,13 +42,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.6</version>
+            <version>2.9.7</version>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>provided</scope>
         </dependency>
 
@@ -79,13 +79,13 @@
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
-            <version>1.48</version>
+            <version>1.72</version>
         </dependency>
 
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.19</version>
+            <version>1.23</version>
         </dependency>
 
         <dependency>
@@ -97,13 +97,13 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.16</version>
+            <version>1.18</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.7</version>
+            <version>3.8.1</version>
         </dependency>
 
         <dependency>
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>com.github.oshi</groupId>
             <artifactId>oshi-json</artifactId>
-            <version>3.5.0</version>
+            <version>3.11.0</version>
         </dependency>
 
         <!--
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-core</artifactId>
-            <version>${java.ee.extras}</version>
+            <version>2.3.0.1</version>
         </dependency>
 
         <dependency>
@@ -163,7 +163,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.8.0</version>
                 <configuration>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>true</showDeprecation>
@@ -171,7 +171,7 @@
                     <fork>true</fork>
                     <source>1.8</source>
                     <target>1.8</target>
-                    <compilerVersion>9</compilerVersion>
+                    <compilerVersion>11</compilerVersion>
                 </configuration>
             </plugin>
 

--- a/src/main/java/com/elastic/support/diagnostics/commands/SystemDigestCmd.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/SystemDigestCmd.java
@@ -2,6 +2,7 @@ package com.elastic.support.diagnostics.commands;
 
 import com.elastic.support.diagnostics.chain.DiagnosticContext;
 import com.elastic.support.util.SystemProperties;
+import com.elastic.support.util.SystemUtils;
 import oshi.hardware.CentralProcessor.TickType;
 import oshi.json.SystemInfo;
 import oshi.json.hardware.*;
@@ -113,7 +114,7 @@ public class SystemDigestCmd extends AbstractDiagnosticCmd {
       writer.newLine();
 
       writer.write("  release date: " + (firmware.getReleaseDate() == null ? "unknown"
-         : firmware.getReleaseDate() == null ? "unknown" : FormatUtil.formatDate(firmware.getReleaseDate())));
+         : firmware.getReleaseDate() == null ? "unknown" : firmware.getReleaseDate()));
       writer.newLine();
 
       final Baseboard baseboard = computerSystem.getBaseboard();


### PR DESCRIPTION
Changed compiler to JDK 11
Updated dependencies to latest.
Modified system digest to fix type change in updated version of oshi library.