### PR TITLE
Configuration move to semver -centric version checks for queries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,19 +4,19 @@
 
     <groupId>com.elasticsearch</groupId>
     <artifactId>support-diagnostics</artifactId>
-    <version>7.1.1</version>
+    <version>7.2.0</version>
     <packaging>jar</packaging>
     <name>Support Diagnostics Utilities</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <log4j.version>2.11.2</log4j.version>
+        <log4j.version>2.12.1</log4j.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.7</version>
+            <version>4.5.10</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9.2</version>
+            <version>2.10.1</version>
         </dependency>
 
         <dependency>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
-            <version>1.72</version>
+            <version>1.78</version>
         </dependency>
 
         <dependency>
@@ -76,45 +76,57 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.18</version>
+            <version>1.19</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.8.1</version>
+            <version>3.9</version>
         </dependency>
 
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.9.3</version>
+            <version>1.9.4</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.oshi</groupId>
             <artifactId>oshi-json</artifactId>
-            <version>3.13.0</version>
+            <version>3.13.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.jcraft</groupId>
+            <artifactId>jsch</artifactId>
+            <version>0.1.55</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.vdurmont</groupId>
+            <artifactId>semver4j</artifactId>
+            <version>3.1.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.2</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.4.0</version>
+            <version>5.5.2</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>5.4.0</version>
+            <version>5.5.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/elastic/support/config/Constants.java
+++ b/src/main/java/com/elastic/support/config/Constants.java
@@ -8,6 +8,9 @@ public class Constants {
    public static final String CHECK_LOG = "Check diagnostics.log in the archive file for more detail.";
 
    public static final String DIAG_CONFIG = "diags.yml";
+   public static final String ES_REST = "elastic-rest.yml";
+   public static final String LS_REST = "logstash-rest.yml";
+
    public static final String CHAINS_CONFIG = "chains.yml";
    public static final String QUERY_CONFIG_PACKAGE = "extract/";
    public static final String MONITORING_DIR = "monitoring-export";

--- a/src/main/java/com/elastic/support/rest/RestEntry.java
+++ b/src/main/java/com/elastic/support/rest/RestEntry.java
@@ -1,0 +1,62 @@
+package com.elastic.support.rest;
+
+import com.elastic.support.util.SystemProperties;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class RestEntry {
+
+    private static final Logger logger = LogManager.getLogger(RestEntry.class);
+
+    public RestEntry(String name, String subdir, String extension, boolean retry, String url){
+        this.name = name;
+        this.subdir = subdir;
+        this.extension = extension;
+        this.retry = retry;
+        this.url = url;
+    }
+
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    private String  url;
+
+    public String getUrl() {
+        return url;
+    }
+
+    private String subdir = SystemProperties.fileSeparator;
+
+    public String getSubdir() {
+        return subdir;
+    }
+
+    private String extension = "json";
+
+    public String getExtension() {
+        return extension;
+    }
+
+    private boolean retry = false;
+
+    public boolean isRetry() {
+        return retry;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RestEntry restEntry = (RestEntry) o;
+        return name.equals(restEntry.name);
+    }
+
+}

--- a/src/main/java/com/elastic/support/rest/RestEntryBuilder.java
+++ b/src/main/java/com/elastic/support/rest/RestEntryBuilder.java
@@ -1,0 +1,62 @@
+package com.elastic.support.rest;
+
+import com.elastic.support.util.SystemProperties;
+import com.sun.org.apache.xpath.internal.operations.Bool;
+import com.vdurmont.semver4j.Semver;
+import jdk.internal.jshell.tool.resources.version;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.swing.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class RestEntryBuilder {
+
+    private static final Logger logger = LogManager.getLogger(RestEntryBuilder.class);
+
+    Semver semver;
+    public RestEntryBuilder(String version){
+        semver = new Semver(version);
+    }
+
+    public RestEntry build(Map.Entry<String, Object> entry){
+
+        String name = entry.getKey();
+        Map<String, Object> values = (Map)entry.getValue();
+        String subdir = (String) ObjectUtils.defaultIfNull(values.get("subdir"), "");
+        String extension = (String)ObjectUtils.defaultIfNull(values.get("extension"), ".json");
+        Boolean retry = (Boolean)ObjectUtils.defaultIfNull(values.get("retry"), false);
+        Map<String, String> versions = (Map)values.get("versions");
+        String url = getVersionSpecificUrl(versions);
+        return new RestEntry(name, subdir, extension, retry, url);
+
+    }
+
+    public List<RestEntry> buildEntryList(Map<String, Object> config){
+
+        ArrayList<RestEntry> entries = new ArrayList<>();
+        for(Map.Entry<String, Object> entry: config.entrySet()){
+            entries.add(build(entry));
+        }
+
+        return entries;
+
+    }
+
+    private String getVersionSpecificUrl(Map<String, String> versions){
+        for(Map.Entry<String, String> urlVersion: versions.entrySet()){
+            if(semver.satisfies(urlVersion.getKey())){
+                return urlVersion.getValue();
+            }
+        }
+
+        // Something is royally screwed up if you hit this but it's not a reason to start
+        // tossing exceptions. Just log it and sub out the version url.
+        logger.log(SystemProperties.DIAG, "Failed to obtain a url for these entries: {}", version::new);
+        return "/";
+    }
+
+}

--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -1,0 +1,437 @@
+# The new settings format:
+# At the top level the label descring the query that will also be used as the
+#   file name for its output.
+#   Below the query label are the following attributes:
+#     * extension - the file extension to be used for output. Currently only .txt and .json are valid. Required
+#     * subdir - some api's are now grouped in a subdirectory of the output directory to lessen clutter. Optional, defaults to root dir.
+#     * retry - whenther if a query fails it will be retried for the configured number of attempts. Optional, defaults to false.
+#     * versions - one or more attributes of the format "version rule: "query string". Each set of version/query key pairs
+#       should evaluate to exactly one that is appropriate for the version of the server being queried. Therefor rules should
+#       be structured in such a way that only a valid query can be executed against a given version. Required.
+#   NPM mode is the only one used: https://github.com/vdurmont/semver4j
+#   NPM Versioning rules are documented here: https://github.com/npm/node-semver
+#
+
+## cat API's
+
+cat_aliases:
+  extension: ".txt"
+  subdir: "cat"
+  versions:
+    ">= 0.9.0": "/_cat/aliases?v"
+
+cat_allocation:
+  extension: ".txt"
+  subdir: "cat"
+  versions:
+    ">= 0.9.0": "/_cat/allocation?v"
+
+cat_count:
+  extension: ".txt"
+  subdir: "cat"
+  versions:
+    ">= 0.9.0": "/_cat/count"
+
+cat_fielddata:
+  extension: ".txt"
+  subdir: "cat"
+  versions:
+    ">= 0.9.0": "/_cat/fielddata?v"
+
+cat_health:
+  extension: ".txt"
+  subdir: "cat"
+  versions:
+    ">= 0.9.0": "/_cat/health?v"
+
+cat_indices:
+  extension: ".txt"
+  subdir: "cat"
+  versions:
+    ">= 0.9.0 < 5.1.1": "/_cat/indices?v"
+    ">= 5.1.1": "/_cat/indices?v&s=index"
+
+cat_master:
+  extension: ".txt"
+  subdir: "cat"
+  versions:
+    ">= 0.9.0": "/_cat/master?format=json"
+
+cat_nodeattrs:
+  extension: ".txt"
+  subdir: "cat"
+  versions:
+    ">= 2.0.0": "/_cat/nodeattrs?v&h=node,id,pid,host,ip,port,attr,value"
+
+cat_nodes:
+  extension: ".txt"
+  subdir: "cat"
+  versions:
+    ">= 0.9.0": "/_cat/nodes?v&h=n,m,i,r,d,hp,rp,cpu,load_1m,load_5m,load_15m,nodeId"
+
+cat_pending_tasks:
+  extension: ".txt"
+  subdir: "cat"
+  versions:
+    ">= 0.9.0": "/_cat/pending_tasks?v"
+
+cat_recovery:
+  extension: ".txt"
+  subdir: "cat"
+  versions:
+    ">= 0.9.0": "/_cat/recovery?v"
+
+cat_repositories:
+  extension: ".txt"
+  subdir: "cat"
+  versions:
+    ">= 2.0.0": "/_cat/repositories?v"
+
+cat_segments:
+  extension: ".txt"
+  subdir: "cat"
+  versions:
+    ">= 0.9.0 < 5.1.1": "/_cat/segments?v"
+    ">= 5.1.1": "/_cat/segments?v&s=index"
+
+cat_shards:
+  extension: ".txt"
+  subdir: "cat"
+  versions:
+    ">= 0.9.0 < 5.1.1": "/_cat/shards?v"
+    ">= 5.1.1": "/_cat/shards?v&s=index"
+
+cat_thread_pool:
+  extension: ".txt"
+  subdir: "cat"
+  versions:
+    ">= 0.9.0": "/_cat/thread_pool?v"
+
+## Non-cat .txt API
+nodes_hot_threads:
+  extension: ".txt"
+  versions:
+    "> 0.9.0": "/_nodes/hot_threads?threads=10000"
+
+## Common JSON API's
+alias:
+  extension: ".json"
+  versions:
+    ">= 0.9.0": "/_alias?pretty&human"
+
+allocation:
+  extension: ".json"
+  versions:
+    ">= 0.9.0": "/_cat/allocation?v&format=json"
+
+allocation_explain:
+  extension: ".json"
+  versions:
+    ">= 5.0.0": "/_cluster/allocation/explain?pretty"
+
+allocation_explain_disk:
+  extension: ".json"
+  versions:
+    ">= 5.0.0": "/_cluster/allocation/explain?include_disk_info=true&pretty"
+
+count:
+  extension: ".json"
+  versions:
+    ">= 2.0.0": "/_count"
+
+cluster_health:
+  extension: ".json"
+  versions:
+    ">= 0.9.0": "/_cluster/health?pretty"
+
+cluster_pending_tasks:
+  extension: ".json"
+  versions:
+    ">= 0.9.0": "/_cluster/pending_tasks?pretty&human"
+
+cluster_settings:
+  extension: ".json"
+  versions:
+    ">= 0.9.0": "/_cluster/settings?pretty&flat_settings"
+
+cluster_settings_defaults:
+  extension: ".json"
+  versions:
+    ">= 6.4.0": "/_cluster/settings?include_defaults&pretty&flat_settings"
+
+cluster_state:
+  extension: ".json"
+  retry: true
+  versions:
+    ">= 0.9.0": "/_cluster/state?pretty&human"
+
+cluster_stats:
+  extension: ".json"
+  versions:
+    ">= 0.9.0": "/_cluster/stats?pretty&human"
+
+fielddata:
+  extension: ".json"
+  versions:
+    ">= 0.9.0": "/_cat/fielddata?format=json&bytes&pretty"
+
+fielddata_stats:
+  extension: ".json"
+  versions:
+    ">= 0.9.0 < 5.0.0": "/_nodes/stats/indices/fielddata?pretty=true&fields=*"
+    ">= 5.0.0": "/_nodes/stats/indices/fielddata?level=shards&pretty=true&fields=*"
+
+indices_stats:
+  extension: ".json"
+  retry: true
+  versions:
+    ">= 0.9.0": "/_stats?level=shards&pretty&human"
+
+licenses:
+  extension: ".json"
+  versions:
+    ">= 1.0.0 < 2.0.0": "/_licenses"
+    ">= 2.0.0": "/_license?pretty"
+
+mapping:
+  extension: ".json"
+  versions:
+    ">= 0.9.0": "/_mapping?pretty"
+
+master:
+  extension: ".json"
+  versions:
+    ">= 0.9.0": "/_cat/master?format=json"
+
+nodes:
+  extension: ".json"
+  retry: true
+  versions:
+    ">= 0.9.0": "/_nodes?pretty&human"
+
+nodes_stats:
+  extension: ".json"
+  retry: true
+  versions:
+    ">= 0.9.0": "/_nodes/stats?pretty&human"
+
+nodes_usage:
+  extension: ".json"
+  versions:
+    ">= 6.0.0": "/_nodes/usage?pretty"
+
+pipelines:
+  extension: ".json"
+  versions:
+    ">= 5.0.0": "/_ingest/pipeline/*?pretty&human"
+
+plugins:
+  extension: ".json"
+  versions:
+    ">= 0.9.0": "/_cat/plugins?format=json"
+
+recovery:
+  extension: ".json"
+  versions:
+    ">= 0.9.0": "/_recovery?pretty&human&detailed=true"
+
+remote_cluster_info:
+  extension: ".json"
+  versions:
+    ">= 6.0.0": "/_remote/info"
+
+segments:
+  extension: ".json"
+  retry: true
+  versions:
+    ">= 0.9.0": "/_segments?pretty&human"
+
+settings:
+  extension: ".json"
+  retry: true
+  versions:
+    ">= 0.9.0": "/_settings?pretty&human"
+
+shard_stores:
+  extension: ".json"
+  versions:
+    ">=2.0.0": "/_shard_stores?pretty"
+
+shards:
+  extension: ".json"
+  retry: true
+  versions:
+    ">=0.9.0": "/_cat/shards?format=json&bytes=b&pretty"
+
+tasks:
+  extension: ".json"
+  versions:
+    ">=2.0.0": "/_tasks?pretty&human&detailed=true"
+
+templates:
+  extension: ".json"
+  versions:
+    ">= 0.9.0": "/_template?pretty"
+
+version:
+  extension: ".json"
+  retry: true
+  versions:
+    ">= 0.9.0": "/"
+
+## Commercial Features
+ccr_autofollow_patterns:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 6.5.0": "/_ccr/auto_follow?pretty"
+
+ccr_follower_info:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 6.7.0": "/_all/_ccr/info?pretty"
+
+ccr_stats:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 6.5.0": "/_ccr/stats?pretty"
+
+enrich_policies:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 7.5.0": "/_enrich/policy?pretty"
+
+enrich_stats:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 7.5.0": "/_enrich/_stats?pretty"
+
+ilm_explain:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 6.6.0": "/*/_ilm/explain?human&pretty"
+
+ilm_policies:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 6.6.0": "/_ilm/policy?human&pretty"
+
+ilm_status:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 6.6.0": "/_ilm/status?pretty"
+
+ml_anomaly_detectors:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 5.0.0 < 7.0.0": "/_xpack/ml/anomaly_detectors?pretty"
+    ">= 7.0.0": "/_ml/anomaly_detectors?pretty"
+
+ml_datafeeds:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 5.0.0 < 7.0.0": "/_xpack/ml/datafeeds?pretty"
+    ">= 7.0.0": "/_ml/datafeeds?pretty"
+
+ml_stats:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 5.0.0 < 7.0.0": "/_xpack/ml/anomaly_detectors/_stats?pretty"
+    ">= 7.0.0": "/_ml/anomaly_detectors/_stats?pretty"
+
+rollup_jobs:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 6.3.0 < 7.0.0": "/_xpack/rollup/job/_all"
+    ">= 7.0.0": "/_rollup/job/_all"
+
+rollup_caps:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 6.3.0 < 7.0.0": "/_xpack/rollup/data/_all"
+    ">= 7.0.0": "/_rollup/data/_all"
+
+rollup_index_caps:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 6.5.0 < 7.0.0": "/*/_xpack/rollup/data"
+    ">= 7.0.0": "/*/_rollup/data"
+
+security_priv:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 6.5.0 < 7.0.0": "/_xpack/security/privilege?pretty"
+    ">= 7.0.0": "/_security/privilege?pretty"
+
+security_roles:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 2.0.0 < 5.0.0": "/_shield/role?pretty"
+    ">= 5.0.0 < 7.0.0": "/_xpack/security/role?pretty"
+    ">= 7.0.0": "/_security/role?pretty"
+
+security_role_mappings:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 5.0.0 < 7.0.0": "/_xpack/security/role_mapping?pretty"
+    ">= 7.0.0": "/_security/role_mapping?pretty"
+
+security_users:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 2.0.0 < 5.0.0": "/_shield/user?pretty"
+    ">= 5.0.0 < 7.0.0": "/_xpack/security/user?pretty"
+    ">= 7.0.0": "/_security/user?pretty"
+
+slm_policies:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 7.4.0": "/_slm/policy?pretty&human"
+
+slm_stats:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 7.5.0": "/_slm/stats?pretty"
+
+watcher_stats:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 1.6.0 < 5.0.0": "/_watcher/stats/_all"
+    ">= 5.0.0 < 7.0.0": "/_xpack/watcher/stats/_all"
+    ">= 7.0.0": "/_watcher/stats/_all"
+
+watcher_stack:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 1.6.0 < 5.0.0": "/_watcher/stats?emit_stacktraces=true"
+    ">= 5.0.0 < 7.0.0": "/_xpack/watcher/stats?emit_stacktraces=true"
+    ">= 7.0.0": "/_watcher/stats?emit_stacktraces=true"
+
+xpack:
+  extension: ".json"
+  subdir: "commercial"
+  versions:
+    ">= 5.0.0": "/_xpack/usage?pretty&human"
+
+

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -5,10 +5,10 @@
     </CustomLevels>
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss} %-5level %msg%n"/>
+            <PatternLayout pattern="%msg%n"/>
             <Filters>
                 <ThresholdFilter level="info" onMatch="ACCEPT" onMismatch="DENY"/>
