### PR TITLE
Stability Related Configuration Adjustments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.elasticsearch</groupId>
     <artifactId>support-diagnostics</artifactId>
-    <version>7.0.1</version>
+    <version>7.0.2</version>
     <packaging>jar</packaging>
     <name>Support Diagnostics Utilities</name>
     <properties>

--- a/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
+++ b/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
@@ -72,10 +72,11 @@ public class DiagnosticService extends BaseService {
 
     private RestClient createGenericClient(DiagConfig diagConfig, DiagnosticInputs diagnosticInputs) {
         RestClientBuilder builder = new RestClientBuilder();
+
         return builder
-                .setConnectTimeout(diagConfig.getRestConfig().get("connectTimeout"))
-                .setRequestTimeout(diagConfig.getRestConfig().get("requestTimeout"))
-                .setSocketTimeout(diagConfig.getRestConfig().get("socketTimeout"))
+                .setConnectTimeout(diagConfig.getRestConfig().get("connectTimeout") * 1000)
+                .setRequestTimeout(diagConfig.getRestConfig().get("requestTimeout") * 1000)
+                .setSocketTimeout(diagConfig.getRestConfig().get("socketTimeout") * 1000)
                 .setProxyHost(diagnosticInputs.getProxyUser())
                 .setProxPort(diagnosticInputs.getProxyPort())
                 .setProxyUser(diagnosticInputs.getUser())
@@ -87,9 +88,9 @@ public class DiagnosticService extends BaseService {
     private RestClient createEsRestClient(DiagConfig diagConfig, DiagnosticInputs diagnosticInputs) {
         RestClientBuilder builder = new RestClientBuilder();
         builder
-                .setConnectTimeout(diagConfig.getRestConfig().get("connectTimeout"))
-                .setRequestTimeout(diagConfig.getRestConfig().get("requestTimeout"))
-                .setSocketTimeout(diagConfig.getRestConfig().get("socketTimeout"))
+                .setConnectTimeout(diagConfig.getRestConfig().get("connectTimeout") * 1000)
+                .setRequestTimeout(diagConfig.getRestConfig().get("requestTimeout") * 1000)
+                .setSocketTimeout(diagConfig.getRestConfig().get("socketTimeout") * 1000)
                 .setProxyHost(diagnosticInputs.getProxyUser())
                 .setProxPort(diagnosticInputs.getProxyPort())
                 .setProxyUser(diagnosticInputs.getUser())

--- a/src/main/resources/diags.yml
+++ b/src/main/resources/diags.yml
@@ -38,9 +38,10 @@ text-file-extensions:
 
 # Uncomment only if modifying defaults
 rest-config:
-   requestTimeout: 30000
-   connectTimeout: 30000
-   socketTimeout:  120000
+   # timeouts in seconds
+   requestTimeout: 60
+   connectTimeout: 60
+   socketTimeout:  120
    maxTotalConn: 100
    maxConnPerRoute: 10
 
@@ -88,7 +89,7 @@ rest-calls:
     nodes: "_nodes?pretty&human"
     plugins: "_cat/plugins?format=json"
     recovery: "_recovery?pretty&human&detailed=true"
-    segments: "_segments?pretty&human&verbose"
+    segments: "_segments?pretty&human"
     settings: "_settings?pretty&human"
     shards: "_cat/shards?format=json&bytes=b&pretty"
     templates: "_template?pretty"


### PR DESCRIPTION
- removed verbose parameter from segments to prevent Elasticsearch exceptions on large clusters generating over 2G of output.
- increased connection and socket read  timeouts in REST calls.
- changed configuration units to seconds rather than milliseconds.
