### PR TITLE
Add Searchable Snapshots Cache Stats API

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -394,6 +394,11 @@ rollup_index_caps:
     ">= 6.5.0 < 7.0.0": "/*/_xpack/rollup/data"
     ">= 7.0.0": "/*/_rollup/data"
 
+searchable_snapshots_cache_stats:
+  subdir: "commercial"
+  versions:
+    ">= 7.13.0": "/_searchable_snapshots/cache/stats?pretty&human"
+
 security_priv:
   subdir: "commercial"
   versions:


### PR DESCRIPTION
Elasticsearch 7.13.0 has a new Cache Stats API for Searchable Snapshots which provides various statistics about the shared cache (see elastic/elasticsearch#71701 and elastic/elasticsearch#71849).

This pull request adds this new API to the support diagnostics.