### PR TITLE
Allow for no scrub config file

### DIFF
--- a/src/main/java/com/elastic/support/scrub/ScrubInputs.java
+++ b/src/main/java/com/elastic/support/scrub/ScrubInputs.java
@@ -80,7 +80,7 @@ public class ScrubInputs extends BaseInputs {
         configFile = ResourceCache.textIO.newStringInputReader()
                 .withInputTrimming(true)
                 .withMinLength(0)
-                .withValueChecker((String val, String propname) -> validateRequiredFile(val))
+                .withValueChecker((String val, String propname) -> validateFile(val))
                 .read("Enter the full path of the Configuration file you wish to import or hit enter to take the default IP/MAC scrub.");
 
         if(runningInDocker){


### PR DESCRIPTION
If you want to use the default scrub configuration, the interactive text tells you you can just hit enter to use the default.

However, if you do just hit enter, it complains that you have to provide a file:
```
Invalid value.
Input file is required.
```

This change uses the optional file validation instead of the required file validation