### PR TITLE
Bypass finding master for api type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.elasticsearch</groupId>
     <artifactId>support-diagnostics</artifactId>
-    <version>8.0.0</version>
+    <version>8.0.1</version>
     <packaging>jar</packaging>
     <name>Support Diagnostics Utilities</name>
     <properties>

--- a/src/main/java/com/elastic/support/diagnostics/chain/DiagnosticChainExec.java
+++ b/src/main/java/com/elastic/support/diagnostics/chain/DiagnosticChainExec.java
@@ -21,7 +21,8 @@ public class DiagnosticChainExec {
                 case Constants.api :
                     new CheckElasticsearchVersion().execute(context);
                     new CheckUserAuthLevel().execute(context);
-                    new CheckPlatformDetails().execute(context);
+                    // Removed temporarily due to issues with finding and accessing cloud master
+                    //new CheckPlatformDetails().execute(context);
                     new RunClusterQueries().execute(context);
                     break;
 

--- a/src/main/java/com/elastic/support/diagnostics/commands/CheckPlatformDetails.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/CheckPlatformDetails.java
@@ -111,7 +111,6 @@ public class CheckPlatformDetails implements Command {
                         targetOS = context.targetNode.os;
                     }
 
-
                     syscmd = new RemoteSystem(
                             targetOS,
                             context.diagnosticInputs.remoteUser,
@@ -151,12 +150,6 @@ public class CheckPlatformDetails implements Command {
                     syscmd = new LocalSystem(context.targetNode.os);
                     ResourceCache.addSystemCommand(Constants.systemCommands, syscmd);
 
-                    break;
-
-                case Constants.api:
-                    context.targetNode = findRemoteTargetNode(
-                            context.diagnosticInputs.host, nodeProfiles);
-                    context.runSystemCalls = false;
                     break;
 
                 default:


### PR DESCRIPTION
Issue calls directly against input host when API used due to issues with Cloud, EDE, ECK clusters.