### PR TITLE
Fix for v5 export issues

### DIFF
--- a/src/main/java/com/elastic/support/diagnostics/commands/CheckElasticsearchVersion.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/CheckElasticsearchVersion.java
@@ -44,7 +44,7 @@ public class CheckElasticsearchVersion implements Command {
             String result = res.toString();
             JsonNode root = JsonYamlUtils.createJsonNodeFromString(result);
             String version = root.path("version").path("number").asText();
-            context.setVersion(new Semver(version, Semver.SemverType.NPM));
+            context.setVersion(getElasticsearchVersion(restClient));
 
             RestEntryFactory builder = new RestEntryFactory(version);
 
@@ -62,5 +62,17 @@ public class CheckElasticsearchVersion implements Command {
             logger.log(SystemProperties.DIAG, "Unanticipated error:", t);
             throw new DiagnosticException(String.format("Could not retrieve the Elasticsearch version due to a system or network error - unable to continue. %s", Constants.CHECK_LOG));
         }
+    }
+
+    public static Semver getElasticsearchVersion(RestClient client){
+        RestResult res = client.execQuery("/");
+        if (! res.isValid()) {
+            throw new DiagnosticException( res.formatStatusMessage( "Could not retrieve the Elasticsearch version - unable to continue."));
+        }
+        String result = res.toString();
+        JsonNode root = JsonYamlUtils.createJsonNodeFromString(result);
+        String version = root.path("version").path("number").asText();
+        return new Semver(version, Semver.SemverType.NPM);
+
     }
 }

--- a/src/main/java/com/elastic/support/monitoring/MonitoringExportService.java
+++ b/src/main/java/com/elastic/support/monitoring/MonitoringExportService.java
@@ -78,12 +78,18 @@ public class MonitoringExportService extends ElasticRestClientService {
             switch (de.getMessage()){
                 case "clusterQueryError" :
                     logger.error("The cluster id could not be validated on this monitoring cluster due to retrieval errors.");
+                    break;
                 case "missingClusterId":
                     logger.error("Cluster id is required. Diaplaying a list of available clusters.");
                     showAvailableClusters(config, client);
+                    break;
                 case "noClusterIdFound" :
                     logger.error("Entered cluster id not found. Please enure you have a valid cluster_uuid for the monitored clusters.");
                     showAvailableClusters(config, client);
+                    break;
+                default:
+                    logger.error("Entered cluster id not found - unexpected exception. Please enure you have a valid cluster_uuid for the monitored clusters. Check diagnostics.log for more details.");
+                    logger.log(SystemProperties.DIAG, de);
             }
             logger.error("Cannot contiue processing. Exiting {}", Constants.CHECK_LOG);
         } catch (IOException e) {

--- a/src/main/java/com/elastic/support/monitoring/MonitoringImportConfig.java
+++ b/src/main/java/com/elastic/support/monitoring/MonitoringImportConfig.java
@@ -1,0 +1,38 @@
+package com.elastic.support.monitoring;
+
+
+import com.elastic.support.BaseConfig;
+import com.elastic.support.Constants;
+import com.elastic.support.util.SystemProperties;
+import com.vdurmont.semver4j.Semver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MonitoringImportConfig extends BaseConfig {
+
+    protected int bulkSize ;
+    protected String bulkUri;
+    protected String bulkIndexLine;
+
+    Logger logger = LogManager.getLogger(MonitoringImportConfig.class);
+
+    public MonitoringImportConfig(Map configuration) {
+        super(configuration);
+        bulkSize = (Integer) configuration.get("bulk-import-size");
+        bulkUri = (String)configuration.get("bulk-uri");
+        bulkIndexLine = (String)configuration.get("bulk-index-line");
+
+    }
+
+
+}
+

--- a/src/main/java/com/elastic/support/monitoring/MonitoringImportProcessor.java
+++ b/src/main/java/com/elastic/support/monitoring/MonitoringImportProcessor.java
@@ -20,13 +20,13 @@ public class MonitoringImportProcessor implements ArchiveEntryProcessor {
     private static final Logger logger = LogManager.getLogger(MonitoringImportProcessor.class);
 
     RestClient client;
-    MonitoringExportConfig config;
+    MonitoringImportConfig config;
     MonitoringImportInputs inputs;
     String newClusterName;
     String index;
     boolean updateClusterName = false;
 
-    public MonitoringImportProcessor(MonitoringExportConfig config, MonitoringImportInputs inputs, RestClient client) {
+    public MonitoringImportProcessor(MonitoringImportConfig config, MonitoringImportInputs inputs, RestClient client) {
         this.config = config;
         this.inputs = inputs;
         this.client = client;

--- a/src/main/resources/diags.yml
+++ b/src/main/resources/diags.yml
@@ -119,11 +119,23 @@ monitoring-queryfiles:
   cluster_id_check: "cluster_id_check.json"
   cluster_ids: "cluster_ids.json"
 
-monitoring-uri: "/.monitoring-es*/_search"
-monitoring-scroll-ttl: "?scroll=2m"
-monitoring-scroll-size: 500
-monitoring-scroll-uri: "/_search/scroll"
+monitoring-queries:
+  monitoring-uri:
+    versions:
+      "< 7.0.0": "/.monitoring-es*/_search"
+      ">= 7.0.0": "/.monitoring-es*/_search?rest_total_hits_as_int=true"
 
+  monitoring-start-scroll-uri:
+    versions:
+      "< 7.0.0":  "/.monitoring-es*/_search?scroll=2m"
+      ">= 7.0.0": "/.monitoring-es*/_search?scroll=2m&rest_total_hits_as_int=true"
+
+  monitoring-scroll-uri:
+    versions:
+      "< 7.0.0":  "/_search/scroll?scroll=2m"
+      ">= 7.0.0": "/_search/scroll?scroll=2m&rest_total_hits_as_int=true"
+
+monitoring-scroll-size: 500
 default-monitoring-index: ".monitoring-es-7"
 
 bulk-import-size: 250


### PR DESCRIPTION
Versioned queries to allow adding legacy hits handling for v7 urls.
Went to separate import configuration object rather than use a shared one for import and export
Exposed the functionality to get ES version and create semver object.
Closes #339 