### PR TITLE
Id auth errors

### DIFF
--- a/src/main/java/com/elastic/support/config/Constants.java
+++ b/src/main/java/com/elastic/support/config/Constants.java
@@ -5,6 +5,7 @@ public class Constants {
    public static final String ES_DIAG_DEFAULT = "standard";
    public static final String ES_DIAG = "diagnostics";
    public static final String NOT_FOUND = "not found";
+   public static final String CHECK_LOG = "Check diagnostics.log in the archive file for more detail.";
 
    public static final String DIAG_CONFIG = "diags.yml";
    public static final String CHAINS_CONFIG = "chains.yml";

--- a/src/main/java/com/elastic/support/diagnostics/DiagnosticApp.java
+++ b/src/main/java/com/elastic/support/diagnostics/DiagnosticApp.java
@@ -4,6 +4,8 @@ import com.elastic.support.config.Constants;
 import com.elastic.support.config.DiagConfig;
 import com.elastic.support.config.DiagnosticInputs;
 import com.elastic.support.util.JsonYamlUtils;
+import com.elastic.support.util.SystemProperties;
+import com.elastic.support.util.SystemUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -16,19 +18,24 @@ public class DiagnosticApp {
 
     public static void main(String[] args) {
 
-        DiagnosticInputs diagnosticInputs = new DiagnosticInputs();
-        diagnosticInputs.parseInputs(args);
-        if (!diagnosticInputs.validate()) {
-            logger.info("Exiting...");
-            System.exit(0);
+
+        try {
+            DiagnosticInputs diagnosticInputs = new DiagnosticInputs();
+            diagnosticInputs.parseInputs(args);
+            if (!diagnosticInputs.validate()) {
+                logger.info("Exiting...");
+                System.exit(0);
+            }
+
+            Map diagMap =JsonYamlUtils.readYamlFromClasspath(Constants.DIAG_CONFIG, true);
+            DiagConfig diagConfig = new DiagConfig(diagMap);
+            Map<String, List<String>> chains = JsonYamlUtils.readYamlFromClasspath(Constants.CHAINS_CONFIG, true);
+
+            DiagnosticService diag = new DiagnosticService();
+            diag.exec(diagnosticInputs, diagConfig, chains);
+        } catch (Throwable t) {
+            logger.log(SystemProperties.DIAG, "Unanticipated error", t);
         }
-
-        Map diagMap =JsonYamlUtils.readYamlFromClasspath(Constants.DIAG_CONFIG, true);
-        DiagConfig diagConfig = new DiagConfig(diagMap);
-        Map<String, List<String>> chains = JsonYamlUtils.readYamlFromClasspath(Constants.CHAINS_CONFIG, true);
-
-        DiagnosticService diag = new DiagnosticService();
-        diag.exec(diagnosticInputs, diagConfig, chains);
     }
 
 }

--- a/src/main/java/com/elastic/support/diagnostics/DiagnosticException.java
+++ b/src/main/java/com/elastic/support/diagnostics/DiagnosticException.java
@@ -5,12 +5,6 @@ import java.util.List;
 
 public class DiagnosticException extends RuntimeException {
 
-    List params;
-
-    public List getParams() {
-        return params;
-    }
-
     public DiagnosticException() {
     }
 
@@ -28,11 +22,6 @@ public class DiagnosticException extends RuntimeException {
 
     public DiagnosticException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
         super(message, cause, enableSuppression, writableStackTrace);
-    }
-
-    public DiagnosticException(String message, List params){
-        super(message);
-        this.params = params;
     }
 
 }

--- a/src/main/java/com/elastic/support/diagnostics/DiagnosticException.java
+++ b/src/main/java/com/elastic/support/diagnostics/DiagnosticException.java
@@ -1,0 +1,38 @@
+package com.elastic.support.diagnostics;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DiagnosticException extends RuntimeException {
+
+    List params;
+
+    public List getParams() {
+        return params;
+    }
+
+    public DiagnosticException() {
+    }
+
+    public DiagnosticException(String message) {
+        super(message);
+    }
+
+    public DiagnosticException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DiagnosticException(Throwable cause) {
+        super(cause);
+    }
+
+    public DiagnosticException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public DiagnosticException(String message, List params){
+        super(message);
+        this.params = params;
+    }
+
+}

--- a/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
+++ b/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
@@ -59,7 +59,7 @@ public class DiagnosticService extends BaseService {
             dc.runDiagnostic(ctx, chain);
 
             if (ctx.isDocker()){
-                logger.warn("Identified Docker installations - bypassing log collection and system calls.");
+                logger.warn("Identified Docker installations - bypassed log collection and system calls.");
             }
 
             String user = ctx.getDiagnosticInputs().getUser();

--- a/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
+++ b/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
@@ -1,6 +1,7 @@
 package com.elastic.support.diagnostics;
 
 import com.elastic.support.BaseService;
+import com.elastic.support.config.Constants;
 import com.elastic.support.config.DiagConfig;
 import com.elastic.support.config.DiagnosticInputs;
 import com.elastic.support.diagnostics.chain.DiagnosticChainExec;
@@ -79,12 +80,10 @@ public class DiagnosticService extends BaseService {
 
             }
         } catch (DiagnosticException de) {
-            logger.info("Fatal error in diagnostic - could not continue. See diagnostics.log in archive or temp directory for more details.");
-            logger.log(SystemProperties.DIAG, "Fatal error in commands", de);
-
-        } catch (IOException e) {
-            logger.error("Access issue with temp directory", e);
-            throw new RuntimeException("Issue with creating temp directory - see logs for details.");
+            logger.warn(de.getMessage());
+        } catch (Throwable t) {
+            logger.log(SystemProperties.DIAG, "Temp directory error" , t);
+            logger.warn(String.format("Issue with creating temp directory. %s", Constants.CHECK_LOG));
         } finally {
             closeLogs();
             createArchive(ctx.getTempDir());

--- a/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
+++ b/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
@@ -57,10 +57,7 @@ public class DiagnosticService extends BaseService {
 
             dc.runDiagnostic(ctx, chain);
 
-            if(ctx.isBypassSystemCalls()){
-                logger.warn("Could not locate local node - bypassing log collection and system calls.");
-            }
-            else if (ctx.isDocker()){
+            if (ctx.isDocker()){
                 logger.warn("Identified Docker installations - bypassing log collection and system calls.");
             }
 

--- a/src/main/java/com/elastic/support/diagnostics/chain/Chain.java
+++ b/src/main/java/com/elastic/support/diagnostics/chain/Chain.java
@@ -1,7 +1,10 @@
 package com.elastic.support.diagnostics.chain;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import com.elastic.support.diagnostics.DiagnosticException;
+import com.elastic.support.util.SystemProperties;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -9,7 +12,7 @@ import java.util.List;
 
 public class Chain implements Command {
 
-    Logger logger = LoggerFactory.getLogger(Chain.class);
+    Logger logger = LogManager.getLogger(Chain.class);
     List<Command> commandChain = new ArrayList<>();
 
     public Chain(List<String> commandList){
@@ -28,9 +31,14 @@ public class Chain implements Command {
 
     public void execute(DiagnosticContext context){
 
-        //Set up initial generic chain
-        for(Command dc : commandChain){
-            dc.execute(context);
+        try {
+            //Set up initial generic chain
+            for(Command dc : commandChain){
+                dc.execute(context);
+            }
+        }
+        catch (Exception e){
+            throw new DiagnosticException("Uncaught error", e);
         }
     }
 

--- a/src/main/java/com/elastic/support/diagnostics/chain/Chain.java
+++ b/src/main/java/com/elastic/support/diagnostics/chain/Chain.java
@@ -15,30 +15,34 @@ public class Chain implements Command {
     Logger logger = LogManager.getLogger(Chain.class);
     List<Command> commandChain = new ArrayList<>();
 
-    public Chain(List<String> commandList){
+    public Chain(List<String> commandList) {
         try {
-            for (String commandClass : commandList){
+            for (String commandClass : commandList) {
                 Class clazz = Class.forName(commandClass);
-                Command cmd = (Command)clazz.getConstructor().newInstance();
+                Command cmd = (Command) clazz.getConstructor().newInstance();
                 commandChain.add(cmd);
             }
-        } catch(Exception e) {
+        } catch (Exception e) {
             String msg = "Error: could not create the configured command class.";
             logger.error(msg, e);
             throw new IllegalArgumentException("Error creating chain", e);
         }
     }
 
-    public void execute(DiagnosticContext context){
+    public void execute(DiagnosticContext context) {
 
         try {
             //Set up initial generic chain
-            for(Command dc : commandChain){
+            for (Command dc : commandChain) {
                 dc.execute(context);
             }
-        }
-        catch (Exception e){
-            throw new DiagnosticException("Uncaught error", e);
+        } catch (DiagnosticException de) {
+            // This was thrown to break out of the command chain so
+            // just pass it along.
+            throw de;
+        } catch (Throwable t) {
+            logger.log(SystemProperties.DIAG, "Unanticipated error.", t);
+            throw new DiagnosticException("Uncaught error");
         }
     }
 

--- a/src/main/java/com/elastic/support/diagnostics/chain/DiagnosticChainExec.java
+++ b/src/main/java/com/elastic/support/diagnostics/chain/DiagnosticChainExec.java
@@ -1,5 +1,6 @@
 package com.elastic.support.diagnostics.chain;
 
+import com.elastic.support.config.Constants;
 import com.elastic.support.diagnostics.DiagnosticException;
 import com.elastic.support.util.SystemProperties;
 import org.apache.logging.log4j.LogManager;
@@ -18,11 +19,13 @@ public class DiagnosticChainExec {
             Chain diagnostic = new Chain(chain);
             diagnostic.execute(context);
 
-        } catch (Exception e) {
-            logger.log(SystemProperties.DIAG, "Error encountered running diagnostic. See logs for additional information.  Exiting application.", e);
-            throw new DiagnosticException("DiagnosticService runtime error");
+        } catch (DiagnosticException de) {
+            throw de;
         }
-
+        catch (Throwable t){
+            logger.log(SystemProperties.DIAG, "Unexpected error", t);
+            throw new DiagnosticException(String.format("Fatal error in diagnostic - could not continue. %s", Constants.CHECK_LOG));
+        }
     }
 
 }

--- a/src/main/java/com/elastic/support/diagnostics/chain/DiagnosticChainExec.java
+++ b/src/main/java/com/elastic/support/diagnostics/chain/DiagnosticChainExec.java
@@ -1,5 +1,6 @@
 package com.elastic.support.diagnostics.chain;
 
+import com.elastic.support.diagnostics.DiagnosticException;
 import com.elastic.support.util.SystemProperties;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -19,7 +20,7 @@ public class DiagnosticChainExec {
 
         } catch (Exception e) {
             logger.log(SystemProperties.DIAG, "Error encountered running diagnostic. See logs for additional information.  Exiting application.", e);
-            throw new RuntimeException("DiagnosticService runtime error");
+            throw new DiagnosticException("DiagnosticService runtime error");
         }
 
     }

--- a/src/main/java/com/elastic/support/diagnostics/commands/BaseQueryCmd.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/BaseQueryCmd.java
@@ -78,7 +78,7 @@ public abstract class BaseQueryCmd implements Command {
                     // error that's retryable such as an auth error remove it.
                     restCallManifest.setCallHistory(queryName, i, false);
 
-                    if (!requireRetry.contains(queryName) || !isRetryable(restResult.getStatus())) {
+                    if (!requireRetry.contains(queryName) || ! RestResult.isRetryable(restResult.getStatus())) {
                         iter.remove();
                         restResult.toFile(filename);
                         logger.info("Call failed. Bypassing.");
@@ -126,28 +126,7 @@ public abstract class BaseQueryCmd implements Command {
         return fileName;
     }
 
-    public boolean isRetryable(int statusCode) {
 
-        if (statusCode == 400) {
-            logger.info("No data retrieved.");
-            return true;
-        } else if (statusCode == 401) {
-            logger.info("Authentication failure: invalid login credentials. Check logs for details.");
-            return false;
-        } else if (statusCode == 403) {
-            logger.info("Authorization failure or invalid license. Check logs for details.");
-            return false;
-        } else if (statusCode == 404) {
-            logger.info("Endpoint does not exist.");
-            return true;
-        } else if (statusCode >= 500 && statusCode < 600) {
-            logger.info("Unrecoverable server error.");
-            return true;
-        }
-
-        return false;
-
-    }
 
 
 }

--- a/src/main/java/com/elastic/support/diagnostics/commands/BaseQueryCmd.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/BaseQueryCmd.java
@@ -81,7 +81,7 @@ public abstract class BaseQueryCmd implements Command {
                     if (!requireRetry.contains(queryName) || ! RestResult.isRetryable(restResult.getStatus())) {
                         iter.remove();
                         restResult.toFile(filename);
-                        logger.info("Call failed. Bypassing.");
+                        logger.info("Call failed. Bypassing. See archived diagnostics.log for more detail.");
 
                     } else {
                         // If it failed, it's in the list and it's last try, write it out

--- a/src/main/java/com/elastic/support/diagnostics/commands/BaseQueryCmd.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/BaseQueryCmd.java
@@ -79,7 +79,7 @@ public abstract class BaseQueryCmd implements Command {
                 }
 
                 // If it succeeded take it out of future work
-                if (restResult.getStatus() == 200) {
+                if (restResult.isValid()) {
                     iter.remove();
                     restCallManifest.setCallHistory(queryName, i, true);
                     logger.info("Results written to: {}", filename);
@@ -88,10 +88,10 @@ public abstract class BaseQueryCmd implements Command {
                     // error that's retryable such as an auth error remove it.
                     restCallManifest.setCallHistory(queryName, i, false);
 
-                    if (!requireRetry.contains(queryName) || ! RestResult.isRetryable(restResult.getStatus())) {
+                    if (!requireRetry.contains(queryName) || !restResult.isRetryable() ) {
                         iter.remove();
                         restResult.toFile(filename);
-                        logger.info("Call failed: {}  {}. Bypassing. See archived diagnostics.log for more detail.", restResult.getStatus(), restResult.getReason());
+                        logger.info(restResult.formatStatusMessage("Call failed: Bypassing. See archived diagnostics.log for more detail."));
 
                     } else {
                         // If it failed, it's in the list and it's last try, write it out
@@ -99,7 +99,7 @@ public abstract class BaseQueryCmd implements Command {
                             restResult.toFile(filename);
                         }
                         else {
-                            logger.info("Call failed: {}  {} - Flagged for retry.", restResult.getStatus(), restResult.getReason());
+                            logger.info(restResult.formatStatusMessage("Call failed: Flagged for retry."));
                         }
                     }
                 }

--- a/src/main/java/com/elastic/support/diagnostics/commands/RunClusterQueriesCmd.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/RunClusterQueriesCmd.java
@@ -2,7 +2,9 @@ package com.elastic.support.diagnostics.commands;
 
 import com.elastic.support.config.DiagConfig;
 import com.elastic.support.config.Version;
+import com.elastic.support.diagnostics.DiagnosticException;
 import com.elastic.support.diagnostics.chain.DiagnosticContext;
+import com.elastic.support.util.SystemProperties;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -21,14 +23,19 @@ public class RunClusterQueriesCmd extends BaseQueryCmd {
 
     public void execute(DiagnosticContext context) {
 
-        Version version = context.getVersion();
+        try {
+            Version version = context.getVersion();
 
-        DiagConfig diagConfig = context.getDiagsConfig();
-        Map restCalls = diagConfig.getRestCalls();
+            DiagConfig diagConfig = context.getDiagsConfig();
+            Map restCalls = diagConfig.getRestCalls();
 
-        Map<String, String> entries = buildStatementsByVersion(version, restCalls);
+            Map<String, String> entries = buildStatementsByVersion(version, restCalls);
 
-        runQueries(context.getEsRestClient(), entries, context.getTempDir(), diagConfig);
+            runQueries(context.getEsRestClient(), entries, context.getTempDir(), diagConfig);
+        } catch (Throwable t) {
+            logger.error("Error executing REST queries - exiting");
+            throw new DiagnosticException("REST Query Execution error", t);
+        }
 
     }
 

--- a/src/main/java/com/elastic/support/diagnostics/commands/RunClusterQueriesCmd.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/RunClusterQueriesCmd.java
@@ -1,5 +1,6 @@
 package com.elastic.support.diagnostics.commands;
 
+import com.elastic.support.config.Constants;
 import com.elastic.support.config.DiagConfig;
 import com.elastic.support.config.Version;
 import com.elastic.support.diagnostics.DiagnosticException;
@@ -33,8 +34,8 @@ public class RunClusterQueriesCmd extends BaseQueryCmd {
 
             runQueries(context.getEsRestClient(), entries, context.getTempDir(), diagConfig);
         } catch (Throwable t) {
-            logger.error("Error executing REST queries - exiting");
-            throw new DiagnosticException("REST Query Execution error", t);
+            logger.log(SystemProperties.DIAG, "Error executing REST queries", t);
+            throw new DiagnosticException(String.format("REST Query Execution error - exiting. %s", Constants.CHECK_LOG));
         }
 
     }

--- a/src/main/java/com/elastic/support/diagnostics/commands/RunLogstashQueriesCmd.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/RunLogstashQueriesCmd.java
@@ -1,9 +1,11 @@
 package com.elastic.support.diagnostics.commands;
 
+import com.elastic.support.config.Constants;
 import com.elastic.support.config.DiagConfig;
 import com.elastic.support.diagnostics.DiagnosticException;
 import com.elastic.support.diagnostics.chain.DiagnosticContext;
 import com.elastic.support.util.JsonYamlUtils;
+import com.elastic.support.util.SystemProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -32,8 +34,8 @@ public class RunLogstashQueriesCmd extends BaseQueryCmd {
          context.setPid(pid);
 
       } catch (Throwable t) {
-         logger.error("Error obtaining logstash output and/or process id");
-         throw new DiagnosticException("Logstash Query Execution error", t);
+         logger.log(SystemProperties.DIAG, "Logstash Query error:", t);
+         throw new DiagnosticException(String.format("Error obtaining logstash output and/or process id - exiting. %s", Constants.CHECK_LOG));
       }
    }
 

--- a/src/main/java/com/elastic/support/diagnostics/commands/RunLogstashQueriesCmd.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/RunLogstashQueriesCmd.java
@@ -1,6 +1,7 @@
 package com.elastic.support.diagnostics.commands;
 
 import com.elastic.support.config.DiagConfig;
+import com.elastic.support.diagnostics.DiagnosticException;
 import com.elastic.support.diagnostics.chain.DiagnosticContext;
 import com.elastic.support.util.JsonYamlUtils;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -30,10 +31,10 @@ public class RunLogstashQueriesCmd extends BaseQueryCmd {
          String pid = jvm.path("pid").asText();
          context.setPid(pid);
 
-      } catch (Exception e) {
-         logger.error("Error obtaining logstash output and/or process id", e);
+      } catch (Throwable t) {
+         logger.error("Error obtaining logstash output and/or process id");
+         throw new DiagnosticException("Logstash Query Execution error", t);
       }
-
    }
 
 

--- a/src/main/java/com/elastic/support/diagnostics/commands/VersionCheckCmd.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/VersionCheckCmd.java
@@ -1,5 +1,6 @@
 package com.elastic.support.diagnostics.commands;
 
+import com.elastic.support.config.Constants;
 import com.elastic.support.config.DiagnosticInputs;
 import com.elastic.support.config.Version;
 import com.elastic.support.diagnostics.DiagnosticException;
@@ -8,6 +9,7 @@ import com.elastic.support.diagnostics.chain.DiagnosticContext;
 import com.elastic.support.rest.RestClient;
 import com.elastic.support.rest.RestResult;
 import com.elastic.support.util.JsonYamlUtils;
+import com.elastic.support.util.SystemProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -31,22 +33,21 @@ public class VersionCheckCmd implements Command {
         logger.info("Getting Elasticsearch Version.");
 
         try {
-            DiagnosticInputs diagnosticInputs = context.getDiagnosticInputs();
             RestClient restClient = context.getEsRestClient();
             RestResult res = restClient.execQuery("/");
-            if(res.getStatus() != 200)){
-                throw new DiagnosticException("Unrecoverable ES query error.");
+            if (! res.isValid()) {
+                throw new DiagnosticException( res.formatStatusMessage( "Could not retrieve the Elasticsearch version - unable to continue."));
             }
-
             String result = res.toString();
             JsonNode root = JsonYamlUtils.createJsonNodeFromString(result);
             String versionNumber = root.path("version").path("number").asText();
             Version version = new Version(versionNumber);
             context.setVersion(version);
-        } catch (Exception e) {
-            logger.error("Could not retrieve the Elasticsearch version - unable to continue.");
-            throw new DiagnosticException("Undetermined error", e);
+        } catch (DiagnosticException de) {
+            throw de;
+        } catch (Throwable t) {
+            logger.log(SystemProperties.DIAG, "Unanticipated error:", t);
+            throw new DiagnosticException(String.format("Could not retrieve the Elasticsearch version due to a system or network error - unable to continue. %s", Constants.CHECK_LOG));
         }
-
     }
 }

--- a/src/main/java/com/elastic/support/diagnostics/commands/VersionCheckCmd.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/VersionCheckCmd.java
@@ -34,8 +34,7 @@ public class VersionCheckCmd implements Command {
             DiagnosticInputs diagnosticInputs = context.getDiagnosticInputs();
             RestClient restClient = context.getEsRestClient();
             RestResult res = restClient.execQuery("/");
-            if(! RestResult.isSuccess(res.getStatus())){
-                RestResult.isRetryable(res.getStatus());
+            if(res.getStatus() != 200)){
                 throw new DiagnosticException("Unrecoverable ES query error.");
             }
 

--- a/src/main/java/com/elastic/support/rest/RestResult.java
+++ b/src/main/java/com/elastic/support/rest/RestResult.java
@@ -102,10 +102,10 @@ public class RestResult implements Cloneable {
             logger.info("No data retrieved.");
             return true;
         } else if (statusCode == 401) {
-            logger.info("Authentication failure: invalid login credentials. Check logs for details.");
+            logger.info("Authentication failure: invalid login credentials.");
             return false;
         } else if (statusCode == 403) {
-            logger.info("Authorization failure or invalid license. Check logs for details.");
+            logger.info("Authorization failure or invalid license.");
             return false;
         } else if (statusCode == 404) {
             logger.info("Endpoint does not exist.");

--- a/src/main/java/com/elastic/support/rest/RestResult.java
+++ b/src/main/java/com/elastic/support/rest/RestResult.java
@@ -27,8 +27,7 @@ public class RestResult implements Cloneable {
     // to disk or the body is stored as a string and the status retained as well.
     public RestResult(HttpResponse response) {
         try{
-            this.status = response.getStatusLine().getStatusCode();
-            this.reason = response.getStatusLine().getReasonPhrase();
+            processCodes(response);
             responseString = EntityUtils.toString(response.getEntity());
         }
         catch (Exception e){
@@ -49,12 +48,11 @@ public class RestResult implements Cloneable {
         // If the query got a success status stream the result immediately to the target file.
         // If not, the result should be small and contain diagnostic info so stgre it in the response string.
         try{
-            this.status = response.getStatusLine().getStatusCode();
+            processCodes(response);
             if (status == 200) {
                 response.getEntity().writeTo(out);
             } else {
-                this.reason = response.getStatusLine().getReasonPhrase();
-                this.responseString = EntityUtils.toString(response.getEntity());
+                responseString = EntityUtils.toString(response.getEntity());
             }
         } catch (Exception e) {
             logger.log(SystemProperties.DIAG, "Error Streaming Response To OutputStream", e);
@@ -62,6 +60,14 @@ public class RestResult implements Cloneable {
         }
         finally {
             HttpClientUtils.closeQuietly(response);
+        }
+    }
+
+    private void processCodes(HttpResponse response){
+        status = response.getStatusLine().getStatusCode();
+        reason = response.getStatusLine().getReasonPhrase();
+        if(status != 200){
+            logger.log(SystemProperties.DIAG, "Error occurred. Status: {}, Reason: {}", status, reason);
         }
     }
 

--- a/src/main/java/com/elastic/support/rest/RestResult.java
+++ b/src/main/java/com/elastic/support/rest/RestResult.java
@@ -39,10 +39,6 @@ public class RestResult implements Cloneable {
         }
     }
 
-    public RestResult(String reason){
-        this.reason = reason;
-    }
-
     public RestResult(HttpResponse response, OutputStream out) {
 
         // If the query got a success status stream the result immediately to the target file.

--- a/src/main/java/com/elastic/support/rest/RestResult.java
+++ b/src/main/java/com/elastic/support/rest/RestResult.java
@@ -85,4 +85,37 @@ public class RestResult implements Cloneable {
             logger.log(SystemProperties.DIAG, "Error writing Response To OutputStream", e);
         }
     }
+
+    public static boolean isSuccess(int statusCode){
+
+        if (statusCode == 200){
+            return true;
+        }
+
+        return false;
+
+    }
+
+    public static boolean isRetryable(int statusCode) {
+
+        if (statusCode == 400) {
+            logger.info("No data retrieved.");
+            return true;
+        } else if (statusCode == 401) {
+            logger.info("Authentication failure: invalid login credentials. Check logs for details.");
+            return false;
+        } else if (statusCode == 403) {
+            logger.info("Authorization failure or invalid license. Check logs for details.");
+            return false;
+        } else if (statusCode == 404) {
+            logger.info("Endpoint does not exist.");
+            return true;
+        } else if (statusCode >= 500 && statusCode < 600) {
+            logger.info("Undetermined server error.");
+            return true;
+        }
+
+        return false;
+
+    }
 }

--- a/src/main/java/com/elastic/support/rest/RestResult.java
+++ b/src/main/java/com/elastic/support/rest/RestResult.java
@@ -88,16 +88,6 @@ public class RestResult implements Cloneable {
         }
     }
 
-    public static boolean isSuccess(int statusCode){
-
-        if (statusCode == 200){
-            return true;
-        }
-
-        return false;
-
-    }
-
     public static boolean isRetryable(int statusCode) {
 
         if (statusCode == 400) {


### PR DESCRIPTION
Closes #293 
* Reworked error handling, moving some of the logging and checking down to the result level from the BaseQuery and changing the command execution to break out of the chain execution on a fatal error, such as a bad version check call. Add specific error codes to display in order to flag a bad login at the command line.