-                <ThresholdFilter level="diag" onMatch="DENY" onMismatch="NEUTRAL" />
+                <ThresholdFilter level="diag" onMatch="ACCEPT" onMismatch="NEUTRAL" />
             </Filters>
         </Console>
     </Appenders>

--- a/src/main/resources/logstash-rest.yml
+++ b/src/main/resources/logstash-rest.yml
@@ -1,0 +1,38 @@
+# The new settings format:
+# At the top level the label descring the query that will also be used as the
+#   file name for its output.
+#   Below the query label are the following attributes:
+#     * extension - the file extension to be used for output. Currently only .txt and .json are valid. Required
+#     * subdir - some api's are now grouped in a subdirectory of the output directory to lessen clutter. Optional, defaults to root dir.
+#     * retry - whenther if a query fails it will be retried for the configured number of attempts. Optional, defaults to false.
+#     * versions - one or more attributes of the format "version rule: "query string". Each set of version/query key pairs
+#       should evaluate to exactly one that is appropriate for the version of the server being queried. Therefor rules should
+#       be structured in such a way that only a valid query can be executed against a given version. Required.
+#   NPM mode is the only one used: https://github.com/vdurmont/semver4j
+#   NPM Versioning rules are documented here: https://github.com/npm/node-semver
+#
+
+logstash_version:
+  extension: ".json"
+  versions:
+    "> 0.0.0": "/?pretty"
+
+logstash_node:
+  extension: ".json"
+  versions:
+    "> 0.0.0": "/_node?pretty"
+
+logstash_node_stats:
+  extension: ".json"
+  versions:
+    "> 0.0.0": "/_node/stats?pretty"
+
+logstash_nodes_hot_threads:
+  extension: ".txt"
+  versions:
+    "> 0.0.0": "/_node/hot_threads?human=true&threads=10000"
+
+logstash_plugins:
+  extension: ".json"
+  versions:
+    "> 0.0.0": "/_node/plugins?pretty"

