### PR TITLE
Send calls to input node

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.elasticsearch</groupId>
     <artifactId>support-diagnostics</artifactId>
-    <version>8.0.2</version>
+    <version>8.0.3</version>
     <packaging>jar</packaging>
     <name>Support Diagnostics Utilities</name>
     <properties>

--- a/src/main/java/com/elastic/support/diagnostics/commands/CheckPlatformDetails.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/CheckPlatformDetails.java
@@ -53,7 +53,9 @@ public class CheckPlatformDetails implements Command {
                 }
             }
 
-            if (!context.dockerPresent) {
+            // Removed temporarily until I put in an option to bypass this feature due to
+            // issue where master was inaccessible via http from another node even though it had http configured.
+/*            if (!context.dockerPresent) {
                 // Get the master node id and flag the master node profile
                 entry = calls.get("master");
                 result = restClient.execQuery(entry.getUrl());
@@ -89,7 +91,7 @@ public class CheckPlatformDetails implements Command {
 
                     ResourceCache.addRestClient(Constants.restTargetHost, masterRestClient);
                 }
-            }
+            }*/
 
             SystemCommand syscmd = null;
             switch (context.diagnosticInputs.diagType) {

--- a/src/main/java/com/elastic/support/diagnostics/commands/RunClusterQueries.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/RunClusterQueries.java
@@ -30,12 +30,13 @@ public class RunClusterQueries extends BaseQuery {
             List<RestEntry> entries = new ArrayList<>();
             entries.addAll(context.elasticRestCalls.values());
             RestClient client;
-            if(ResourceCache.resourceExists(Constants.restTargetHost)){
+            client = ResourceCache.getRestClient(Constants.restInputHost);
+/*            if(ResourceCache.resourceExists(Constants.restTargetHost)){
                 client = ResourceCache.getRestClient(Constants.restTargetHost);
             }
             else {
                 client = ResourceCache.getRestClient(Constants.restInputHost);
-            }
+            }*/
 
             runQueries(client, entries, context.tempDir, diagConfig.callRetries, diagConfig.pauseRetries);
         } catch (Throwable t) {


### PR DESCRIPTION
User had http traffic from node where diag was run to host where master was installed blocked, which called all rest calls to fail. Sending all rest calls through the target node for now until ability to disable and get diagnostic data can be added.