### PR TITLE
ss command flag changes

### DIFF
--- a/src/main/resources/diags.yml
+++ b/src/main/resources/diags.yml
@@ -168,7 +168,7 @@ logstash:
 linuxOS:
   top: "top -b -n1"
   netstat: "netstat -an"
-  ss: "ss"
+  ss: "ss -an"
   process-list: "ps -ef"
   top_threads: "top -b -n1 -H"
   uname: "uname -a -r"
@@ -185,7 +185,6 @@ linuxOS:
   jstack: "JAVA_HOME/bin/jstack PID"
 
 macOS:
-  ss: "ss"
   top: "top -l 1"
   netstat: "netstat -an"
   process-list: "ps -ef"

--- a/src/test/resources/diags-test.yml
+++ b/src/test/resources/diags-test.yml
@@ -94,7 +94,7 @@ logstash:
 linuxOS:
   top: "top -b -n1"
   netstat: "netstat -an"
-  ss: "ss"
+  ss: "ss -an"
   process-list: "ps -ef"
   top_threads: "top -b -n1 -H"
   uname: "uname -a -r"
@@ -113,7 +113,6 @@ linuxOS-dep:
   jstack: "JAVA_HOME/bin/jstack PID"
 
 macOS:
-  ss: "ss"
   top: "top -l 1"
   netstat: "netstat -an"
   process-list: "ps -ef"


### PR DESCRIPTION
We do not need to `ss` to resolve service names and we would like to see all sockets.

Add `-an` to (from the man page):

* `-a` Display both listening and non-listening (for TCP this means established connections) sockets.
* `-n` Do not try to resolve service names.

Also removed the command from MacOS as it does not exist there.