### PR TITLE
Collect SLM information

### DIFF
--- a/src/main/resources/diags.yml
+++ b/src/main/resources/diags.yml
@@ -148,6 +148,12 @@ rest-calls:
         ilm_status: "/_ilm/status?pretty"
       minor-7:
         ccr_follower_info: "/_all/_ccr/info?pretty"
+    
+    major-7:
+      minor-4:
+        slm_policies: "/_slm/policy?pretty&human"
+      minor-5:
+        slm_stats: "/_slm/stats?pretty"
 
 thread-dump:
   jstack: "jstack PID"


### PR DESCRIPTION
In preparation for Snapshot Lifecycle Management shipping in 7.4.0,
collect information that will be useful and/or necessary to troubleshoot
SLM issues.