### PR TITLE
Bumped up timeout limits after reports of large stressed clusters exp…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.elasticsearch</groupId>
     <artifactId>support-diagnostics</artifactId>
-    <version>7.0.0</version>
+    <version>7.0.1</version>
     <packaging>jar</packaging>
     <name>Support Diagnostics Utilities</name>
     <properties>

--- a/src/main/resources/diags.yml
+++ b/src/main/resources/diags.yml
@@ -18,6 +18,7 @@ password-keys:
 
 text-file-extensions:
   - allocation
+  - cat_allocation
   - cat_aliases
   - cat_count
   - cat_fielddata
@@ -37,9 +38,9 @@ text-file-extensions:
 
 # Uncomment only if modifying defaults
 rest-config:
-   requestTimeout: 10000
-   connectTimeout: 5000
-   socketTimeout:  5000
+   requestTimeout: 30000
+   connectTimeout: 30000
+   socketTimeout:  120000
    maxTotalConn: 100
    maxConnPerRoute: 10
 


### PR DESCRIPTION
…eriencing drops. A read timeout will not trigger a retry.

Incremented  version number.