### PR TITLE
Fix 32 byte character limit on obfuscation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,13 @@ As a first step the diagnostic will check the Github repo for the current releas
 * For air gapped environments this can be bypassed by adding `--bypassDiagVerify` to the command line.
 
 ## Usage - Simplest Case
-* Run the application via the diagnostics.sh or diagnostics.bat script. The host name or IP address used by the HTTP connector of the node is required.
+* Run the application via the diagnostics.sh or diagnostics.bat script. The host name or IP address used by the HTTP connector of the node is required. IP address will generally ensure the best result.
 * In order to assure that all artifacts are collected it is recommended that you run the tool with elevated privileges. This means sudo on Linux type platforms and via an Administor Prompt in Windows.
 * A hostname or IP address must now be specified via the `--host` parameter. This is due to the changes in default port binding what were introduced starting with version 2. You must supply this even if you are running as localhost.
 * The utility will use default listening port of `9200` if you do not specify one.
 * If the utility cannot find a running ES version for that host/port combination the utility will exit and you will need to run it again.
 * Input parameters may be specified in any order.
 * An archive with the format diagnostics-`<DateTimeStamp>`.tar.gz will be created in the utility directory. If you wish to specify a specific output folder you may do so by using the -o `<Full path to custom output folder>` option.
-
 
 #### Basic Usage Examples
     NOTE: Windows users use .\diagnostics.bat instead of ./diagnostics.sh
@@ -59,7 +58,7 @@ As a first step the diagnostic will check the Github repo for the current releas
 
 ## Using With Shield/Security
 * a truststore does not need to be specified - it's assumed you are running this against a node that you set up and if you didn't trust it you wouldn't be running this.
-* When using Shield authentication, do not specify a password and the `-p` option.  Using the `-p` option will bring up a prompt for you to type an obfuscated value that will not be displayed on the command history.
+* When using security authentication, do not specify a password and the `-p` option.  Using the `-p` option will bring up a prompt for you to type an obfuscated value that will not be displayed on the command history.
 * `--noVerify` will bypass hostname verification with SSL.
 * `--keystore` and --keystorePass` allow you to specify client side certificates for authentication.
 * To script the utility when using Shield/Security, you may use the `--ptp` option to allow you to pass a plain text password to the command line rather than use `-p` and get a prompt.  Note that this is inherently insecure - use at your own risk.
@@ -83,7 +82,6 @@ If the presence of a proxy server prevents the diagnostic from being run(general
 * --proxyPort
 * --proxyUser
 * --proxyPassword 
-
 
 ### Customizing the output
 The `diag.yml` file in the `/lib/support-diagnostics-x.x.x` contains all the REST and system commands that will be run. These are tied to a particular version. You can extract this file and remove commands you do not wish to run as well as adding any that may not be currently included. Place this revised file in the directory containing the diagnostics.sh script and it will override the settings contained in the jar.
@@ -117,43 +115,40 @@ $ sudo .diagnostics.sh --host 10.0.0.20 --dockerId 4577fe120750
     sudo ./diagnostics.sh --host localhost --type logstash
     sudo ./diagnostics.sh --host localhost --type logstash --port 9610
 
-### Multiple Runs At Timed Intervals
-This option has been removed. If you used this feature or have a use case for this functionality, please open an issue.
-
-#### Examples - 6 runs with 20 seconds separating each run
-    sudo ./diagnostics.sh --host localhost -u elastic -p --interval 600 --reps 6
-    sudo ./diagnostics.sh --host localhost -u elastic -p --interval 600 --reps 6 --type remote
-    sudo ./diagnostics.sh --host localhost -u elastic -p --interval 600 --reps 6 --type logstash 
-
 ## File Sanitization Utility
 
 #### Description
 * Works on diagnostics produced by version 6.4 and later. Please don't turn in a ticket if you run it on an older one.
 * Runs as a separate application from the diagnostic. It does not need to be run on the same host the diagnostic utility ran on.
-* Inputs an archive produced via a normal diagnostic run.
-* Goes through each file in that archive line by line and does the following:
+* Inputs an archive produced via a normal diagnostic run or a single file such as a log.
+* Goes through each line in each file in that archive line by line and does the following:
   * Automatically obfuscates all IPv4 and IPv6 addresses. These will be consistent throughout all files in the archive. In other words, it encounters 10.0.0.5 in one file, the obfuscated value will be used for all occurrences of the IP in other files. These will not, however be consistent from run to run.
   * Obfuscates MAC addresses.
   * If you include a configuration file of supplied string tokens, any occurrence of that token will be replaced with a generated replacement. As with IP's this will be consistent from file to file but not between runs. Literal strings or regex's may be used.
-* Re-archives the file with "scrubbed-" prepended to the  name. An example file (`scrub.yml`) is included as an example.
-* If you are processing a large cluster's diagnostic, this may take a while to run, and you may need to use the `DIAG_JAVA_OPTS` environment variable to bump up the Java Heap if you see OutOfMemoryExceptions.
+* If running against a standard diagnostic package, re-archives the file with "scrubbed-" prepended to the  name. An example file (`scrub.yml`) is included as an example. Single files will be written to the output directiory prepended with _scrubbed-_.
+* If you are processing a large cluster's diagnostic, this may take a while to run, and you may need to use the `DIAG_JAVA_OPTS` environment variable to bump up the Java Heap if processing is extremely slow or you see OutOfMemoryExceptions.
 
 #### How to run
 * Run the diagnostic utility to get an archive.
 * Add any tokens for text you wish to conceal to a config file. By default the utility will look for scrub.yml in the working directory.
 * Run the utility with the necessary and optional diagnosticInputs. It is a different script execution than the diagnostic with different arguments.
-  * *-a* &nbsp;&nbsp;&nbsp; An absolute path to the archive file you wish to sanitize(required)
-  * *-t* &nbsp;&nbsp;&nbsp; A target directory where you want the revised archive written. If not supplied it will be written to the same folder as the diagnostic archive it processed.
-  * *-f* &nbsp;&nbsp;&nbsp; A file containing any text tokens you wish to conceal. These can be literals or regex's. 
+  * *-a*, *--archive* &nbsp;&nbsp;&nbsp; An absolute path to the archive file you wish to sanitize(required if single file not specified).
+  * *-i*, *--infile* &nbsp;&nbsp;&nbsp; An absolute path to the individual file you wish to sanitize(required if diagnostic archive file not specified).
+  * *-o*, *--out*, *--output*, *--outputDir* &nbsp;&nbsp;&nbsp; A target directory where you want the revised archive written. If not supplied it will be written to the same folder as the diagnostic archive it processed.
+  * *-c*, *--config* &nbsp;&nbsp;&nbsp; The configuration file containing any text tokens you wish to conceal. These can be literals or regex's. The default is the scrub.yml contained in the jar distribution.
 
 #### Examples
 #####With no tokens specified, writing the same directory as the diagnostic:
 ```$xslt
