### PR TITLE
Correct file validation logic

### DIFF
--- a/src/main/java/com/elastic/support/BaseInputs.java
+++ b/src/main/java/com/elastic/support/BaseInputs.java
@@ -166,8 +166,8 @@ public abstract class BaseInputs {
 
         File file = new File(val);
 
-        if (!file.exists() && file.isDirectory()) {
-            return Collections.singletonList("Specified required file location could not be located.");
+        if (!file.exists() || file.isDirectory()) {
+            return Collections.singletonList("Specified required file location could not be located or is a directory.");
         }
 
         return null;


### PR DESCRIPTION
Before this patch `validateRequiredFile` will never fail if any string is passed in

because ` if (!file.exists() && file.isDirectory())` will never return ~false~ true ( it can't be a directory if it doesn't exist).

To see the first behaviour before this change:
- Run the Scrub in interactive mode
- Select Archive
- put in gibberish for the archive 
The script should fail with "Specified required file location could not be located", but it doesn't, it just carries on:
```
Select the type of file you wish to scrub.
  1: Scrub Archive
  2: Scrub Single File
Enter your choice: 1

Enter the full path of the archive you wish to import. sdadsadas

If you do not specify a yaml configuration file, the utility will automatically....
```

[Edit sneaky ninja edit to correct my own bug-raising logic! This logic stuff is hard]