### PR TITLE
Exclamation Point Fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.elasticsearch</groupId>
     <artifactId>support-diagnostics</artifactId>
-    <version>8.0.3</version>
+    <version>8.0.4</version>
     <packaging>jar</packaging>
     <name>Support Diagnostics Utilities</name>
     <properties>
@@ -118,8 +118,19 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>jline</groupId>
+                    <artifactId>jline</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>jline</groupId>
+            <artifactId>jline</artifactId>
+            <version>2.14.6</version>
+        </dependency>
+
 
         <dependency>
             <groupId>org.junit.platform</groupId>

--- a/src/main/java/com/elastic/support/util/ResourceCache.java
+++ b/src/main/java/com/elastic/support/util/ResourceCache.java
@@ -1,11 +1,14 @@
 package com.elastic.support.util;
 
 import com.elastic.support.rest.RestClient;
+import jdk.tools.jlink.internal.Jlink;
+import jline.console.ConsoleReader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.beryx.textio.TextIO;
 import org.beryx.textio.TextIoFactory;
 import org.beryx.textio.TextTerminal;
+import org.beryx.textio.jline.JLineTextTerminal;
 
 import java.io.Closeable;
 import java.util.concurrent.ConcurrentHashMap;
@@ -18,6 +21,14 @@ public class ResourceCache{
 
     public static final TextIO textIO = TextIoFactory.getTextIO();
     public static final TextTerminal terminal = textIO.getTextTerminal();
+
+    static {
+        if(terminal instanceof JLineTextTerminal){
+            JLineTextTerminal jltt = (JLineTextTerminal)terminal;
+            ConsoleReader reader = jltt.getReader();
+            reader.setExpandEvents(false);
+        }
+    }
 
     public static boolean resourceExists(String name){
         return resources.containsKey(name);


### PR DESCRIPTION
Check the input terminal for whether it was created with JLIne - if so suppress event handling to prevent the exclamation point from terminating the process.
Fixes #390 