-./scrub.sh -a diagnostics-20180621-161231.tar.gz
+./scrub.sh -a /home/adminuser/diagoutput/diagnostics-20180621-161231.tar.gz
 ```
 #####With a token file writing to a specific output directory:
 ```$xslt
-./scrub.sh -a diagnostics-20180621-161231.tar.gz -t /home/adminuser/sanitized-diags -f /home/adminuser/sanitized-diags/scrub.yml
+./scrub.sh -a /Users/rdavies/diagoutput/diagnostics-20180621-161231.tar.gz -o /home/adminuser/sanitized-diags -c /home/adminuser/sanitized-diags/scrub.yml
+```
+#####With a token file processing a single log file:
+```$xslt
+./scrub.sh -i /home/adminuser/elasticsearch.log -o /home/adminuser/sanitized-diags -c /home/adminuser/sanitized-diags/scrub.yml
 ```
 #####Sample token scrub file entries:
 ```$xslt
@@ -164,27 +159,13 @@ tokens:
   - Typhoid
 
 ```
-###  Local Artifacts Collection
-##### Important - Please do not run this option when asked for an initial diagnostic unless _explicitly_ instructed to do so by support! It is also currently under review and may be removed in the future.
-* This option will collect logs for the node on the current host and run the system statistics calls. It will allow the logs to be collected for a non-running or hung node without having to manually go to the log directory. It will follow the same rules as standard log collection. It will collect the current, as well as the last two rollovers, any slow logs, and three gc logs.
-* It runs via a separate script than the standard diagnostic function.
-* The standard REST API calls used for the normal and remote types will not be run.
-* The user *must* specify the log location via the command line via the -l or --logDir option.
-* If a full set of system calls is desired for a running Elasticsearch instance you must specify the process id with -p or --pid. Optional, will collect calls that do not require a pid otherweise.
-* Output written to the diagnostics directory by default, otherwise specify a custom location with -o or --outputDir.
-#### Examples
-```
- ./log-collection.sh -l /var/log/elasticsearch -o /admin/storage/logs -p 444999
- ./log-collection.sh --logDir /var/log/elasticsearch --outputDir /admin/storage/logs --pid 444999
-
-```
-
 # Troubleshooting
   * The file: diagnostic.log file will be generated  and included in the archive. In all but the worst case an archive will be created. Some messages will be written to the console output but granualar errors and stack traces will only be written to this log.
   * If you get a message saying that it can't find a class file, you probably downloaded the src zip instead of the one with "-dist" in the name. Download that and try it again.
   * If you get a message saying that it can't locate the diagnostic node, it usually means you are running the diagnostic on a host containing a different node than the one you are pointing to. Try running in remote node or changing the host you are executing on.
   * Make sure the account you are running from has read access to all the Elasticsearch log directories.  This account must have write access to any directory you are using for output.
   * Make sure you have a valid Java installation that the JAVA_HOME environment variable is pointing to.
+  * IBM JDK's have proven to be problematic when using SSL. If you see an error with _com.ibm.jsse2_ in the stack trace please obtain a recent Oracle or OpenJDK release and try again.
   * If you are not in the installation directory CD in and run it from there.
   * If you encounter OutOfMemoryExceptions, use the `DIAG_JAVA_OPTS` environment variable to set an `-Xmx` value greater than the standard `2g`.  Start with `-Xmx4g` and move up from there if necessary.
   * If reporting an issue make sure to include that.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ As a first step the diagnostic will check the Github repo for the current releas
     ./diagnostics.sh --help
     .\diagnostics.bat --help
 
-## Using With Shield/Security
+## Using With Security
 * a truststore does not need to be specified - it's assumed you are running this against a node that you set up and if you didn't trust it you wouldn't be running this.
 * When using authentication, do not specify both a password and the `-p` option.  Using the `-p` option will bring up a prompt for you to type an obfuscated value that will not be displayed on the command history.
 * `--noVerify` will bypass hostname verification with SSL.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ As a first step the diagnostic will check the Github repo for the current releas
 
 ## Using With Shield/Security
 * a truststore does not need to be specified - it's assumed you are running this against a node that you set up and if you didn't trust it you wouldn't be running this.
-* When using security authentication, do not specify a password and the `-p` option.  Using the `-p` option will bring up a prompt for you to type an obfuscated value that will not be displayed on the command history.
+* When using authentication, do not specify both a password and the `-p` option.  Using the `-p` option will bring up a prompt for you to type an obfuscated value that will not be displayed on the command history.
 * `--noVerify` will bypass hostname verification with SSL.
 * `--keystore` and --keystorePass` allow you to specify client side certificates for authentication.
 * To script the utility when using Shield/Security, you may use the `--ptp` option to allow you to pass a plain text password to the command line rather than use `-p` and get a prompt.  Note that this is inherently insecure - use at your own risk.

