### PR TITLE
Include ccr info, stats and auto follow pattern endpoints.

### DIFF
--- a/src/main/resources/diags.yml
+++ b/src/main/resources/diags.yml
@@ -120,6 +120,10 @@ rest-calls:
       minor-5:
         rollup_index_caps: "*/_xpack/rollup/data"
         security_priv: "_xpack/security/privilege?pretty"
+        ccr_stats: "_ccr/stats?pretty"
+        ccr_autofollow_patterns: "/_ccr/auto_follow?pretty"
+      minor-7:
+        ccr_follower_info: "_all/_ccr/info?pretty"
 
 elastic-threads:
   nodes: "_nodes?pretty&human"


### PR DESCRIPTION
CCR is going to be GA from 6.7, so it is time to include some of its endpoints in the diagnostic tool.