--- a/src/test/java/com/elastic/support/version/TestRestConfigFileValidity.java
+++ b/src/test/java/com/elastic/support/version/TestRestConfigFileValidity.java
@@ -1,0 +1,55 @@
+package com.elastic.support.version;
+
+import com.elastic.support.util.JsonYamlUtils;
+import com.vdurmont.semver4j.Semver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class TestRestConfigFileValidity {
+
+    private static final Logger logger = LogManager.getLogger(TestRestConfigFileValidity.class);
+
+    protected static Semver sem= new Semver("9.9.999", Semver.SemverType.NPM);
+
+    @Test
+    public void validateElasticConfigVersioning(){
+        Map<String, Object> restEntriesConfig = JsonYamlUtils.readYamlFromClasspath("elastic-rest.yml", true);
+        validateEntries(restEntriesConfig);
+        restEntriesConfig = JsonYamlUtils.readYamlFromClasspath("logstash-rest.yml", true);
+        validateEntries(restEntriesConfig);
+    }
+
+
+    private void validateEntries(Map<String, Object> config) {
+        for( Map.Entry<String, Object>entry : config.entrySet() ) {
+
+            Map<String, Object> values = (Map) entry.getValue();
+            Map<String, String> urls = (Map) values.get("versions");
+
+            assertNotNull(values.get("subdir"));
+            String ext = (String) values.get("extension");
+            assertTrue(".txt".equals(ext) || ".json".equals(ext));
+            assertNotNull(values.get("retry"));
+
+            int nbrValid = 0;
+
+            // For each entry there should be only 1 valid url.
+            for (Map.Entry<String, String> url : urls.entrySet()) {
+                if (sem.satisfies(url.getKey())) {
+                    nbrValid++;
+                }
+            }
+
+            assertTrue( nbrValid == 1 );
+
+        }
+
+    }
+
+}

--- a/src/test/resources/log4j2-test.xml
+++ b/src/test/resources/log4j2-test.xml
@@ -7,7 +7,7 @@
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss} %-5level %msg%n"/>
             <Filters>
-                <ThresholdFilter level="info" />
+                <ThresholdFilter level="info" onMatch="ACCEPT" onMismatch="DENY"/>
                 <ThresholdFilter level="diag" onMatch="DENY" onMismatch="NEUTRAL" />
             </Filters>
         </Console>
@@ -18,3 +18,6 @@
         </Root>
     </Loggers>
 </Configuration>
+
+
+


### PR DESCRIPTION
Dependency and version updates.
Minor mods to logging config.
Separated out rest calls to elastic and logstash specific and changed versioning format from release based to call based.
Added test to validate format of rest configuration files at build time.
New classes for refactored rest entries.
Closes #326 , #277 