--- a/src/main/java/com/elastic/support/BaseService.java
+++ b/src/main/java/com/elastic/support/BaseService.java
@@ -17,6 +17,7 @@ public abstract  class BaseService {
 
     protected Logger logger = LogManager.getLogger(BaseService.class);
     protected boolean isLogClosed = false;
+    protected String logPath;
 
     protected void closeLogs() {
 
@@ -35,7 +36,7 @@ public abstract  class BaseService {
 
     protected void createFileAppender(String logDir, String logFile) {
 
-        logDir = logDir + SystemProperties.fileSeparator + logFile;
+        logPath = logDir + SystemProperties.fileSeparator + logFile;
 
         LoggerContext context = (LoggerContext) LogManager.getContext(false);
         Configuration logConfig = context.getConfiguration();
@@ -46,7 +47,7 @@ public abstract  class BaseService {
 
         FileAppender.Builder builder = FileAppender.newBuilder();
         builder.setConfiguration(logConfig);
-        builder.withFileName(logDir);
+        builder.withFileName(logPath);
         builder.withAppend(false);
         builder.withLocking(false);
         builder.setName("File");

--- a/src/main/java/com/elastic/support/scrub/ScrubApp.java
+++ b/src/main/java/com/elastic/support/scrub/ScrubApp.java
@@ -16,9 +16,12 @@ public class ScrubApp {
 
         ScrubInputs scrubInputs = new ScrubInputs();
         scrubInputs.parseInputs(args);
+        if (!scrubInputs.validate()) {
+            logger.info("Exiting...");
+            System.exit(0);
+        }
         ScrubService scrub = new ScrubService(scrubInputs);
         scrub.exec();
-
     }
 
 }

--- a/src/main/java/com/elastic/support/scrub/ScrubProcessor.java
+++ b/src/main/java/com/elastic/support/scrub/ScrubProcessor.java
@@ -61,9 +61,6 @@ public class ScrubProcessor implements PostProcessor {
 
    public String process(String line){
 
-      if( line.contains("Apple") ){
-         boolean hit = true;
-      }
       line = processIpv4Addresses(line);
       line = processIpv6Addresses(line);
       line = processMacddresses(line);
@@ -161,10 +158,21 @@ public class ScrubProcessor implements PostProcessor {
 
    public String generateReplacementToken(String token, int len){
 
-      String replacement =
-         ("" + (UUID.nameUUIDFromBytes(token.getBytes())).toString())
-         .replaceAll("-", "")
-         .substring(0, len);
+      StringBuffer newToken = new StringBuffer();
+
+      int passes = 1;
+      if(len > 32){
+         passes = (len/32) + 1;
+      }
+
+      for(int i = 0; i < passes; i++){
+         newToken.append(
+                 ("" + (UUID.nameUUIDFromBytes(token.getBytes())).toString())
+                         .replaceAll("-", "")
+         );
+      }
+
+      String replacement = newToken.toString().substring(0, len);
 
       return replacement;
 

--- a/src/main/java/com/elastic/support/scrub/ScrubProcessor.java
+++ b/src/main/java/com/elastic/support/scrub/ScrubProcessor.java
@@ -158,7 +158,7 @@ public class ScrubProcessor implements PostProcessor {
 
    public String generateReplacementToken(String token, int len){
 
-      StringBuffer newToken = new StringBuffer();
+      StringBuilder newToken = new StringBuilder();
 
       int passes = 1;
       if(len > 32){

--- a/src/main/java/com/elastic/support/scrub/ScrubProcessor.java
+++ b/src/main/java/com/elastic/support/scrub/ScrubProcessor.java
@@ -167,7 +167,7 @@ public class ScrubProcessor implements PostProcessor {
 
       for(int i = 0; i < passes; i++){
          newToken.append(
-                 ("" + (UUID.nameUUIDFromBytes(token.getBytes())).toString())
+                 UUID.nameUUIDFromBytes(token.getBytes()).toString()
                          .replaceAll("-", "")
          );
       }

--- a/src/main/java/com/elastic/support/util/ArchiveUtils.java
+++ b/src/main/java/com/elastic/support/util/ArchiveUtils.java
@@ -92,9 +92,8 @@ public class ArchiveUtils {
 
    public void extractDiagnosticArchive(String sourceInput, String targetDir, boolean scrub) throws Exception {
 
-      Files.createDirectories(Paths.get(targetDir + SystemProperties.fileSeparator + "logs"));
+      boolean logsPresent = false;
       TarArchiveInputStream archive = readDiagArchive(sourceInput);
-
       String baseArchivePath = null;
       logger.info("Extracting archive...");
 
@@ -109,6 +108,13 @@ public class ArchiveUtils {
          while (tae != null) {
             String name = tae.getName();
             name = name.replace(baseArchivePath, "");
+
+            if(  name.contains("gc.log.") ||
+                    (name.contains(".log") && !name.equalsIgnoreCase("diagnostics.log") ) ||
+                    (!name.contains( "logs" + SystemProperties.fileSeparator ) && !name.contains( "log" + SystemProperties.fileSeparator ))
+            ){
+               Files.createDirectories(Paths.get(targetDir + SystemProperties.fileSeparator + "logs"));
+            }
 
             if(name.contains("gc.log.")){
                logger.info("Processing: {}", name);

--- a/src/main/java/com/elastic/support/util/SystemUtils.java
+++ b/src/main/java/com/elastic/support/util/SystemUtils.java
@@ -55,9 +55,9 @@ public class SystemUtils {
             File tmp = new File(dir);
             tmp.setWritable(true, false);
             FileUtils.deleteDirectory(tmp);
-            logger.info("Deleted temp directory: {}.", dir);
+            logger.info("Deleted directory: {}.", dir);
         } catch (IOException e) {
-            logger.error("Access issue with temp directory", e);
+            logger.error("Access issue with target directory", e);
         }
     }
 


### PR DESCRIPTION
Fixed issue where Strings longer than 32 characters generated an error during token replacement.
Added option to obfuscate a single file rather than a full diagnostic archive.
Closes #301 , #302 