### PR TITLE
fix documentation about parameter to ask for keystore password

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@
  </tr>
  
  <tr>
-   <td width="20%" align="left" valign="top">--pkiKeyPass</td>
+   <td width="20%" align="left" valign="top">--pkiPass</td>
    <td width="50%" align="left" valign="top">Prompt for a password if the PKI keystore is secured. </td>
    <td width="30%" align="left" valign="top">Option only - no value.</td>
  </tr>


### PR DESCRIPTION
Hi guys,

the documentation of how to provide a password for a keystore provided, in case of using pki-authentication, points to a parameter called:
pkiKeyPass
which is not existing in:
https://github.com/elastic/support-diagnostics/blob/master/src/main/java/com/elastic/support/rest/ElasticRestClientInputs.java#L62
So i guess, this fixes the documentation 
Worked for me, at least