### PR TITLE
Refactor logging

### DIFF
--- a/src/main/java/com/elastic/support/BaseInputs.java
+++ b/src/main/java/com/elastic/support/BaseInputs.java
@@ -70,7 +70,7 @@ public abstract class BaseInputs {
     public abstract boolean runInteractive();
 
     public List<String> parseInputs(String[] args){
-        logger.info("Processing diagnosticInputs...");
+        logger.info(Constants.CONSOLE, "Processing diagnosticInputs...");
         jCommander = new JCommander(this);
         jCommander.setCaseSensitiveOptions(true);
         jCommander.parse(args);
@@ -89,7 +89,7 @@ public abstract class BaseInputs {
             jCommander.usage();
         }
         else{
-            logger.info("Please rerun with the --help option or with no arguments for interactive mode.");
+            logger.error(Constants.CONSOLE, "Please rerun with the --help option or with no arguments for interactive mode.");
         }
     }
 
@@ -121,7 +121,7 @@ public abstract class BaseInputs {
                 file.mkdir();
             }
         } catch (Exception e) {
-            logger.log(SystemProperties.DIAG, e);
+            logger.error( e);
             return Collections.singletonList("Output directory did not exist and could not be created. " + Constants.CHECK_LOG);
         }
 

--- a/src/main/java/com/elastic/support/BaseService.java
+++ b/src/main/java/com/elastic/support/BaseService.java
@@ -22,7 +22,7 @@ public abstract  class BaseService {
 
     protected void closeLogs() {
 
-        logger.info("Closing loggers.");
+        logger.info(Constants.CONSOLE, "Closing loggers.");
 
         Appender appndr = logConfig.getAppender("diag");
         if(appndr != null && appndr.isStarted()){
@@ -72,13 +72,13 @@ public abstract  class BaseService {
         AppenderRef.createAppenderRef("diag", null, null);
         logConfig.getRootLogger().addAppender(diagAppender, null, null);
         loggerContext.updateLoggers();
-        logger.info("Diagnostic ogger reconfigured for inclusion into archive");
+        logger.info(Constants.CONSOLE, "Diagnostic logger reconfigured for inclusion into archive");
 
     }
 
     public void createArchive(String tempDir) {
 
-        logger.info("Archiving diagnostic results.");
+        logger.info(Constants.CONSOLE, "Archiving diagnostic results.");
 
         try {
             String archiveFilename = SystemProperties.getFileDateString();

--- a/src/main/java/com/elastic/support/BaseService.java
+++ b/src/main/java/com/elastic/support/BaseService.java
@@ -17,14 +17,14 @@ public abstract  class BaseService {
 
     private Logger logger = LogManager.getLogger(BaseService.class);
     protected String logPath;
+    protected LoggerContext loggerContext = (LoggerContext) LogManager.getContext(false);
+    protected Configuration logConfig = loggerContext.getConfiguration();
 
     protected void closeLogs() {
 
-        logger.info("Closing logger.");
+        logger.info("Closing loggers.");
 
-        LoggerContext lc = (LoggerContext) LogManager.getContext(false);
-        Configuration logConfig = lc.getConfiguration();
-        Appender appndr = logConfig.getAppender("File");
+        Appender appndr = logConfig.getAppender("diag");
         if(appndr != null && appndr.isStarted()){
             appndr.stop();
         }
@@ -36,9 +36,13 @@ public abstract  class BaseService {
     protected void createFileAppender(String logDir, String logFile) {
 
         logPath = logDir + SystemProperties.fileSeparator + logFile;
+        Appender appndr = logConfig.getAppender("diag");
 
-        LoggerContext context = (LoggerContext) LogManager.getContext(false);
-        Configuration logConfig = context.getConfiguration();
+/*        if(appndr != null && appndr.isStarted()){
+            appndr.stop();
+        }*/
+
+        logger.info(Constants.CONSOLE, logPath);
         Layout layout = PatternLayout.newBuilder()
                 .withConfiguration(logConfig)
                 .withPattern("%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n")
@@ -49,20 +53,26 @@ public abstract  class BaseService {
         builder.withFileName(logPath);
         builder.withAppend(false);
         builder.withLocking(false);
-        builder.setName("File");
+        builder.setName("diag");
         builder.setIgnoreExceptions(false);
         builder.withImmediateFlush(true);
         builder.withBufferedIo(false);
         builder.withBufferSize(0);
         builder.setLayout(layout);
-        builder.withAdvertise(false);
-        Appender appender = builder.build();
+        Appender diagAppender = builder.build();
 
-        appender.start();
-        logConfig.addAppender(appender);
-        AppenderRef.createAppenderRef("File", SystemProperties.DIAG, null);
-        logConfig.getRootLogger().addAppender(appender, Level.DEBUG, null);
-        context.updateLoggers();
+        Appender oldAppender = logConfig.getAppender("diag");
+        if(oldAppender != null && oldAppender.isStarted()){
+            oldAppender.stop();
+            logConfig.getRootLogger().removeAppender("diag");
+        }
+
+        diagAppender.start();
+        logConfig.addAppender(diagAppender);
+        AppenderRef.createAppenderRef("diag", null, null);
+        logConfig.getRootLogger().addAppender(diagAppender, null, null);
+        loggerContext.updateLoggers();
+        logger.info("Diagnostic ogger reconfigured for inclusion into archive");
 
     }
 

--- a/src/main/java/com/elastic/support/Constants.java
+++ b/src/main/java/com/elastic/support/Constants.java
@@ -1,12 +1,16 @@
 package com.elastic.support;
 
 import com.elastic.support.util.SystemProperties;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 public class Constants {
+
+   public static final Marker CONSOLE = MarkerManager.getMarker("CONSOLE");
 
    public static final String ES_DIAG = "diagnostics";
    public static final String NOT_FOUND = "not found";

--- a/src/main/java/com/elastic/support/diagnostics/DiagnosticApp.java
+++ b/src/main/java/com/elastic/support/diagnostics/DiagnosticApp.java
@@ -1,6 +1,5 @@
 package com.elastic.support.diagnostics;
 
-import com.elastic.support.BaseInputs;
 import com.elastic.support.Constants;
 import com.elastic.support.util.JsonYamlUtils;
 import com.elastic.support.util.ResourceCache;
@@ -21,14 +20,14 @@ public class DiagnosticApp {
         try {
             DiagnosticInputs diagnosticInputs = new DiagnosticInputs();
             if (args.length == 0) {
-                logger.info(Constants.interactiveMsg);
+                logger.info(Constants.CONSOLE, Constants.interactiveMsg);
                 diagnosticInputs.interactive = true;
                 diagnosticInputs.runInteractive();
             } else {
                 List<String> errors = diagnosticInputs.parseInputs(args);
                 if (errors.size() > 0) {
                     for (String err : errors) {
-                        logger.info(err);
+                        logger.error(Constants.CONSOLE, err);
                     }
                     diagnosticInputs.usage();
                     SystemUtils.quitApp();
@@ -44,8 +43,8 @@ public class DiagnosticApp {
         } catch (ShowHelpException she){
             SystemUtils.quitApp();
         } catch (Exception e) {
-            logger.info("Fatal error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
-            logger.log(SystemProperties.DIAG, e);
+            logger.error(Constants.CONSOLE,"Fatal error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
+            logger.error( e);
         } finally {
             ResourceCache.closeAll();
         }

--- a/src/main/java/com/elastic/support/diagnostics/DiagnosticInputs.java
+++ b/src/main/java/com/elastic/support/diagnostics/DiagnosticInputs.java
@@ -152,7 +152,7 @@ public class DiagnosticInputs extends ElasticRestClientInputs {
         runHttpInteractive();
 
         if(diagType.contains("remote")) {
-            logger.info(remoteAccessMessage);
+            logger.info(Constants.CONSOLE, remoteAccessMessage);
 
             String  remoteUserTxt = "User account to be used for running system commands and obtaining logs." +
                     SystemProperties.lineSeparator

--- a/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
+++ b/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
@@ -48,29 +48,28 @@ public class DiagnosticService extends ElasticRestClientService {
             // Create the temp directory - delete if first if it exists from a previous run
             String outputDir = inputs.outputDir;
             ctx.tempDir = outputDir + SystemProperties.fileSeparator + inputs.diagType + "-" + Constants.ES_DIAG;
-            logger.info("{}Creating temp directory: {}", SystemProperties.lineSeparator, ctx.tempDir);
+            logger.info(Constants.CONSOLE, "{}Creating temp directory: {}", SystemProperties.lineSeparator, ctx.tempDir);
 
             FileUtils.deleteDirectory(new File(ctx.tempDir));
             Files.createDirectories(Paths.get(ctx.tempDir));
 
             // Set up the log file manually since we're going to package it with the diagnostic.
             // It will go to wherever we have the temp dir set up.
-            logger.info("Configuring log file.");
+            logger.info(Constants.CONSOLE, "Configuring log file.");
             createFileAppender(ctx.tempDir, "diagnostics.log");
-
             DiagnosticChainExec.runDiagnostic(ctx, inputs.diagType);
 
             if (ctx.dockerPresent) {
-                logger.info("Identified Docker installations - bypassed log collection and some system calls.");
+                logger.info(Constants.CONSOLE, "Identified Docker installations - bypassed log collection and some system calls.");
             }
 
            checkAuthLevel(ctx.diagnosticInputs.user, ctx.isAuthorized);
 
         } catch (DiagnosticException de) {
-            logger.info(de.getMessage());
+            logger.error(Constants.CONSOLE, de.getMessage());
         } catch (Throwable t) {
-            logger.log(SystemProperties.DIAG, "Temp directory error", t);
-            logger.info(String.format("Issue with creating temp directory. %s", Constants.CHECK_LOG));
+            logger.error( "Temp directory error", t);
+            logger.info(Constants.CONSOLE, String.format("Issue with creating temp directory. %s", Constants.CHECK_LOG));
         } finally {
             closeLogs();
             createArchive(ctx.tempDir);

--- a/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
+++ b/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
@@ -53,8 +53,16 @@ public class DiagnosticService extends ElasticRestClientService {
             FileUtils.deleteDirectory(new File(ctx.tempDir));
             Files.createDirectories(Paths.get(ctx.tempDir));
 
-            // Set up the log file manually since we're going to package it with the diagnostic.
-            // It will go to wherever we have the temp dir set up.
+            // Modify the log file setup since we're going to package it with the diagnostic.
+            // The log4 configuration file sets up 2 loggers, one strictly for the console and a file log in the working directory to handle
+            // any errors we get at the library level that occur before we can get it initiailized.  When we have a target directory to
+            // redirect output to we can reconfigure the appender to go to the diagnostic output temp directory for packaging with the archive.
+            // This lets you configure and create loggers via the file if you want to up the level on one of the library dependencies as well
+            // as internal classes.
+            // If you want the output to also be shown on the console use: logger.info/error/warn/debug(Constants.CONSOLE, "Some log message");
+            // This will also log that same output to the diagnostic log file.
+            // To just log to the file log as normal: logger.info/error/warn/debug("Log mewssage");
+
             logger.info(Constants.CONSOLE, "Configuring log file.");
             createFileAppender(ctx.tempDir, "diagnostics.log");
             DiagnosticChainExec.runDiagnostic(ctx, inputs.diagType);

--- a/src/main/java/com/elastic/support/diagnostics/JavaPlatform.java
+++ b/src/main/java/com/elastic/support/diagnostics/JavaPlatform.java
@@ -58,7 +58,7 @@ public class JavaPlatform {
                 }
             }
         } catch (Exception e) {
-            logger.log(SystemProperties.DIAG, "Error obtaining the path for the JDK", e);
+            logger.error( "Error obtaining the path for the JDK", e);
         }
 
         // If we got this far we couldn't find a JDK

--- a/src/main/java/com/elastic/support/diagnostics/JavaPlatform.java
+++ b/src/main/java/com/elastic/support/diagnostics/JavaPlatform.java
@@ -40,7 +40,7 @@ public class JavaPlatform {
 
             default:
                 // default it to Linux
-                logger.info("Failed to detect operating system for: {}", osName);
+                logger.info(Constants.CONSOLE, "Failed to detect operating system for: {}", osName);
                 this.platform = Constants.linuxPlatform;
         }
     }
@@ -62,7 +62,7 @@ public class JavaPlatform {
         }
 
         // If we got this far we couldn't find a JDK
-        logger.info("Could not locate the location of the java executable used to launch Elasticsearch");
+        logger.info(Constants.CONSOLE, "Could not locate the location of the java executable used to launch Elasticsearch");
         throw new DiagnosticException("JDK not found.");
     }
 

--- a/src/main/java/com/elastic/support/diagnostics/chain/DiagnosticChainExec.java
+++ b/src/main/java/com/elastic/support/diagnostics/chain/DiagnosticChainExec.java
@@ -87,7 +87,7 @@ public class DiagnosticChainExec {
             throw de;
         }
         catch (Throwable t){
-            logger.log(SystemProperties.DIAG, "Unexpected error", t);
+            logger.error( "Unexpected error", t);
             throw new DiagnosticException(String.format("Fatal error in diagnostic - could not continue. %s", Constants.CHECK_LOG));
         }
     }

--- a/src/main/java/com/elastic/support/diagnostics/commands/BaseQuery.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/BaseQuery.java
@@ -74,7 +74,7 @@ public abstract class BaseQuery implements Command {
                 String fileName = subdir + SystemProperties.fileSeparator + entry.getName() + entry.getExtension();
                 RestResult restResult = restClient.execQuery(entry.getUrl(), fileName);
                 if (restResult.isValid()) {
-                    logger.info("Results written to: {}", fileName);
+                    logger.info(Constants.CONSOLE, "Results written to: {}", fileName);
                 }
                 else{
                     if(entry.isRetry() && restResult.isRetryable()){
@@ -83,8 +83,8 @@ public abstract class BaseQuery implements Command {
                         logger.info(restResult.formatStatusMessage("Flagged for retry."));
                     }
                     else{
-                        logger.info("{}   {}  failed. Bypassing", entry.getName(), entry.getUrl());
-                        logger.info(restResult.formatStatusMessage("See archived diagnostics.log for more detail."));
+                        logger.info(Constants.CONSOLE, "{}   {}  failed. Bypassing", entry.getName(), entry.getUrl());
+                        logger.info(Constants.CONSOLE, restResult.formatStatusMessage("See archived diagnostics.log for more detail."));
                     }
                 }
             } catch (Exception e) {

--- a/src/main/java/com/elastic/support/diagnostics/commands/BaseQuery.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/BaseQuery.java
@@ -1,5 +1,6 @@
 package com.elastic.support.diagnostics.commands;
 
+import com.elastic.support.Constants;
 import com.elastic.support.diagnostics.chain.Command;
 import com.elastic.support.rest.RestClient;
 import com.elastic.support.rest.RestEntry;
@@ -40,10 +41,10 @@ public abstract class BaseQuery implements Command {
 
             // Wait the configured pause time before trying again
             try {
-                logger.info("Some calls failed but were flagged as recoverable: retrying in {} seconds.", pause / 1000);
+                logger.warn(Constants.CONSOLE, "Some calls failed but were flagged as recoverable: retrying in {} seconds.", pause / 1000);
                 Thread.sleep(pause);
             } catch (Exception e) {
-                logger.info("Failed pause on error.", e);
+                logger.info(Constants.CONSOLE,  "Failed pause on error.", e);
             }
 
             retryList = execQueryList(restClient, retryList, tempDir);
@@ -88,7 +89,7 @@ public abstract class BaseQuery implements Command {
                 }
             } catch (Exception e) {
                 // Something happens just log it and go to the next query.
-                logger.log(SystemProperties.DIAG, "Error occurred executing query {}", entry.getName() + " - " + entry.getUrl(), e);
+                logger.error( "Error occurred executing query {}", entry.getName() + " - " + entry.getUrl(), e);
                 continue;
             }
 

--- a/src/main/java/com/elastic/support/diagnostics/commands/CheckDiagnosticVersion.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/CheckDiagnosticVersion.java
@@ -33,7 +33,6 @@ public class CheckDiagnosticVersion implements Command {
 
     public void execute(DiagnosticContext context) {
 
-        logger.log(SystemProperties.DIAG, "This is a test");
         // For airgapped environments allow them to bypass this check
         if (context.diagnosticInputs.bypassDiagVerify) {
             return;
@@ -103,7 +102,7 @@ public class CheckDiagnosticVersion implements Command {
             }
 
         } catch (Exception e) {
-            logger.log(SystemProperties.DIAG, e);
+            logger.error( e);
             logger.info("Issue encountered while checking diagnostic version for updates.");
             logger.info("Failed to get current diagnostic version from Github.");
             logger.info("If Github is not accessible from this environemnt current supported version cannot be confirmed.");

--- a/src/main/java/com/elastic/support/diagnostics/commands/CheckDiagnosticVersion.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/CheckDiagnosticVersion.java
@@ -38,7 +38,7 @@ public class CheckDiagnosticVersion implements Command {
             return;
         }
 
-        logger.info("Checking for diagnostic version updates.");
+        logger.info(Constants.CONSOLE, "Checking for diagnostic version updates.");
         // Only need this once so let it auto-close at the end of the try catch block.
         try(RestClient restClient = RestClient.getClient(
                     context.diagsConfig.diagReleaseHost,
@@ -63,7 +63,7 @@ public class CheckDiagnosticVersion implements Command {
             // have a value of "debug" instead of an actual version.
             context.diagVersion = getToolVersion();
             if (context.diagVersion.equals(Constants.runningInIde) || StringUtils.isEmpty(context.diagVersion)) {
-                logger.info("Running in IDE");
+                logger.info(Constants.CONSOLE, "Running in IDE");
                 // Default it to something that won't blow up the Semver but shows it's not a normal run.
                 context.diagVersion = "0.0.0";
                 return;
@@ -78,8 +78,8 @@ public class CheckDiagnosticVersion implements Command {
 
             if (!diagVer.satisfies(rule)) {
 
-                logger.info("Warning: DiagnosticService version:{} is not the current recommended release", context.diagVersion);
-                logger.info("The current release is {}", ver);
+                logger.info(Constants.CONSOLE, "Warning: DiagnosticService version:{} is not the current recommended release", context.diagVersion);
+                logger.info(Constants.CONSOLE, "The current release is {}", ver);
 
                 // Try to get the link for the download url of the current release.
                 List<JsonNode> assets = rootNode.findValues("assets");
@@ -94,8 +94,8 @@ public class CheckDiagnosticVersion implements Command {
                     downloadUrl = context.diagsConfig.diagLatestRelease;
                 }
 
-                logger.info("The latest version can be downloaded at {}", downloadUrl);
-                logger.info("Press the Enter key to continue.");
+                logger.info(Constants.CONSOLE, "The latest version can be downloaded at {}", downloadUrl);
+                logger.info(Constants.CONSOLE, "Press the Enter key to continue.");
 
                 Scanner sc = new Scanner(System.in);
                 sc.nextLine();
@@ -103,9 +103,9 @@ public class CheckDiagnosticVersion implements Command {
 
         } catch (Exception e) {
             logger.error( e);
-            logger.info("Issue encountered while checking diagnostic version for updates.");
-            logger.info("Failed to get current diagnostic version from Github.");
-            logger.info("If Github is not accessible from this environemnt current supported version cannot be confirmed.");
+            logger.info(Constants.CONSOLE, "Issue encountered while checking diagnostic version for updates.");
+            logger.info(Constants.CONSOLE, "Failed to get current diagnostic version from Github.");
+            logger.info(Constants.CONSOLE, "If Github is not accessible from this environemnt current supported version cannot be confirmed.");
         }
     }
 

--- a/src/main/java/com/elastic/support/diagnostics/commands/CheckElasticsearchVersion.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/CheckElasticsearchVersion.java
@@ -67,7 +67,7 @@ public class CheckElasticsearchVersion implements Command {
         } catch (DiagnosticException de) {
             throw de;
         } catch (Exception e) {
-            logger.log(SystemProperties.DIAG, "Unanticipated error:", e);
+            logger.error( "Unanticipated error:", e);
             throw new DiagnosticException(String.format("Could not retrieve the Elasticsearch version due to a system or network error - unable to continue. %s%s%s", e.getMessage(), SystemProperties.lineSeparator, Constants.CHECK_LOG));
         }
     }

--- a/src/main/java/com/elastic/support/diagnostics/commands/CheckElasticsearchVersion.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/CheckElasticsearchVersion.java
@@ -34,7 +34,7 @@ public class CheckElasticsearchVersion implements Command {
 
         // Get the version number from the JSON returned
         // by just submitting the host/port combo
-        logger.info("Getting Elasticsearch Version.");
+        logger.info(Constants.CONSOLE, "Getting Elasticsearch Version.");
         DiagnosticInputs inputs = context.diagnosticInputs;
 
         try {

--- a/src/main/java/com/elastic/support/diagnostics/commands/CheckPlatformDetails.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/CheckPlatformDetails.java
@@ -102,7 +102,7 @@ public class CheckPlatformDetails implements Command {
                         context.runSystemCalls = false;
                         // We really don't have any way of really knowing
                         // what the enclosing platform is. So this may fail...
-                        logger.info("Docker containers detected on remote platform - unable to determine host OS. Linux will be used but if another operating system is present the Docker diagnostic calls may fail.");
+                        logger.warn(Constants.CONSOLE, "Docker containers detected on remote platform - unable to determine host OS. Linux will be used but if another operating system is present the Docker diagnostic calls may fail.");
                         targetOS = Constants.linuxPlatform;
                         //break;
                     }
@@ -157,15 +157,15 @@ public class CheckPlatformDetails implements Command {
                 default:
                     // If it's not one of the above types it shouldn't be here but try to keep going...
                     context.runSystemCalls = false;
-                    logger.info("Error occurred checking the network hosts information. Bypassing system calls.");
+                    logger.warn(Constants.CONSOLE, "Error occurred checking the network hosts information. Bypassing system calls.");
                     throw new RuntimeException("Host/Platform check error.");
 
             }
 
         } catch (Exception e) {
             // Try to keep going even if this didn't work.
-            logger.info("Error: {}", e.getMessage());
-            logger.log(SystemProperties.DIAG, "Error checking node metadata and deployment info.", e);
+            logger.error(Constants.CONSOLE,"Error: {}", e.getMessage());
+            logger.error( "Error checking node metadata and deployment info.", e);
             context.runSystemCalls = false;
         }
     }
@@ -179,7 +179,7 @@ public class CheckPlatformDetails implements Command {
                 .orElse(null);
 
         if (targetNode == null) {
-            logger.info("Could not find current master in node list.");
+            logger.warn(Constants.CONSOLE, "Could not find current master in node list.");
             throw new RuntimeException();
         }
 
@@ -251,7 +251,7 @@ public class CheckPlatformDetails implements Command {
                 nodeNetworkInfo.add(diagNode);
             }
         } catch (Exception e) {
-            logger.log(SystemProperties.DIAG, "Error extracting node network addresses from nodes output", e);
+            logger.error( "Error extracting node network addresses from nodes output", e);
         }
 
         return nodeNetworkInfo;
@@ -265,7 +265,7 @@ public class CheckPlatformDetails implements Command {
                 .orElse(null);
 
         if (targetNode == null) {
-            logger.info("Could not match node publish address to specified host. Bypassing system calls");
+            logger.warn(Constants.CONSOLE, "Could not match node publish address to specified host. Bypassing system calls");
             throw new RuntimeException();
         }
 
@@ -275,7 +275,7 @@ public class CheckPlatformDetails implements Command {
 
     public ProcessProfile findLocalTargetNode(String inputHost, List<ProcessProfile> nodeProfiles) {
 
-        logger.info("Checking the supplied hostname against the node information retrieved to verify location. This may take some time.");
+        logger.info(Constants.CONSOLE, "Checking the supplied hostname against the node information retrieved to verify location. This may take some time.");
 
         // If the input host was a loopback we need to compare each of the none loopback addresses present
         // on this host to the set of bound http addresses in each node. If if a non-loopback was input
@@ -319,7 +319,7 @@ public class CheckPlatformDetails implements Command {
         }
 
         // If we got this far and came up empty, signal our displeasure
-        logger.log(SystemProperties.DIAG, "Comparison did not result in an IP or Host match. {} {}", localAddrs, nodeAddrs);
+        logger.error( "Comparison did not result in an IP or Host match. {} {}", localAddrs, nodeAddrs);
         throw new RuntimeException("Could not find the target node.");
     }
 

--- a/src/main/java/com/elastic/support/diagnostics/commands/CollectDockerInfo.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/CollectDockerInfo.java
@@ -65,12 +65,12 @@ public class CollectDockerInfo implements Command {
                     return lines;
 
                 } catch (Exception e) {
-                    logger.log(SystemProperties.DIAG, "Error getting directory listing.", e);
+                    logger.error( "Error getting directory listing.", e);
                 }
             }
 
         } catch (Exception e) {
-            logger.log(SystemProperties.DIAG, "Error obtaining Docker Container Id's");
+            logger.error( "Error obtaining Docker Container Id's");
         }
 
         // If anything happened just bypass processing and continue with the rest.
@@ -92,7 +92,7 @@ public class CollectDockerInfo implements Command {
                 String output = sysCmd.runCommand(cmd);
                 SystemUtils.writeToFile(output, targetDir + SystemProperties.fileSeparator + entry.getKey() + suffix + ".txt");
             } catch (Exception e) {
-                logger.info(e.getMessage());
+                logger.error(Constants.CONSOLE, e.getMessage());
             }
         }
 

--- a/src/main/java/com/elastic/support/diagnostics/commands/CollectLogs.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/CollectLogs.java
@@ -27,7 +27,7 @@ public  class CollectLogs implements Command {
     public void execute(DiagnosticContext context) {
         // If we hit a snafu earlier in determining the details on where and how to run, then just get out.
         if(!context.runSystemCalls){
-            logger.info("There was an issue in setting up system logs collection - bypassing. {}", Constants.CHECK_LOG);
+            logger.info(Constants.CONSOLE, "There was an issue in setting up system logs collection - bypassing. {}", Constants.CHECK_LOG);
             return;
         }
 
@@ -61,7 +61,7 @@ public  class CollectLogs implements Command {
             logStatement = logStatement.replace("{{LOGPATH}}", logDir);
             String logListing = sysCmd.runCommand(logStatement).trim();
             if (StringUtils.isEmpty(logListing)) {
-                logger.info("No Elasticsearch log could be located at the path configured for this node. The cause of this is usually insufficient read authority. Please be sure the account you are using to access the logs has the necessary permissions or use sudo. See the diagnostic README for more information. ");
+                logger.info(Constants.CONSOLE, "No Elasticsearch log could be located at the path configured for this node. The cause of this is usually insufficient read authority. Please be sure the account you are using to access the logs has the necessary permissions or use sudo. See the diagnostic README for more information. ");
                 return;
             }
 
@@ -80,7 +80,7 @@ public  class CollectLogs implements Command {
             sysCmd.copyLogs(fileList, logDir, targetDir );
 
         } catch (Exception e) {
-            logger.info("An error occurred while copying the logs. It may not have completed normally {}.", Constants.CHECK_LOG);
+            logger.info(Constants.CONSOLE, "An error occurred while copying the logs. It may not have completed normally {}.", Constants.CHECK_LOG);
             logger.error( e.getMessage(), e);
         }
     }

--- a/src/main/java/com/elastic/support/diagnostics/commands/CollectLogs.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/CollectLogs.java
@@ -81,7 +81,7 @@ public  class CollectLogs implements Command {
 
         } catch (Exception e) {
             logger.info("An error occurred while copying the logs. It may not have completed normally {}.", Constants.CHECK_LOG);
-            logger.log(SystemProperties.DIAG, e.getMessage(), e);
+            logger.error( e.getMessage(), e);
         }
     }
 
@@ -102,7 +102,7 @@ public  class CollectLogs implements Command {
                     }
                 }
             } catch (Exception e) {
-                logger.log(SystemProperties.DIAG, "Error getting directory listing.", e);
+                logger.error( "Error getting directory listing.", e);
             }
         }
 

--- a/src/main/java/com/elastic/support/diagnostics/commands/CollectSystemCalls.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/CollectSystemCalls.java
@@ -75,7 +75,7 @@ public class CollectSystemCalls implements Command {
                 logger.info("JDK not found - bypassing jstack and jps commands.");
             }
         } catch (Exception e) {
-            logger.log(SystemProperties.DIAG, e);
+            logger.error( e);
             logger.info("Unexpected error - bypassing some or all system calls. {}", Constants.CHECK_LOG);
         }
     }

--- a/src/main/java/com/elastic/support/diagnostics/commands/CollectSystemCalls.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/CollectSystemCalls.java
@@ -9,6 +9,7 @@ import com.elastic.support.util.ResourceCache;
 import com.elastic.support.util.SystemCommand;
 import com.elastic.support.util.SystemProperties;
 import com.elastic.support.util.SystemUtils;
+import com.sun.xml.bind.v2.runtime.reflect.opt.Const;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import java.util.Map;
@@ -21,7 +22,7 @@ public class CollectSystemCalls implements Command {
 
         // If we hit a snafu earlier in determining the details on where and how to run, then just get out.
         if(!context.runSystemCalls){
-            logger.info("There was an issue in setting up system call collection - bypassing. {}", Constants.CHECK_LOG);
+            logger.info( Constants.CONSOLE, "There was an issue in setting up system call collection - bypassing. {}", Constants.CHECK_LOG);
             return;
         }
 
@@ -49,7 +50,7 @@ public class CollectSystemCalls implements Command {
             // JVM that's running ES. Given that it could be the bundled one or some
             // previously installed version we need to shell out and check before we run them.
             String esJavaHome = javaPlatform.extractJavaHome(javaExecutablePath);
-            logger.info("Java Home installation at: {}", esJavaHome);
+            logger.info(Constants.CONSOLE, "Java Home installation at: {}", esJavaHome);
 
             // Check for the presence of a JDK - run the javac command with no arguments
             // and see if you get a valid return - javac <version>
@@ -72,11 +73,11 @@ public class CollectSystemCalls implements Command {
                 processCalls(targetDir, javaCalls, sysCmd, pid);
             }
             else {
-                logger.info("JDK not found - bypassing jstack and jps commands.");
+                logger.info( Constants.CONSOLE, "JDK not found - bypassing jstack and jps commands.");
             }
         } catch (Exception e) {
             logger.error( e);
-            logger.info("Unexpected error - bypassing some or all system calls. {}", Constants.CHECK_LOG);
+            logger.info(Constants.CONSOLE, "Unexpected error - bypassing some or all system calls. {}", Constants.CHECK_LOG);
         }
     }
 

--- a/src/main/java/com/elastic/support/diagnostics/commands/GenerateManifest.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/GenerateManifest.java
@@ -30,7 +30,7 @@ public class GenerateManifest implements Command {
    public void execute(DiagnosticContext context) {
 
       // Dump out background information to provide information for potentially debugging the diagnostic if an issue occurs.
-      logger.info("Writing diagnostic manifest.");
+      logger.info(Constants.CONSOLE, "Writing diagnostic manifest.");
       try {
          ObjectMapper mapper = new ObjectMapper();
          mapper.enable(SerializationFeature.INDENT_OUTPUT);
@@ -46,7 +46,7 @@ public class GenerateManifest implements Command {
          File manifestFile = new File(context.tempDir + SystemProperties.fileSeparator + "manifest.json");
          mapper.writeValue(manifestFile, manifest);
       } catch (Exception e) {
-         logger.info("Error creating the manifest file", e);
+         logger.info(Constants.CONSOLE, "Error creating the manifest file", e);
       }
    }
 

--- a/src/main/java/com/elastic/support/diagnostics/commands/RunClusterQueries.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/RunClusterQueries.java
@@ -40,7 +40,7 @@ public class RunClusterQueries extends BaseQuery {
 
             runQueries(client, entries, context.tempDir, diagConfig.callRetries, diagConfig.pauseRetries);
         } catch (Throwable t) {
-            logger.log(SystemProperties.DIAG, "Error executing REST queries", t);
+            logger.error( "Error executing REST queries", t);
             throw new DiagnosticException(String.format("Unrecoverable REST Query Execution error - exiting. %s", Constants.CHECK_LOG));
         }
 

--- a/src/main/java/com/elastic/support/diagnostics/commands/RunLogstashQueries.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/RunLogstashQueries.java
@@ -96,7 +96,7 @@ public class RunLogstashQueries extends BaseQuery {
 
 
         } catch (Throwable t) {
-            logger.log(SystemProperties.DIAG, "Logstash Query error:", t);
+            logger.error( "Logstash Query error:", t);
             throw new DiagnosticException(String.format("Error obtaining logstash output and/or process id - will bypass the rest of processing.. %s", Constants.CHECK_LOG));
         }
     }

--- a/src/main/java/com/elastic/support/monitoring/MonitoringExportApp.java
+++ b/src/main/java/com/elastic/support/monitoring/MonitoringExportApp.java
@@ -19,14 +19,14 @@ public class MonitoringExportApp {
         try {
             MonitoringExportInputs monitoringExportInputs = new MonitoringExportInputs();
             if (args.length == 0) {
-                logger.info(Constants.interactiveMsg);
+                logger.info(Constants.CONSOLE,  Constants.interactiveMsg);
                 monitoringExportInputs.interactive = true;
                 monitoringExportInputs.runInteractive();
             } else {
                 List<String> errors = monitoringExportInputs.parseInputs(args);
                 if (errors.size() > 0) {
                     for (String err : errors) {
-                        logger.info(err);
+                        logger.error(Constants.CONSOLE, err);
                     }
                     monitoringExportInputs.usage();
                     SystemUtils.quitApp();
@@ -39,7 +39,7 @@ public class MonitoringExportApp {
         } catch (ShowHelpException she){
             SystemUtils.quitApp();
         } catch (Exception e) {
-            logger.info("Fatal error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
+            logger.error(Constants.CONSOLE, "Fatal error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
         } finally {
             ResourceCache.closeAll();
         }

--- a/src/main/java/com/elastic/support/monitoring/MonitoringExportConfig.java
+++ b/src/main/java/com/elastic/support/monitoring/MonitoringExportConfig.java
@@ -89,7 +89,8 @@ public class MonitoringExportConfig extends BaseConfig {
                     }
                 }
             } catch (IOException e) {
-                logger.info("Failed to read query configuration file", e);
+                logger.info(Constants.CONSOLE, "Failed to read query configuration file");
+                logger.info("Bad config", e);
             }
 
             buildQueries.put(entry.getKey(), resultStringBuilder.toString());

--- a/src/main/java/com/elastic/support/monitoring/MonitoringExportInputs.java
+++ b/src/main/java/com/elastic/support/monitoring/MonitoringExportInputs.java
@@ -1,9 +1,11 @@
 package com.elastic.support.monitoring;
 
 import com.beust.jcommander.Parameter;
+import com.elastic.support.Constants;
 import com.elastic.support.rest.ElasticRestClientInputs;
 import com.elastic.support.util.ResourceCache;
 import com.elastic.support.util.SystemProperties;
+import com.sun.xml.bind.v2.runtime.reflect.opt.Const;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -108,7 +110,7 @@ public class MonitoringExportInputs extends ElasticRestClientInputs {
             end = ZonedDateTime.parse(cutoff + ":00+00:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME);
             ZonedDateTime current = ZonedDateTime.now(ZoneId.of("+0"));
             if (end.isAfter(current)) {
-                logger.info("Warning: The input collection interval designates a stopping point after the current date and time. Resetting the start to the current date/time.");
+                logger.warn(Constants.CONSOLE, "Warning: The input collection interval designates a stopping point after the current date and time. Resetting the start to the current date/time.");
                 end = current;
             }
 

--- a/src/main/java/com/elastic/support/monitoring/MonitoringImportApp.java
+++ b/src/main/java/com/elastic/support/monitoring/MonitoringImportApp.java
@@ -20,14 +20,14 @@ public class MonitoringImportApp {
         try {
             MonitoringImportInputs monitoringImportInputs = new MonitoringImportInputs();
             if (args.length == 0) {
-                logger.info(Constants.interactiveMsg);
+                logger.info(Constants.CONSOLE,  Constants.interactiveMsg);
                 monitoringImportInputs.interactive = true;
                 monitoringImportInputs.runInteractive();
             } else {
                 List<String> errors = monitoringImportInputs.parseInputs(args);
                 if (errors.size() > 0) {
                     for (String err : errors) {
-                        logger.info(err);
+                        logger.error(Constants.CONSOLE,  err);
                     }
                     monitoringImportInputs.usage();
                     SystemUtils.quitApp();
@@ -38,7 +38,7 @@ public class MonitoringImportApp {
         } catch (ShowHelpException she){
             SystemUtils.quitApp();
         } catch (Exception e) {
-            logger.info("Error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
+            logger.error(Constants.CONSOLE,  "Error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
         } finally {
             ResourceCache.closeAll();
         }

--- a/src/main/java/com/elastic/support/monitoring/MonitoringImportProcessor.java
+++ b/src/main/java/com/elastic/support/monitoring/MonitoringImportProcessor.java
@@ -50,7 +50,7 @@ public class MonitoringImportProcessor implements ArchiveEntryProcessor {
             return;
         }
 
-        logger.info("Processing: {}", name);
+        logger.info(Constants.CONSOLE, "Processing: {}", name);
         long eventsWritten = 0;
 
         try {
@@ -86,7 +86,7 @@ public class MonitoringImportProcessor implements ArchiveEntryProcessor {
 
                     // See if we need to
                     if(batch >= config.bulkSize){
-                        logger.info("Indexing document batch {} to {}",  eventsWritten, eventsWritten+batch);
+                        logger.info(Constants.CONSOLE,  "Indexing document batch {} to {}",  eventsWritten, eventsWritten+batch);
 
                         long docsWritten = writeBatch(batchBuilder.toString(), batch);
                         eventsWritten += docsWritten;
@@ -100,20 +100,20 @@ public class MonitoringImportProcessor implements ArchiveEntryProcessor {
 
                 // if there's anything left do the cleanup
                 if(batch > 0){
-                    logger.info("Indexing document batch {} to {}",  eventsWritten, eventsWritten+batch);
+                    logger.info(Constants.CONSOLE,  "Indexing document batch {} to {}",  eventsWritten, eventsWritten+batch);
                     long docsWritten = writeBatch(batchBuilder.toString(), batch);
                     eventsWritten  += docsWritten;
                 }
 
             } catch (Throwable t) {
                 // If something goes wrong just log it and keep boing.
-                logger.info("Error processing JSON event for {}.", t);
+                logger.error(Constants.CONSOLE,"Error processing JSON event for {}.", t);
             }
         } catch (Throwable t) {
-            logger.info("Error processing entry - stream related error,", t);
+            logger.error(Constants.CONSOLE,"Error processing entry - stream related error,", t);
         }
         finally {
-            logger.info("{} events written from {}", eventsWritten, name);
+            logger.info(Constants.CONSOLE,"{} events written from {}", eventsWritten, name);
         }
 
     }
@@ -125,9 +125,9 @@ public class MonitoringImportProcessor implements ArchiveEntryProcessor {
     private long writeBatch(String query, int size){
         RestResult res = new RestResult( client.execPost("_bulk", query), "_bulk");
         if( res.getStatus() != 200){
-            logger.info("Batch update had errors: {}  {}", res.getStatus(), res.getReason());
-            logger.info(Constants.CHECK_LOG);
-            logger.log(SystemProperties.DIAG, res.toString());
+            logger.error(Constants.CONSOLE,"Batch update had errors: {}  {}", res.getStatus(), res.getReason());
+            logger.error(Constants.CONSOLE,Constants.CHECK_LOG);
+            logger.error(res.toString());
             return 0;
         }
         else {

--- a/src/main/java/com/elastic/support/monitoring/MonitoringImportService.java
+++ b/src/main/java/com/elastic/support/monitoring/MonitoringImportService.java
@@ -67,7 +67,7 @@ public class MonitoringImportService extends ElasticRestClientService {
             archiveUtils.extractDiagnosticArchive(inputs.input);
 
         }catch (Exception e){
-            logger.log(SystemProperties.DIAG, "Error extracting archive or indexing results", e);
+            logger.error( "Error extracting archive or indexing results", e);
             logger.info("Cannot contiue processing. {} \n {}", e.getMessage(), Constants.CHECK_LOG);
         }
         finally {

--- a/src/main/java/com/elastic/support/monitoring/MonitoringImportService.java
+++ b/src/main/java/com/elastic/support/monitoring/MonitoringImportService.java
@@ -49,12 +49,12 @@ public class MonitoringImportService extends ElasticRestClientService {
 
             // Create the temp directory - delete if first if it exists from a previous run
             SystemUtils.nukeDirectory(tempDir);
-            logger.info("Creating temp directory: {}", tempDir);
+            logger.info(Constants.CONSOLE, "Creating temp directory: {}", tempDir);
             Files.createDirectories(Paths.get(tempDir));
 
             // Set up the log file manually since we're going to package it with the diagnostic.
             // It will go to wherever we have the temp dir set up.
-            logger.info("Configuring log file.");
+            logger.info(Constants.CONSOLE, "Configuring log file.");
             createFileAppender(tempDir, "import.log");
 
             // Check the version.
@@ -68,7 +68,7 @@ public class MonitoringImportService extends ElasticRestClientService {
 
         }catch (Exception e){
             logger.error( "Error extracting archive or indexing results", e);
-            logger.info("Cannot contiue processing. {} \n {}", e.getMessage(), Constants.CHECK_LOG);
+            logger.info(Constants.CONSOLE, "Cannot contiue processing. {} \n {}", e.getMessage(), Constants.CHECK_LOG);
         }
         finally {
             closeLogs();

--- a/src/main/java/com/elastic/support/rest/ElasticRestClientService.java
+++ b/src/main/java/com/elastic/support/rest/ElasticRestClientService.java
@@ -2,6 +2,7 @@ package com.elastic.support.rest;
 
 import com.elastic.support.BaseService;
 import com.elastic.support.BaseConfig;
+import com.elastic.support.Constants;
 import com.elastic.support.util.SystemProperties;
 import com.elastic.support.util.SystemUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -16,16 +17,16 @@ public class ElasticRestClientService extends BaseService {
 
         if(StringUtils.isNotEmpty(user) && !isAuth){
             String border = SystemUtils.buildStringFromChar(60, '*');
-            logger.info(SystemProperties.lineSeparator);
-            logger.info(border);
-            logger.info(border);
-            logger.info(border);
-            logger.info("The elasticsearch user entered: {} does not appear to have sufficient authorization to access all collected information", user);
-            logger.info("Some of the calls may not have completed successfully.");
-            logger.info("If you are using a custom role please verify that it has the admin role for versions prior to 5.x or the superuser role for subsequent versions.");
-            logger.info(border);
-            logger.info(border);
-            logger.info(border);
+            logger.info(Constants.CONSOLE, SystemProperties.lineSeparator);
+            logger.info(Constants.CONSOLE, border);
+            logger.info(Constants.CONSOLE, border);
+            logger.info(Constants.CONSOLE, border);
+            logger.info(Constants.CONSOLE, "The elasticsearch user entered: {} does not appear to have sufficient authorization to access all collected information", user);
+            logger.info(Constants.CONSOLE, "Some of the calls may not have completed successfully.");
+            logger.info(Constants.CONSOLE, "If you are using a custom role please verify that it has the admin role for versions prior to 5.x or the superuser role for subsequent versions.");
+            logger.info(Constants.CONSOLE, border);
+            logger.info(Constants.CONSOLE, border);
+            logger.info(Constants.CONSOLE, border);
         }
 
     }

--- a/src/main/java/com/elastic/support/rest/RestClient.java
+++ b/src/main/java/com/elastic/support/rest/RestClient.java
@@ -1,5 +1,6 @@
 package com.elastic.support.rest;
 
+import com.elastic.support.Constants;
 import com.elastic.support.util.SystemProperties;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
@@ -70,10 +71,10 @@ public class RestClient implements Closeable {
         try {
             return client.execute(httpHost, httpRequest, httpContext);
         } catch (HttpHostConnectException e) {
-            logger.log(SystemProperties.DIAG, "Host connection error.", e);
+            logger.error( "Host connection error.", e);
             throw new RuntimeException("Host connection");
         } catch (Exception e) {
-            logger.log(SystemProperties.DIAG, "Unexpected Execution Error", e);
+            logger.error( "Unexpected Execution Error", e);
             throw new RuntimeException(e.getMessage());
         }
     }
@@ -87,7 +88,7 @@ public class RestClient implements Closeable {
             httpPost.setHeader("Content-type", "application/json");
             return execRequest(httpPost);
         } catch (UnsupportedEncodingException e) {
-            logger.info("Error with json body.", e);
+            logger.error(Constants.CONSOLE,  "Error with json body.", e);
             throw new RuntimeException("Could not complete post request.");
         }
     }
@@ -103,7 +104,7 @@ public class RestClient implements Closeable {
                 client.close();
             }
         } catch (Exception e) {
-            logger.log(SystemProperties.DIAG, "Error occurred closing client connection.");
+            logger.error( "Error occurred closing client connection.");
         }
     }
 
@@ -211,7 +212,7 @@ public class RestClient implements Closeable {
             return restClient;
         }
         catch (Exception e){
-            logger.log(SystemProperties.DIAG, "Connection setup failed", e);
+            logger.error( "Connection setup failed", e);
             throw new RuntimeException("Error establishing http connection for: " + host, e);
         }
     }

--- a/src/main/java/com/elastic/support/rest/RestEntryConfig.java
+++ b/src/main/java/com/elastic/support/rest/RestEntryConfig.java
@@ -23,7 +23,7 @@ public class RestEntryConfig {
         for(Map.Entry<String, Object> entry: config.entrySet()){
             RestEntry re = build(entry);
             if(re.getUrl().equals(RestEntry.MISSING) ){
-                logger.log(SystemProperties.DIAG, "{} was bypassed due by version check.", re.getName());
+                logger.error( "{} was bypassed due by version check.", re.getName());
             }
             else{
                 entries.put(re.getName(), re);

--- a/src/main/java/com/elastic/support/rest/RestResult.java
+++ b/src/main/java/com/elastic/support/rest/RestResult.java
@@ -35,7 +35,7 @@ public class RestResult implements Cloneable {
             responseString = EntityUtils.toString(response.getEntity());
         }
         catch (Exception e){
-            logger.log(SystemProperties.DIAG, "Error Processing Response", e);
+            logger.error( "Error Processing Response", e);
             throw new RuntimeException();
         }
         finally {
@@ -63,7 +63,7 @@ public class RestResult implements Cloneable {
                 IOUtils.write(reason + SystemProperties.lineSeparator + responseString, out, Constants.UTF_8);
             }
         } catch (Exception e) {
-            logger.log(SystemProperties.DIAG, "Error Streaming Response To OutputStream", e);
+            logger.error( "Error Streaming Response To OutputStream", e);
             throw new RuntimeException();
         }
         finally {
@@ -125,7 +125,7 @@ public class RestResult implements Cloneable {
             IOUtils.write(reason + SystemProperties.lineSeparator + responseString, fs, Constants.UTF_8);
         }
         catch (Exception e){
-            logger.log(SystemProperties.DIAG, "Error writing Response To OutputStream", e);
+            logger.error( "Error writing Response To OutputStream", e);
         }
     }
 

--- a/src/main/java/com/elastic/support/scrub/ScrubApp.java
+++ b/src/main/java/com/elastic/support/scrub/ScrubApp.java
@@ -23,14 +23,14 @@ public class ScrubApp {
         try {
             ScrubInputs scrubInputs = new ScrubInputs();
             if (args.length == 0) {
-                logger.info(Constants.interactiveMsg);
+                logger.error(Constants.CONSOLE,  Constants.interactiveMsg);
                 scrubInputs.interactive = true;
                 scrubInputs.runInteractive();
             } else {
                 List<String> errors = scrubInputs.parseIinputs(args);
                 if (errors.size() > 0) {
                     for (String err : errors) {
-                        logger.info(err);
+                        logger.error(Constants.CONSOLE,  err);
                     }
                     scrubInputs.usage();
                     SystemUtils.quitApp();
@@ -41,7 +41,7 @@ public class ScrubApp {
         } catch (ShowHelpException she){
             SystemUtils.quitApp();
         } catch (Exception e) {
-            logger.info("Fatal error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
+            logger.error(Constants.CONSOLE,  "Fatal error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
         } finally {
             ResourceCache.closeAll();
         }

--- a/src/main/java/com/elastic/support/scrub/ScrubInputs.java
+++ b/src/main/java/com/elastic/support/scrub/ScrubInputs.java
@@ -2,6 +2,7 @@ package com.elastic.support.scrub;
 
 import com.beust.jcommander.Parameter;
 import com.elastic.support.BaseInputs;
+import com.elastic.support.Constants;
 import com.elastic.support.util.ResourceCache;
 import com.elastic.support.util.SystemProperties;
 import org.apache.commons.lang3.ObjectUtils;
@@ -56,7 +57,7 @@ public class ScrubInputs extends BaseInputs {
                 .withNumberedPossibleValues("Scrub Archive", "Scrub Single File")
                 .withIgnoreCase()
                 .read(SystemProperties.lineSeparator + "Select the type of file you wish to scrub." );
-        logger.info("");
+        logger.info(Constants.CONSOLE, "");
 
         if(operation.toLowerCase().contains("archive")) {
             archive = ResourceCache.textIO.newStringInputReader()
@@ -71,12 +72,12 @@ public class ScrubInputs extends BaseInputs {
                     .read("Enter the full path of the individual file you wish to import.");
         }
 
-        logger.info("");
+        logger.info(Constants.CONSOLE, "");
 
-        logger.info("If you do not specify a yaml configuration file, the utility will automatically");
-        logger.info("obfuscate IP and MAC addresses by default. You do NOT need to configure that functionality.");
-        logger.info("If you wish to extend for additional masking you MUST explicitly enter a file to input.");
-        logger.info("Note that for docker containers this must be a file within the configured volume.");
+        logger.info(Constants.CONSOLE,  "If you do not specify a yaml configuration file, the utility will automatically");
+        logger.info(Constants.CONSOLE,  "obfuscate IP and MAC addresses by default. You do NOT need to configure that functionality.");
+        logger.info(Constants.CONSOLE,  "If you wish to extend for additional masking you MUST explicitly enter a file to input.");
+        logger.info(Constants.CONSOLE,  "Note that for docker containers this must be a file within the configured volume.");
         configFile = ResourceCache.textIO.newStringInputReader()
                 .withInputTrimming(true)
                 .withMinLength(0)
@@ -84,7 +85,7 @@ public class ScrubInputs extends BaseInputs {
                 .read("Enter the full path of the Configuration file you wish to import or hit enter to take the default IP/MAC scrub.");
 
         if(runningInDocker){
-            logger.info("Result will be written to the configured Docker volume.");
+            logger.info(Constants.CONSOLE,  "Result will be written to the configured Docker volume.");
         }
         else{
             runOutputDirInteractive();

--- a/src/main/java/com/elastic/support/scrub/ScrubProcessor.java
+++ b/src/main/java/com/elastic/support/scrub/ScrubProcessor.java
@@ -53,7 +53,7 @@ public class ScrubProcessor implements ArchiveEntryProcessor {
          if(scrubConfig.get("tokens") != null){
             tokens = (List<String>)scrubConfig.get("tokens");
             if (tokens.size() == 0){
-               logger.info("Scrubbing was enabled but no substitutions were defined. Bypassing log file processing.");
+               logger.info(Constants.CONSOLE,  "Scrubbing was enabled but no substitutions were defined. Bypassing log file processing.");
             }
          }
 
@@ -67,7 +67,7 @@ public class ScrubProcessor implements ArchiveEntryProcessor {
          }
 
       } catch (Exception e) {
-         logger.info("Error initializing scrubbing  files.", e);
+         logger.error(Constants.CONSOLE,  "Error initializing scrubbing  files.", e);
          throw new RuntimeException("Scrub initialization failed");
       }
 
@@ -112,7 +112,7 @@ public class ScrubProcessor implements ArchiveEntryProcessor {
          String dir = targetDir;
          InputStream processedStream = ais;
 
-         logger.info("Processing: {}", name);
+         logger.info(Constants.CONSOLE,"Processing: {}", name);
          int dirPos =  name.indexOf("/");
          name = name.substring(dirPos);
          // It's a directory, so we don't process the file. but we do need to create a target subdirectory for subsequent files.

--- a/src/main/java/com/elastic/support/scrub/ScrubService.java
+++ b/src/main/java/com/elastic/support/scrub/ScrubService.java
@@ -70,8 +70,8 @@ public class ScrubService extends BaseService {
          }
 
       } catch (Throwable t) {
-         logger.log(SystemProperties.DIAG, "Error occurred: ", t);
-         logger.info("Issue encountered during scrub processing. {}.", Constants.CHECK_LOG);
+         logger.error( "Error occurred: ", t);
+         logger.error(Constants.CONSOLE,  "Issue encountered during scrub processing. {}.", Constants.CHECK_LOG);
       }
       finally{
          closeLogs();

--- a/src/main/java/com/elastic/support/util/ArchiveUtils.java
+++ b/src/main/java/com/elastic/support/util/ArchiveUtils.java
@@ -1,5 +1,6 @@
 package com.elastic.support.util;
 
+import com.elastic.support.Constants;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
@@ -34,7 +35,7 @@ public class ArchiveUtils {
 
    public void createArchive(String dir, String archiveFileName) {
       if(! createZipArchive(dir, archiveFileName)){
-         logger.info("Couldn't create zip archive. Trying tar.gz");
+         logger.error(Constants.CONSOLE,  "Couldn't create zip archive. Trying tar.gz");
          if(! createTarArchive(dir, archiveFileName)){
             logger.info("Couldn't create tar.gz archive.");
          }
@@ -52,10 +53,10 @@ public class ArchiveUtils {
          archiveResultsZip(archiveFileName, taos, srcDir, "", true);
          taos.close();
 
-         logger.info("Archive: " + filename + " was created");
+         logger.info(Constants.CONSOLE, "Archive: " + filename + " was created");
 
       } catch (Exception ioe) {
-         logger.log(SystemProperties.DIAG, "Couldn't create archive.", ioe);
+         logger.error( "Couldn't create archive.", ioe);
          return false;
       }
       return true;
@@ -77,10 +78,10 @@ public class ArchiveUtils {
          archiveResultsTar(archiveFileName, taos, srcDir, "", true);
          taos.close();
 
-         logger.info("Archive: " + filename + " was created");
+         logger.info(Constants.CONSOLE,  "Archive: " + filename + " was created");
 
       } catch (Exception ioe) {
-         logger.log(SystemProperties.DIAG, "Couldn't create archive.", ioe);
+         logger.error( "Couldn't create archive.", ioe);
          return false;
       }
 
@@ -113,7 +114,7 @@ public class ArchiveUtils {
             }
          }
       } catch (IOException e) {
-         logger.info("Archive Error", e);
+         logger.error(Constants.CONSOLE,"Archive Error", e);
       }
    }
 
@@ -142,13 +143,13 @@ public class ArchiveUtils {
             }
          }
       } catch (IOException e) {
-         logger.info("Archive Error", e);
+         logger.error(Constants.CONSOLE,"Archive Error", e);
       }
    }
 
    public void extractDiagnosticArchive(String sourceInput) throws Exception {
 
-      logger.info("Extracting archive...");
+      logger.info(Constants.CONSOLE,  "Extracting archive...");
 
       try {
          ZipFile zf = new ZipFile(new File(sourceInput));
@@ -164,7 +165,7 @@ public class ArchiveUtils {
          }
 
       } catch (IOException e)      {
-         logger.info("Error extracting {}.", "", e);
+         logger.error(Constants.CONSOLE, "Error extracting {}.", "", e);
          throw new RuntimeException("Error extracting {} from archive.", e);
       }
    }

--- a/src/main/java/com/elastic/support/util/ArchiveUtils.java
+++ b/src/main/java/com/elastic/support/util/ArchiveUtils.java
@@ -37,7 +37,7 @@ public class ArchiveUtils {
       if(! createZipArchive(dir, archiveFileName)){
          logger.error(Constants.CONSOLE,  "Couldn't create zip archive. Trying tar.gz");
          if(! createTarArchive(dir, archiveFileName)){
-            logger.info("Couldn't create tar.gz archive.");
+            logger.info(Constants.CONSOLE, "Couldn't create tar.gz archive.");
          }
       }
    }

--- a/src/main/java/com/elastic/support/util/LocalSystem.java
+++ b/src/main/java/com/elastic/support/util/LocalSystem.java
@@ -64,7 +64,7 @@ public class LocalSystem extends SystemCommand {
 
         } catch (Exception e) {
             logger.info("Error encountered running {}", cmd);
-            logger.log(SystemProperties.DIAG, "System command error", e);
+            logger.error( "System command error", e);
         }
 
         return sb.toString();
@@ -81,7 +81,7 @@ public class LocalSystem extends SystemCommand {
                 FileUtils.copyFile(new File(source), new File(target));
             } catch (IOException e) {
                 logger.info("Error retrieving log: {}. Bypassing.", entry);
-                logger.log(SystemProperties.DIAG, e);
+                logger.error( e);
             }
         }
     }

--- a/src/main/java/com/elastic/support/util/RemoteSystem.java
+++ b/src/main/java/com/elastic/support/util/RemoteSystem.java
@@ -40,7 +40,7 @@ public class RemoteSystem extends SystemCommand {
 
         try {
             if(osName.equals(Constants.winPlatform)){
-                logger.info("Windows is not supported for remote calls at this time. Session not created.");
+                logger.info(Constants.CONSOLE, "Windows is not supported for remote calls at this time. Session not created.");
                 disabledForPlatform = true;
                 return;
             }
@@ -94,7 +94,7 @@ public class RemoteSystem extends SystemCommand {
 
     public String runCommand(String cmd) {
         if(disabledForPlatform){
-            logger.info("Windows is not supported for remote calls at this time");
+            logger.info(Constants.CONSOLE, "Windows is not supported for remote calls at this time");
             return "No Content available: Incompatible platform.";
         }
 
@@ -133,7 +133,7 @@ public class RemoteSystem extends SystemCommand {
             }
         }
         catch(Exception e){
-            logger.info("Failed remote command: {}. {}", cmd, Constants.CHECK_LOG) ;
+            logger.info(Constants.CONSOLE, "Failed remote command: {}. {}", cmd, Constants.CHECK_LOG) ;
             logger.error("System command failed.", e);
         }
         finally {
@@ -176,7 +176,7 @@ public class RemoteSystem extends SystemCommand {
             runCommand(" rm -Rf templogs");
 
         } catch (Exception e) {
-            logger.info("Error occurred copying remote logfiles. {}", Constants.CHECK_LOG);
+            logger.info(Constants.CONSOLE, "Error occurred copying remote logfiles. {}", Constants.CHECK_LOG);
             logger.error( e);
         } finally {
             if(channelSftp != null && channelSftp.isConnected()){

--- a/src/main/java/com/elastic/support/util/RemoteSystem.java
+++ b/src/main/java/com/elastic/support/util/RemoteSystem.java
@@ -125,7 +125,7 @@ public class RemoteSystem extends SystemCommand {
                 }
                 if(channel.isClosed()){
                     if(istream.available()>0) continue;
-                    logger.log(SystemProperties.DIAG, "Cmd: {}, Exit status: {}", scrubCommandText(cmd), channel.getExitStatus());
+                    logger.error( "Cmd: {}, Exit status: {}", scrubCommandText(cmd), channel.getExitStatus());
                     break;
                 }
                 try{
@@ -134,7 +134,7 @@ public class RemoteSystem extends SystemCommand {
         }
         catch(Exception e){
             logger.info("Failed remote command: {}. {}", cmd, Constants.CHECK_LOG) ;
-            logger.log(SystemProperties.DIAG,"System command failed.", e);
+            logger.error("System command failed.", e);
         }
         finally {
             if (channel!= null && channel.isConnected()) {
@@ -177,7 +177,7 @@ public class RemoteSystem extends SystemCommand {
 
         } catch (Exception e) {
             logger.info("Error occurred copying remote logfiles. {}", Constants.CHECK_LOG);
-            logger.log(SystemProperties.DIAG, e);
+            logger.error( e);
         } finally {
             if(channelSftp != null && channelSftp.isConnected()){
                 channelSftp.disconnect();

--- a/src/main/java/com/elastic/support/util/ResourceCache.java
+++ b/src/main/java/com/elastic/support/util/ResourceCache.java
@@ -64,7 +64,7 @@ public class ResourceCache{
                     resource.close();
                 }
                 catch (Exception e){
-                    logger.log(SystemProperties.DIAG, "Failed to close resource {}", name);
+                    logger.error( "Failed to close resource {}", name);
                 }
         });
         textIO.dispose();

--- a/src/main/java/com/elastic/support/util/SystemProperties.java
+++ b/src/main/java/com/elastic/support/util/SystemProperties.java
@@ -9,6 +9,7 @@ import java.util.Date;
 public class SystemProperties {
 
    public static Level DIAG = Level.forName("DIAG", 250);
+   public static Level CONSOLE = Level.forName("CONSOLE", 50);
 
    public static final String osName = System.getProperty("os.name");
 

--- a/src/main/java/com/elastic/support/util/SystemUtils.java
+++ b/src/main/java/com/elastic/support/util/SystemUtils.java
@@ -27,17 +27,17 @@ public class SystemUtils {
     private static final Logger logger = LogManager.getLogger(SystemUtils.class);
 
     public static void quitApp(){
-        logger.info("Exiting...");
+        logger.info(Constants.CONSOLE,  "Exiting...");
         System.exit(0);
     }
 
     public static void writeToFile(String content, String dest) {
         try {
-            logger.info("Writing to {}", dest);
+            logger.info(Constants.CONSOLE,  "Writing to {}", dest);
             File outFile = new File(dest);
             FileUtils.writeStringToFile(outFile, content, "UTF-8");
         } catch (IOException e) {
-            logger.log(SystemProperties.DIAG, "Error writing content for {}", dest, e);
+            logger.error( "Error writing content for {}", dest, e);
             throw new DiagnosticException("Error writing " + dest + " See diagnostic.log for details.");
         }
     }
@@ -48,10 +48,10 @@ public class SystemUtils {
             try {
                 instream.close();
             } catch (Throwable t) {
-                logger.info("Error encountered when attempting to close file {}", path);
+                logger.error(Constants.CONSOLE, "Error encountered when attempting to close file {}", path);
             }
         } else {
-            logger.info("Error encountered when attempting to close file: null InputStream {}", path);
+            logger.error(Constants.CONSOLE, "Error encountered when attempting to close file: null InputStream {}", path);
         }
 
     }
@@ -61,9 +61,9 @@ public class SystemUtils {
             File tmp = new File(dir);
             tmp.setWritable(true, false);
             FileUtils.deleteDirectory(tmp);
-            logger.info("Deleted directory: {}.", dir);
+            logger.info(Constants.CONSOLE,  "Deleted directory: {}.", dir);
         } catch (IOException e) {
-            logger.info("Delete of directory:{} failed. Usually this indicates a permission issue", dir, e);
+            logger.error(Constants.CONSOLE, "Delete of directory:{} failed. Usually this indicates a permission issue", dir, e);
         }
     }
 
@@ -85,7 +85,7 @@ public class SystemUtils {
             s = stdInput.readLine();
 
         } catch (IOException e) {
-            logger.info("Error retrieving hostname.", e);
+            logger.error(Constants.CONSOLE,  "Error retrieving hostname.", e);
         }
         finally {
             try {
@@ -93,14 +93,14 @@ public class SystemUtils {
                     stdError.close();
                 }
             } catch (IOException e) {
-                logger.info("Couldn't close stderror stream");
+                logger.error(Constants.CONSOLE,  "Couldn't close stderror stream");
             }
             try {
                 if(stdInput != null){
                     stdInput.close();
                 }
             } catch (IOException e) {
-                logger.info("Couldn't close stdinput stream");
+                logger.error(Constants.CONSOLE,  "Couldn't close stdinput stream");
             }
         }
 
@@ -129,7 +129,7 @@ public class SystemUtils {
                 }
             }
         } catch (Exception e) {
-            logger.info("Error occurred acquiring IP's and hostnames", e);
+            logger.error(Constants.CONSOLE,  "Error occurred acquiring IP's and hostnames", e);
         }
 
         return ipAndHosts;
@@ -170,7 +170,7 @@ public class SystemUtils {
 
         } else {
             // default it to Linux
-            logger.info("Unsupported OS -defaulting to Linux: {}", osName);
+            logger.warn(Constants.CONSOLE, "Unsupported OS -defaulting to Linux: {}", osName);
             return  Constants.linuxPlatform;
         }
     }
@@ -190,9 +190,9 @@ public class SystemUtils {
             isDocker = checkCGroupEntries(entries);
 
         } catch (Exception e) {
-            logger.log(SystemProperties.DIAG, e);
-            logger.info("Error encountered during check docker embedding. {} {}", e.getMessage(), Constants.CHECK_LOG);
-            logger.info("Assuming no container, local calls enabled.");
+            logger.error( e);
+            logger.error(Constants.CONSOLE,  "Error encountered during check docker embedding. {} {}", e.getMessage(), Constants.CHECK_LOG);
+            logger.error(Constants.CONSOLE,  "Assuming no container, local calls enabled.");
         }
 
         return isDocker;

--- a/src/main/resources/diags.yml
+++ b/src/main/resources/diags.yml
@@ -8,7 +8,6 @@
 #
 #
 
-diagnosticVersion: 8.0.1
 ## Should only need to change these if Github modifies something
   ## github-settings:
   ##   diagReleaseHost: "api.github.com"
@@ -134,3 +133,36 @@ monitoring-queryfiles:
 monitoring-scroll-size: 500
 default-monitoring-index: ".monitoring-es-7"
 bulk-import-size: 250
+
+flight-recorder-es:
+  complete:
+    - allocation
+    - allocation_explain
+    - allocation_explain_disk
+    - cluster_settings
+    - cluster_settings_defaults
+    - cluster_stats
+    - fielddata
+    - fielddata_stats
+    - indices
+    - indices_stats
+    - licenses
+    - mapping
+    - master
+    - nodes
+    - nodes_stats
+    - nodes_usage
+    - pipelines
+    - recovery
+    - segments
+    - settings
+    - shards
+    - tasks
+    - templates
+    - ccr_stats
+    - enrich_stats
+    - ilm_status
+    - rollup_jobs
+  stability:
+    - nodes
+    - shards

--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -173,6 +173,11 @@ fielddata_stats:
     ">= 0.9.0 < 5.0.0": "/_nodes/stats/indices/fielddata?pretty=true&fields=*"
     ">= 5.0.0": "/_nodes/stats/indices/fielddata?level=shards&pretty=true&fields=*"
 
+indices:
+  versions:
+    ">= 0.9.0 < 5.1.1": "/_cat/indices?v&format=json"
+    ">= 5.1.1": "/_cat/indices?v&s=index&format=json"
+
 indices_stats:
   retry: true
   versions:

--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -69,7 +69,7 @@ cat_nodes:
   extension: ".txt"
   subdir: "cat"
   versions:
-    ">= 0.9.0": "/_cat/nodes?v&h=n,m,i,r,d,hp,rp,cpu,load_1m,load_5m,load_15m,nodeId"
+    ">= 0.9.0": "/_cat/nodes?v&h=n,nodeId,m,i,r,d,hp,rp,cpu,load_1m,load_5m,load_15m,"
 
 cat_pending_tasks:
   extension: ".txt"
@@ -175,8 +175,8 @@ fielddata_stats:
 
 indices:
   versions:
-    ">= 0.9.0 < 5.1.1": "/_cat/indices?v&format=json"
-    ">= 5.1.1": "/_cat/indices?v&s=index&format=json"
+    ">= 0.9.0 < 5.1.1": "/_cat/indices?format=json&bytes=b&h=index,shard,prirep,state,docs,store,id,node"
+    ">= 7.0.0": "/_cat/shards?format=json&bytes=b&s=index&h=index,shard,prirep,state,docs,store,id,node,se,sm,fm,fe,ft,iiti,iito,iitf,idto,idti,ftt,ua,ud,ur"
 
 indices_stats:
   retry: true
@@ -202,6 +202,10 @@ nodes:
   retry: true
   versions:
     ">= 0.9.0": "/_nodes?pretty&human"
+
+nodes_short:
+  versions:
+    ">= 0.9.0": "/_cat/nodes?format=json&v&full_id&h=name,id,master,ip,role"
 
 nodes_stats:
   retry: true

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -4,17 +4,22 @@
         <CustomLevel name="DIAG" intLevel="250" />
     </CustomLevels>
     <Appenders>
-        <Console name="Console" target="SYSTEM_OUT">
+        <Console name="console" target="SYSTEM_OUT">
             <PatternLayout pattern="%msg%n"/>
             <Filters>
-           <!--     <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>-->
-                <ThresholdFilter level="DIAG" onMatch="DENY" onMismatch="NEUTRAL" />
+                <MarkerFilter marker="CONSOLE" onMatch="ACCEPT" onMismatch="DENY"/>
             </Filters>
         </Console>
+        <File name="diag" fileName="diag-startup.log"
+              append="false"
+              immediateFlush="true">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </File>
     </Appenders>
     <Loggers>
         <Root level="info">
-            <AppenderRef ref="Console" />
+            <AppenderRef ref="console" />
+            <AppenderRef ref="diag" />
         </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
Prior to this, logging to the console and included diagnostic log was handled by specifying a custom log level for the archived diagnostic log. This made setting a custom log level for an included library or isolated pieces of diag code cumbersome. Instead a marker is used to differentiate between messages that go only to the diagnostic log and those that go to both the console and the log.