### PR TITLE
Fix issue with misleading Diagnostic Version Check message.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ It will execute a series of REST API calls to the running cluster, run a number 
 * Switch to the diagnostics distribution directory.
 
 ## Version check
-As a first step the diagnostic will check the Github repo for the current released version, and if not the same as the one running will:
-* Provide the URL for the current release.
-* Ask the user whether they wish to continue. 
+As a first step the diagnostic will check the Github repo for the current released version, and if not the same as the one running will provide the URL for the current release and then stop. The user will then be prompted to to press Enter before the diag continues.
 * For air gapped environments this can be bypassed by adding `--bypassDiagVerify` to the command line.
 
 ## Usage - Simplest Case

--- a/src/main/java/com/elastic/support/diagnostics/commands/DiagVersionCheckCmd.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/DiagVersionCheckCmd.java
@@ -71,24 +71,11 @@ public class DiagVersionCheckCmd implements Command {
                 logger.info("Warning: DiagnosticService version:{} is not the current recommended release", diagVersion);
                 logger.info("The current release is {}", ver);
                 logger.info("The latest version can be downloaded at {}", downloadUrl);
+                logger.info("Press the Enter key to continue.");
 
                 Scanner sc = new Scanner(System.in);
-                String feedback = null;
-                boolean valid = false;
-                System.out.println("Continue anyway? [Y/N]");
-                feedback = sc.nextLine();
-                while (!valid) {
-                    if ("y".equalsIgnoreCase(feedback) || "n".equalsIgnoreCase(feedback)) {
-                        valid = true;
-                    } else {
-                        System.out.println("Continue anyway? [Y/N]");
-                        feedback = sc.nextLine();
-                    }
-                }
+                sc.nextLine();
 
-                if ("n".equalsIgnoreCase(feedback)) {
-                    System.out.println("Exiting application");
-                }
             }
         } catch (Exception e) {
             logger.log(SystemProperties.DIAG, e);


### PR DESCRIPTION
Current behavior prompts user on whether to continue, but it will continue no matter which they select. Since exiting can be problematic change message to an alert that the diag is out of date, display the URL to the current version, and then stop. The user will then need to press Enter to continue.
