### PR TITLE
Check for source distribution

### DIFF
--- a/scripts/diagnostics.bat
+++ b/scripts/diagnostics.bat
@@ -3,7 +3,13 @@ setlocal enabledelayedexpansion
 
 SET scriptpath=%~dp0
 SET diagpath=%scriptpath:~0,-1%
+SET libpath=%diagpath%\lib\NUL
 
+IF NOT EXIST %libpath% (
+    ECHO "Runtimes library does not exist - make sure you are running the "
+    ECHO "archive with 'dist' in the name, not the one labeled: 'source'."
+    EXIT
+)
 set JAVA_EXEC=java
 if not defined JAVA_HOME (
   set JAVA_EXEC=java

--- a/scripts/diagnostics.sh
+++ b/scripts/diagnostics.sh
@@ -2,6 +2,13 @@
 
 scriptDir=$0
 scriptDir=${scriptDir/\/diagnostics.sh/$''}
+libDir=$scriptDir'/lib'
+
+if [  -d "libDir" ]; then
+    echo "Runtimes library does not exist - make sure you are running the "
+    echo "archive with 'dist-' in the name, not the one labeled: 'source'."
+    exit
+fi
 
 if [ -x "$JAVA_HOME/bin/java" ]; then
     JAVA="$JAVA_HOME/bin/java"

--- a/scripts/export-monitoring.bat
+++ b/scripts/export-monitoring.bat
@@ -3,6 +3,13 @@ setlocal enabledelayedexpansion
 
 SET scriptpath=%~dp0
 SET diagpath=%scriptpath:~0,-1%
+SET libpath=%diagpath%\lib\NUL
+
+IF NOT EXIST %libpath% (
+    ECHO "Runtimes library does not exist - make sure you are running the "
+    ECHO "archive with 'dist' in the name, not the one labeled: 'source'."
+    EXIT
+)
 
 set JAVA_EXEC=java
 if not defined JAVA_HOME (

--- a/scripts/export-monitoring.sh
+++ b/scripts/export-monitoring.sh
@@ -2,6 +2,13 @@
 
 scriptDir=$0
 scriptDir=${scriptDir/\/export-monitoring.sh/$''}
+libDir=$scriptDir'/lib'
+
+if [  -d "libDir" ]; then
+    echo "Runtimes library does not exist - make sure you are running the "
+    echo "archive with 'dist' in the name, not the one labeled: 'source'."
+    exit
+fi
 
 if [ -x "$JAVA_HOME/bin/java" ]; then
     JAVA="$JAVA_HOME/bin/java"

--- a/scripts/import-monitoring.bat
+++ b/scripts/import-monitoring.bat
@@ -3,6 +3,13 @@ setlocal enabledelayedexpansion
 
 SET scriptpath=%~dp0
 SET diagpath=%scriptpath:~0,-1%
+SET libpath=%diagpath%\lib\NUL
+
+IF NOT EXIST %libpath% (
+    ECHO "Runtimes library does not exist - make sure you are running the "
+    ECHO "archive with 'dist' in the name, not the one labeled: 'source'."
+    EXIT
+)
 
 set JAVA_EXEC=java
 if not defined JAVA_HOME (

--- a/scripts/import-monitoring.sh
+++ b/scripts/import-monitoring.sh
@@ -2,6 +2,13 @@
 
 scriptDir=$0
 scriptDir=${scriptDir/\/import-monitoring.sh/$''}
+libDir=$scriptDir'/lib'
+
+if [  -d "libDir" ]; then
+    echo "Runtimes library does not exist - make sure you are running the "
+    echo "archive with 'dist' in the name, not the one labeled: 'source'."
+    exit
+fi
 
 if [ -x "$JAVA_HOME/bin/java" ]; then
     JAVA="$JAVA_HOME/bin/java"

--- a/scripts/scrub.bat
+++ b/scripts/scrub.bat
@@ -3,6 +3,13 @@ setlocal enabledelayedexpansion
 
 SET scriptpath=%~dp0
 SET diagpath=%scriptpath:~0,-1%
+SET libpath=%diagpath%\lib\NUL
+
+IF NOT EXIST %libpath% (
+    ECHO "Runtimes library does not exist - make sure you are running the "
+    ECHO "archive with 'dist' in the name, not the one labeled: 'source'."
+    EXIT
+)
 
 set JAVA_EXEC=java
 if not defined JAVA_HOME (

--- a/scripts/scrub.sh
+++ b/scripts/scrub.sh
@@ -2,6 +2,13 @@
 
 scriptDir=$0
 scriptDir=${scriptDir/\/scrub.sh/$''}
+libDir=$scriptDir'/lib'
+
+if [  -d "libDir" ]; then
+    echo "Runtimes library does not exist - make sure you are running the "
+    echo "archive with 'dist-' in the name, not the one labeled: 'source'."
+    exit
+fi
 
 if [ -x "$JAVA_HOME/bin/java" ]; then
     JAVA="$JAVA_HOME/bin/java"


### PR DESCRIPTION
Displays error message and exits if it cannot find the lib directory created when building the runtime distribution.
closes #203