### PR TITLE
Add support for capturing dangling indices

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -174,6 +174,10 @@ cluster_stats:
   versions:
     ">= 0.9.0": "/_cluster/stats?pretty&human"
 
+dangling_indices:
+  versions:
+    ">= 7.9.0": "/_dangling?pretty&human"
+
 fielddata:
   versions:
     ">= 0.9.0": "/_cat/fielddata?format=json&bytes&pretty"


### PR DESCRIPTION
Add support for capturing the output from the new dangling indices API. This applies from 7.9.0 onwwards.