### PR TITLE
Correct validation of existing directory

### DIFF
--- a/src/main/java/com/elastic/support/BaseInputs.java
+++ b/src/main/java/com/elastic/support/BaseInputs.java
@@ -151,8 +151,8 @@ public abstract class BaseInputs {
 
         File file = new File(val);
 
-        if (!file.exists() && file.isDirectory()) {
-            return Collections.singletonList("Specified directory location could not be located.");
+        if (!file.exists() || !file.isDirectory()) {
+            return Collections.singletonList("Specified directory location could not be located or is not a directory.");
         }
 
         return null;


### PR DESCRIPTION
Similar symptoms as  https://github.com/elastic/support-diagnostics/pull/412 

Before this patch `validateDir` will never fail if any string is passed in

because `if (!file.exists() && file.isDirectory())` will never return ~false~ true ( it can't be a directory if it doesn't exist).

I can't reproduce the undesired behaviour this could cause, as there are several places this is called from, and I'm still getting my head around it.
Because of that, I would ask that someone who knows their way around this and can assess all the places it is used reviews this change.
I'll keep digging to see if I can come up with some concrete examples

[Edit: Sneaky ninja edit - this logic stuff is hard!]