### PR TITLE
Correct validation of non-existent output directory

### DIFF
--- a/src/main/java/com/elastic/support/BaseInputs.java
+++ b/src/main/java/com/elastic/support/BaseInputs.java
@@ -96,7 +96,7 @@ public abstract class BaseInputs {
     protected void runOutputDirInteractive(){
         String output = ResourceCache.textIO.newStringInputReader()
                 .withMinLength(0)
-                .withValueChecker(( String val, String propname) -> validateFile(val))
+                .withValueChecker(( String val, String propname) -> validateOutputDirectory(val))
                 .read(SystemProperties.lineSeparator + outputDirDescription);
         if(StringUtils.isNotEmpty(output)){
             outputDir = output;
@@ -151,8 +151,8 @@ public abstract class BaseInputs {
 
         File file = new File(val);
 
-        if (!file.exists() && file.isDirectory()) {
-            return Collections.singletonList("Specified directory location could not be located.");
+        if (!file.exists() || !file.isDirectory()) {
+            return Collections.singletonList("Specified directory location could not be located or is not a directory.");
         }
 
         return null;


### PR DESCRIPTION
Prior to this change, the user cannot specify a directory to be used for output, if the directory does not already exist.
The interactive text says:
"Fully qualified path to an output directory. If it does not exist the diagnostic will attempt to create it."
but the bit which does the creation if it doesn't exist `validateOutputDirectory`  is never called.

To see this behaviour pre-patch
Run the Scrub 
- Select Archive
- Select an archive file to scrub
- select a config file
- Select a non-existent directory for the output.
The scrubber should create this directory (assuming sufficient permissions etc.), but it fails with 
```
Invalid value.
Specified file could not be located.
```
and asks for the directory again.