### PR TITLE
DiagnosticService and ScrubService should return File and throw checked Exception

### DIFF
--- a/src/main/java/com/elastic/support/BaseService.java
+++ b/src/main/java/com/elastic/support/BaseService.java
@@ -3,7 +3,6 @@ package com.elastic.support;
 import com.elastic.support.diagnostics.DiagnosticException;
 import com.elastic.support.util.ArchiveUtils;
 import com.elastic.support.util.SystemProperties;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.Appender;
@@ -13,6 +12,8 @@ import org.apache.logging.log4j.core.appender.FileAppender;
 import org.apache.logging.log4j.core.config.AppenderRef;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.layout.PatternLayout;
+
+import java.io.File;
 
 public abstract  class BaseService {
 
@@ -71,9 +72,9 @@ public abstract  class BaseService {
 
     }
 
-    public void createArchive(String tempDir) throws DiagnosticException {
+    public File createArchive(String tempDir) throws DiagnosticException {
         logger.info(Constants.CONSOLE, "Archiving diagnostic results.");
-        ArchiveUtils.createArchive(tempDir, SystemProperties.getFileDateString());
+        return ArchiveUtils.createArchive(tempDir, SystemProperties.getFileDateString());
     }
 
 }

--- a/src/main/java/com/elastic/support/BaseService.java
+++ b/src/main/java/com/elastic/support/BaseService.java
@@ -1,5 +1,6 @@
 package com.elastic.support;
 
+import com.elastic.support.diagnostics.DiagnosticException;
 import com.elastic.support.util.ArchiveUtils;
 import com.elastic.support.util.SystemProperties;
 import org.apache.logging.log4j.Level;
@@ -70,18 +71,9 @@ public abstract  class BaseService {
 
     }
 
-    public void createArchive(String tempDir) {
-
+    public void createArchive(String tempDir) throws DiagnosticException {
         logger.info(Constants.CONSOLE, "Archiving diagnostic results.");
-
-        try {
-            String archiveFilename = SystemProperties.getFileDateString();
-            ArchiveUtils archiveUtils = new ArchiveUtils();
-            archiveUtils.createArchive(tempDir, archiveFilename);
-
-        } catch (Exception ioe) {
-            logger.info("Couldn't create archive. {}", ioe);
-        }
+        ArchiveUtils.createArchive(tempDir, SystemProperties.getFileDateString());
     }
 
 }

--- a/src/main/java/com/elastic/support/diagnostics/DiagnosticException.java
+++ b/src/main/java/com/elastic/support/diagnostics/DiagnosticException.java
@@ -1,11 +1,8 @@
 package com.elastic.support.diagnostics;
 
-import java.util.ArrayList;
-import java.util.List;
-
-public class DiagnosticException extends RuntimeException {
-
+public class DiagnosticException extends Exception {
     public DiagnosticException() {
+        super();
     }
 
     public DiagnosticException(String message) {
@@ -15,13 +12,4 @@ public class DiagnosticException extends RuntimeException {
     public DiagnosticException(String message, Throwable cause) {
         super(message, cause);
     }
-
-    public DiagnosticException(Throwable cause) {
-        super(cause);
-    }
-
-    public DiagnosticException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-        super(message, cause, enableSuppression, writableStackTrace);
-    }
-
 }

--- a/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
+++ b/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
@@ -79,10 +79,10 @@ public class DiagnosticService extends ElasticRestClientService {
             }
 
             checkAuthLevel(ctx.diagnosticInputs.user, ctx.isAuthorized);
-            closeLogs();
 
             return createArchive(ctx.tempDir);
         } finally {
+            closeLogs();
             SystemUtils.nukeDirectory(ctx.tempDir);
             ResourceCache.closeAll();
         }

--- a/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
+++ b/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
@@ -19,8 +19,7 @@ public class DiagnosticService extends ElasticRestClientService {
 
     private Logger logger = LogManager.getLogger(DiagnosticService.class);
 
-    public void exec(DiagnosticInputs inputs, DiagConfig config) throws DiagnosticException {
-
+    public File exec(DiagnosticInputs inputs, DiagConfig config) throws DiagnosticException {
         DiagnosticContext ctx = new DiagnosticContext();
         ctx.diagsConfig = config;
         ctx.diagnosticInputs = inputs;
@@ -81,7 +80,8 @@ public class DiagnosticService extends ElasticRestClientService {
 
             checkAuthLevel(ctx.diagnosticInputs.user, ctx.isAuthorized);
             closeLogs();
-            createArchive(ctx.tempDir);
+
+            return createArchive(ctx.tempDir);
         } finally {
             SystemUtils.nukeDirectory(ctx.tempDir);
             ResourceCache.closeAll();

--- a/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
+++ b/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -18,7 +19,7 @@ public class DiagnosticService extends ElasticRestClientService {
 
     private Logger logger = LogManager.getLogger(DiagnosticService.class);
 
-    public void exec(DiagnosticInputs inputs, DiagConfig config) {
+    public void exec(DiagnosticInputs inputs, DiagConfig config) throws DiagnosticException {
 
         DiagnosticContext ctx = new DiagnosticContext();
         ctx.diagsConfig = config;
@@ -50,8 +51,15 @@ public class DiagnosticService extends ElasticRestClientService {
             ctx.tempDir = outputDir + SystemProperties.fileSeparator + inputs.diagType + "-" + Constants.ES_DIAG;
             logger.info(Constants.CONSOLE, "{}Creating temp directory: {}", SystemProperties.lineSeparator, ctx.tempDir);
 
-            FileUtils.deleteDirectory(new File(ctx.tempDir));
-            Files.createDirectories(Paths.get(ctx.tempDir));
+            try {
+                FileUtils.deleteDirectory(new File(ctx.tempDir));
+                Files.createDirectories(Paths.get(ctx.tempDir));
+            }
+            catch (IOException ioe) {
+                logger.error("Temp directory error", ioe);
+                logger.info(Constants.CONSOLE, String.format("Issue with creating temp directory. %s", Constants.CHECK_LOG));
+                throw new DiagnosticException("Could not create temporary directory", ioe);
+            }
 
             // Modify the log file setup since we're going to package it with the diagnostic.
             // The log4 configuration file sets up 2 loggers, one strictly for the console and a file log in the working directory to handle
@@ -71,16 +79,10 @@ public class DiagnosticService extends ElasticRestClientService {
                 logger.info(Constants.CONSOLE, "Identified Docker installations - bypassed log collection and some system calls.");
             }
 
-           checkAuthLevel(ctx.diagnosticInputs.user, ctx.isAuthorized);
-
-        } catch (DiagnosticException de) {
-            logger.error(Constants.CONSOLE, de.getMessage());
-        } catch (Throwable t) {
-            logger.error( "Temp directory error", t);
-            logger.info(Constants.CONSOLE, String.format("Issue with creating temp directory. %s", Constants.CHECK_LOG));
-        } finally {
+            checkAuthLevel(ctx.diagnosticInputs.user, ctx.isAuthorized);
             closeLogs();
             createArchive(ctx.tempDir);
+        } finally {
             SystemUtils.nukeDirectory(ctx.tempDir);
             ResourceCache.closeAll();
         }

--- a/src/main/java/com/elastic/support/diagnostics/JavaPlatform.java
+++ b/src/main/java/com/elastic/support/diagnostics/JavaPlatform.java
@@ -38,7 +38,7 @@ public class JavaPlatform {
         }
     }
 
-    public String extractJdkPath(String processList) {
+    public String extractJdkPath(String processList) throws DiagnosticException {
 
         String line;
         try (BufferedReader br = new BufferedReader(new StringReader(processList))) {

--- a/src/main/java/com/elastic/support/diagnostics/chain/Command.java
+++ b/src/main/java/com/elastic/support/diagnostics/chain/Command.java
@@ -1,5 +1,7 @@
 package com.elastic.support.diagnostics.chain;
 
+import com.elastic.support.diagnostics.DiagnosticException;
+
 public interface Command {
-    void execute(DiagnosticContext context);
+    void execute(DiagnosticContext context) throws DiagnosticException;
 }

--- a/src/main/java/com/elastic/support/diagnostics/chain/DiagnosticChainExec.java
+++ b/src/main/java/com/elastic/support/diagnostics/chain/DiagnosticChainExec.java
@@ -12,7 +12,7 @@ public class DiagnosticChainExec {
 
     private static Logger logger = LogManager.getLogger(DiagnosticChainExec.class);
 
-    public static void runDiagnostic(DiagnosticContext context, String type) {
+    public static void runDiagnostic(DiagnosticContext context, String type) throws DiagnosticException {
 
         try {
             new CheckDiagnosticVersion().execute(context);
@@ -114,9 +114,6 @@ public class DiagnosticChainExec {
                 }
 
             new GenerateManifest().execute(context);
-
-        } catch (DiagnosticException de) {
-            throw de;
         }
         catch (Throwable t){
             logger.error( "Unexpected error", t);

--- a/src/main/java/com/elastic/support/diagnostics/chain/DiagnosticChainExec.java
+++ b/src/main/java/com/elastic/support/diagnostics/chain/DiagnosticChainExec.java
@@ -3,122 +3,109 @@ package com.elastic.support.diagnostics.chain;
 import com.elastic.support.Constants;
 import com.elastic.support.diagnostics.DiagnosticException;
 import com.elastic.support.diagnostics.commands.*;
-import com.elastic.support.util.SystemProperties;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 
 public class DiagnosticChainExec {
 
-    private static Logger logger = LogManager.getLogger(DiagnosticChainExec.class);
-
     public static void runDiagnostic(DiagnosticContext context, String type) throws DiagnosticException {
+        new CheckDiagnosticVersion().execute(context);
 
-        try {
-            new CheckDiagnosticVersion().execute(context);
+        switch (type){
+            case Constants.api :
+                new CheckElasticsearchVersion().execute(context);
+                new CheckUserAuthLevel().execute(context);
+                // Removed temporarily due to issues with finding and accessing cloud master
+                //new CheckPlatformDetails().execute(context);
+                new RunClusterQueries().execute(context);
+                break;
 
-            switch (type){
-                case Constants.api :
-                    new CheckElasticsearchVersion().execute(context);
-                    new CheckUserAuthLevel().execute(context);
-                    // Removed temporarily due to issues with finding and accessing cloud master
-                    //new CheckPlatformDetails().execute(context);
-                    new RunClusterQueries().execute(context);
-                    break;
-
-                case Constants.local :
-                    new CheckElasticsearchVersion().execute(context);
-                    new CheckUserAuthLevel().execute(context);
-                    new CheckPlatformDetails().execute(context);
-                    new RunClusterQueries().execute(context);
-                    if(context.runSystemCalls){
-                        new CollectSystemCalls().execute(context);
-                        new CollectLogs().execute(context);
-                        new RetrieveSystemDigest().execute(context);
-                    }
-                    if(context.dockerPresent){
-                        new CollectDockerInfo().execute(context);
-                    }
-                    break;
-
-                case Constants.remote :
-                    new CheckElasticsearchVersion().execute(context);
-                    new CheckUserAuthLevel().execute(context);
-                    new CheckPlatformDetails().execute(context);
-                    new RunClusterQueries().execute(context);
-                    if(context.runSystemCalls){
-                        new CollectSystemCalls().execute(context);
-                        new CollectLogs().execute(context);
-                    }
-                    if(context.dockerPresent){
-                        new CollectDockerInfo().execute(context);
-                    }
-                    break;
-
-                case Constants.logstashLocal :
-                    new RunLogstashQueries().execute(context);
-                    if(context.runSystemCalls){
-                        new CollectSystemCalls().execute(context);
-                        new RetrieveSystemDigest().execute(context);
-                    }
-                    if(context.dockerPresent){
-                        new CollectDockerInfo().execute(context);
-                    }
-                    break;
-
-                case Constants.logstashRemote :
-                    new RunLogstashQueries().execute(context);
-                    if(context.runSystemCalls){
-                        new CollectSystemCalls().execute(context);
-                    }
-                    if(context.dockerPresent){
-                        new CollectDockerInfo().execute(context);
-                    }
-                    break;
-
-                case Constants.logstashApi :
-                    new RunLogstashQueries().execute(context);
-                    break;
-                    
-                case Constants.kibanaLocal :
-                    new CheckKibanaVersion().execute(context);
-                    new KibanaGetDetails().execute(context);
-                    new RunKibanaQueries().execute(context);
-                    if(context.runSystemCalls){
-                        new CollectSystemCalls().execute(context);
-                        new CollectKibanaLogs().execute(context);
-                        new RetrieveSystemDigest().execute(context);
-                    }
-                    if(context.dockerPresent){
-                        new CollectDockerInfo().execute(context);
-                    }
-                    break;
-
-                case Constants.kibanaRemote :
-                    new CheckKibanaVersion().execute(context);
-                    new KibanaGetDetails().execute(context);
-                    new RunKibanaQueries().execute(context);
-                    if(context.runSystemCalls){
-                        new CollectSystemCalls().execute(context);
-                        new CollectKibanaLogs().execute(context);
-                    }
-                    if(context.dockerPresent){
-                        new CollectDockerInfo().execute(context);
-                    }
-                    break;
-
-                 case Constants.kibanaApi :
-                    new CheckKibanaVersion().execute(context);
-                    new RunKibanaQueries().execute(context);
-                    break;
+            case Constants.local :
+                new CheckElasticsearchVersion().execute(context);
+                new CheckUserAuthLevel().execute(context);
+                new CheckPlatformDetails().execute(context);
+                new RunClusterQueries().execute(context);
+                if(context.runSystemCalls){
+                    new CollectSystemCalls().execute(context);
+                    new CollectLogs().execute(context);
+                    new RetrieveSystemDigest().execute(context);
                 }
+                if(context.dockerPresent){
+                    new CollectDockerInfo().execute(context);
+                }
+                break;
 
-            new GenerateManifest().execute(context);
-        }
-        catch (Throwable t){
-            logger.error( "Unexpected error", t);
-            throw new DiagnosticException(String.format("Fatal error in diagnostic - could not continue. %s", Constants.CHECK_LOG));
-        }
+            case Constants.remote :
+                new CheckElasticsearchVersion().execute(context);
+                new CheckUserAuthLevel().execute(context);
+                new CheckPlatformDetails().execute(context);
+                new RunClusterQueries().execute(context);
+                if(context.runSystemCalls){
+                    new CollectSystemCalls().execute(context);
+                    new CollectLogs().execute(context);
+                }
+                if(context.dockerPresent){
+                    new CollectDockerInfo().execute(context);
+                }
+                break;
+
+            case Constants.logstashLocal :
+                new RunLogstashQueries().execute(context);
+                if(context.runSystemCalls){
+                    new CollectSystemCalls().execute(context);
+                    new RetrieveSystemDigest().execute(context);
+                }
+                if(context.dockerPresent){
+                    new CollectDockerInfo().execute(context);
+                }
+                break;
+
+            case Constants.logstashRemote :
+                new RunLogstashQueries().execute(context);
+                if(context.runSystemCalls){
+                    new CollectSystemCalls().execute(context);
+                }
+                if(context.dockerPresent){
+                    new CollectDockerInfo().execute(context);
+                }
+                break;
+
+            case Constants.logstashApi :
+                new RunLogstashQueries().execute(context);
+                break;
+
+            case Constants.kibanaLocal :
+                new CheckKibanaVersion().execute(context);
+                new KibanaGetDetails().execute(context);
+                new RunKibanaQueries().execute(context);
+                if(context.runSystemCalls){
+                    new CollectSystemCalls().execute(context);
+                    new CollectKibanaLogs().execute(context);
+                    new RetrieveSystemDigest().execute(context);
+                }
+                if(context.dockerPresent){
+                    new CollectDockerInfo().execute(context);
+                }
+                break;
+
+            case Constants.kibanaRemote :
+                new CheckKibanaVersion().execute(context);
+                new KibanaGetDetails().execute(context);
+                new RunKibanaQueries().execute(context);
+                if(context.runSystemCalls){
+                    new CollectSystemCalls().execute(context);
+                    new CollectKibanaLogs().execute(context);
+                }
+                if(context.dockerPresent){
+                    new CollectDockerInfo().execute(context);
+                }
+                break;
+
+             case Constants.kibanaApi :
+                new CheckKibanaVersion().execute(context);
+                new RunKibanaQueries().execute(context);
+                break;
+            }
+
+        new GenerateManifest().execute(context);
     }
 
 }

--- a/src/main/java/com/elastic/support/diagnostics/commands/CheckElasticsearchVersion.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/CheckElasticsearchVersion.java
@@ -30,7 +30,7 @@ public class CheckElasticsearchVersion implements Command {
      */
     private static final Logger logger = LogManager.getLogger(CheckElasticsearchVersion.class);
 
-    public void execute(DiagnosticContext context) {
+    public void execute(DiagnosticContext context) throws DiagnosticException {
 
         // Get the version number from the JSON returned
         // by just submitting the host/port combo
@@ -63,16 +63,13 @@ public class CheckElasticsearchVersion implements Command {
             Map restCalls = JsonYamlUtils.readYamlFromClasspath(Constants.ES_REST, true);
 
             context.elasticRestCalls = builder.buildEntryMap(restCalls);
-
-        } catch (DiagnosticException de) {
-            throw de;
         } catch (Exception e) {
             logger.error( "Unanticipated error:", e);
             throw new DiagnosticException(String.format("Could not retrieve the Elasticsearch version due to a system or network error - unable to continue. %s%s%s", e.getMessage(), SystemProperties.lineSeparator, Constants.CHECK_LOG));
         }
     }
 
-    public static Semver getElasticsearchVersion(RestClient client){
+    public static Semver getElasticsearchVersion(RestClient client) throws DiagnosticException {
             RestResult res = client.execQuery("/");
             if (! res.isValid()) {
                 throw new DiagnosticException( res.formatStatusMessage( "Could not retrieve the Elasticsearch version - unable to continue."));

--- a/src/main/java/com/elastic/support/diagnostics/commands/CheckKibanaVersion.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/CheckKibanaVersion.java
@@ -34,7 +34,7 @@ public class CheckKibanaVersion implements Command {
    
     private static final Logger logger = LogManager.getLogger(CheckKibanaVersion.class);
 
-    public void execute(DiagnosticContext context) {
+    public void execute(DiagnosticContext context) throws DiagnosticException {
 
         // Get the version number from the JSON returned
         // by just submitting the host/port combo
@@ -70,9 +70,6 @@ public class CheckKibanaVersion implements Command {
             logger.info(Constants.CONSOLE, "Run basic queries for Kibana: {}", restCalls);
 
             context.elasticRestCalls = builder.buildEntryMap(restCalls);
-
-        } catch (DiagnosticException de) {
-            throw de;
         } catch (Exception e) {
             logger.error( "Unanticipated error:", e);
             String errorLog = "Could't retrieve Kibana version due to a system or network error. %s%s%s";
@@ -91,7 +88,7 @@ public class CheckKibanaVersion implements Command {
     * @return The Kibana version (semver).
     * @throws DiagnosticException if the request fails or the version is invalid
     */
-    public static Semver getKibanaVersion(RestClient client){
+    public static Semver getKibanaVersion(RestClient client) throws DiagnosticException {
             RestResult res = client.execQuery("/api/settings");
             if (! res.isValid()) {
                 throw new DiagnosticException(res.formatStatusMessage("Could not retrieve the Kibana version - unable to continue."));

--- a/src/main/java/com/elastic/support/diagnostics/commands/KibanaGetDetails.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/KibanaGetDetails.java
@@ -77,7 +77,7 @@ public class KibanaGetDetails extends CheckPlatformDetails {
      * @param  context The current diagnostic context as set in the DiagnosticService class
      * @param  profiles list of network information for each kibana instance running
      */
-    private void isKibanaRemoteSystem(DiagnosticContext context, List<ProcessProfile> profiles) {
+    private void isKibanaRemoteSystem(DiagnosticContext context, List<ProcessProfile> profiles) throws DiagnosticException {
         if (!context.diagnosticInputs.diagType.equals(Constants.kibanaRemote)) {
             return;
         }
@@ -219,7 +219,7 @@ public class KibanaGetDetails extends CheckPlatformDetails {
      * @return Never {@code null}.
      * @throws DiagnosticContext if Kibana responds with a non-200 response
      */
-    public JsonNode getStats(DiagnosticContext context) {
+    public JsonNode getStats(DiagnosticContext context) throws DiagnosticException {
 
         RestClient restClient = ResourceCache.getRestClient(Constants.restInputHost);
         String url = context.elasticRestCalls.get("kibana_stats").getUrl();

--- a/src/main/java/com/elastic/support/diagnostics/commands/RunClusterQueries.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/RunClusterQueries.java
@@ -23,7 +23,7 @@ public class RunClusterQueries extends BaseQuery {
 
     private static final Logger logger = LogManager.getLogger(RunClusterQueries.class);
 
-    public void execute(DiagnosticContext context) {
+    public void execute(DiagnosticContext context) throws DiagnosticException {
 
         try {
             DiagConfig diagConfig = context.diagsConfig;

--- a/src/main/java/com/elastic/support/diagnostics/commands/RunKibanaQueries.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/RunKibanaQueries.java
@@ -59,7 +59,7 @@ public class RunKibanaQueries extends BaseQuery {
     * @param  context  The current diagnostic context as set in the DiagnosticService class
     * @return Number of HTTP request that will be executed.
     */
-    public int runBasicQueries(RestClient client, DiagnosticContext context) {
+    public int runBasicQueries(RestClient client, DiagnosticContext context) throws DiagnosticException {
 
         int totalRetries = 0;
         List<RestEntry> queries = new ArrayList<>();
@@ -90,7 +90,7 @@ public class RunKibanaQueries extends BaseQuery {
     * @param  perPage  Number of docusment we reques to the API
     * @param  action Kibana API name we are running
     */
-    public void getAllPages(RestClient client, List<RestEntry> queries, int perPage, RestEntry action) {
+    public void getAllPages(RestClient client, List<RestEntry> queries, int perPage, RestEntry action) throws DiagnosticException {
         // get the values needed to the pagination.
         RestResult res = client.execQuery(String.format("%s?per_page=1", action.getUrl()));
         if (! res.isValid()) {
@@ -237,7 +237,7 @@ public class RunKibanaQueries extends BaseQuery {
     *
     * @param  context The current diagnostic context as set in the DiagnosticService class
     */
-    public void execute(DiagnosticContext context) {
+    public void execute(DiagnosticContext context) throws DiagnosticException {
 
         try {
             context.perPage         = 100;

--- a/src/main/java/com/elastic/support/diagnostics/commands/RunLogstashQueries.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/RunLogstashQueries.java
@@ -26,7 +26,7 @@ public class RunLogstashQueries extends BaseQuery {
 
     private static final Logger logger = LogManager.getLogger(BaseQuery.class);
 
-    public void execute(DiagnosticContext context) {
+    public void execute(DiagnosticContext context) throws DiagnosticException {
 
         try {
             RestClient client = ResourceCache.getRestClient(Constants.restInputHost);

--- a/src/main/java/com/elastic/support/monitoring/MonitoringExportService.java
+++ b/src/main/java/com/elastic/support/monitoring/MonitoringExportService.java
@@ -29,8 +29,7 @@ public class MonitoringExportService extends ElasticRestClientService {
     private static final String SCROLL_ID = "{ \"scroll_id\" : \"{{scrollId}}\" }";
     private Logger logger = LogManager.getLogger(MonitoringExportService.class);
 
-    public void execExtract(MonitoringExportInputs inputs) {
-
+    public void execExtract(MonitoringExportInputs inputs) throws DiagnosticException {
         // Initialize outside the block for Exception handling
         RestClient client = null;
         MonitoringExportConfig config = null;

--- a/src/main/java/com/elastic/support/monitoring/MonitoringExportService.java
+++ b/src/main/java/com/elastic/support/monitoring/MonitoringExportService.java
@@ -132,7 +132,7 @@ public class MonitoringExportService extends ElasticRestClientService {
         outputAvailableClusters(clusters);
     }
 
-    private void validateClusterId(String clusterId, MonitoringExportConfig config, RestClient client, String monitoringUri) {
+    private void validateClusterId(String clusterId, MonitoringExportConfig config, RestClient client, String monitoringUri) throws DiagnosticException {
         String clusterIdQuery = config.queries.get("cluster_id_check");
         clusterIdQuery = clusterIdQuery.replace("{{clusterId}}", clusterId);
 

--- a/src/main/java/com/elastic/support/scrub/ScrubService.java
+++ b/src/main/java/com/elastic/support/scrub/ScrubService.java
@@ -2,6 +2,7 @@ package com.elastic.support.scrub;
 
 import com.elastic.support.BaseService;
 import com.elastic.support.Constants;
+import com.elastic.support.diagnostics.DiagnosticException;
 import com.elastic.support.util.*;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
@@ -18,15 +19,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-
 public class ScrubService extends BaseService {
 
     private Logger logger = LogManager.getLogger(ScrubService.class);
 
-    public void exec(ScrubInputs inputs) {
+    public File exec(ScrubInputs inputs) throws DiagnosticException {
         ExecutorService executorService = null;
         String scrubDir = "";
-
 
         try {
             scrubDir = inputs.outputDir + SystemProperties.fileSeparator + "scrubbed-" + inputs.scrubbedFileBaseName;
@@ -85,11 +84,9 @@ public class ScrubService extends BaseService {
             });
 
             // Finish up by zipping it.
-            createArchive(scrubDir);
-
-        } catch (Throwable t) {
-            logger.error("Error occurred: ", t);
-            logger.error(Constants.CONSOLE, "Issue encountered during scrub processing. {}.", Constants.CHECK_LOG);
+            return createArchive(scrubDir);
+        } catch (Throwable throwable) {
+            throw new DiagnosticException("Could not scrub archive", throwable);
         } finally {
             executorService.shutdown();
             closeLogs();

--- a/src/main/java/com/elastic/support/util/ArchiveUtils.java
+++ b/src/main/java/com/elastic/support/util/ArchiveUtils.java
@@ -129,7 +129,7 @@ public class ArchiveUtils {
       }
    }
 
-   public static void extractArchive(String filename, String targetDir) throws Exception{
+   public static void extractArchive(String filename, String targetDir) throws IOException {
       final int bufferSize = 1024;
       ArchiveInputStream ais = null;
       try  {

--- a/src/main/java/com/elastic/support/util/ArchiveUtils.java
+++ b/src/main/java/com/elastic/support/util/ArchiveUtils.java
@@ -1,91 +1,70 @@
 package com.elastic.support.util;
 
 import com.elastic.support.Constants;
+import com.elastic.support.diagnostics.DiagnosticException;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
-import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
-import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.commons.compress.compressors.CompressorOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.apache.commons.io.*;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Vector;
 
 
 public class ArchiveUtils {
 
    private static final Logger logger = LogManager.getLogger(ArchiveUtils.class);
 
-   public static void createArchive(String dir, String archiveFileName) {
-      if(! createZipArchive(dir, archiveFileName)){
-         logger.error(Constants.CONSOLE,  "Couldn't create zip archive. Trying tar.gz");
-         if(! createTarArchive(dir, archiveFileName)){
+   public static void createArchive(String dir, String archiveFileName) throws DiagnosticException {
+      try {
+         createZipArchive(dir, archiveFileName);
+      } catch (Exception zipException) {
+         logger.info(Constants.CONSOLE, "Couldn't create zip archive. Trying tar.gz");
+
+         try {
+            createTarArchive(dir, archiveFileName);
+         } catch (Exception tarException) {
             logger.info(Constants.CONSOLE, "Couldn't create tar.gz archive.");
+            tarException.addSuppressed(zipException);
+            throw new DiagnosticException("Couldn't create zip and tar.gz archives.", tarException);
          }
       }
    }
 
-   public static boolean createZipArchive(String dir, String archiveFileName)  {
+   public static void createZipArchive(String dir, String archiveFileName) throws IOException {
+      File srcDir = new File(dir);
+      String filename = dir + "-" + archiveFileName + ".zip";
 
-      try {
-         File srcDir = new File(dir);
-         String filename = dir + "-" + archiveFileName + ".zip";
+      FileOutputStream fout = new FileOutputStream(filename);
+      ZipArchiveOutputStream taos = new ZipArchiveOutputStream(fout);
+      archiveResultsZip(archiveFileName, taos, srcDir, "", true);
+      taos.close();
 
-         FileOutputStream fout = new FileOutputStream(filename);
-         ZipArchiveOutputStream taos = new ZipArchiveOutputStream(fout);
-         archiveResultsZip(archiveFileName, taos, srcDir, "", true);
-         taos.close();
-
-         logger.info(Constants.CONSOLE, "Archive: " + filename + " was created");
-
-      } catch (Exception ioe) {
-         logger.error( "Couldn't create archive.", ioe);
-         return false;
-      }
-      return true;
-
+      logger.info(Constants.CONSOLE, "Archive: " + filename + " was created");
    }
 
-   public static boolean createTarArchive(String dir, String archiveFileName) {
+   public static void createTarArchive(String dir, String archiveFileName)throws IOException {
+      File srcDir = new File(dir);
+      String filename = dir + "-" + archiveFileName + ".tar.gz";
 
-      try {
-         File srcDir = new File(dir);
-         String filename = dir + "-" + archiveFileName + ".tar.gz";
+      FileOutputStream fout = new FileOutputStream(filename);
+      CompressorOutputStream cout = new GzipCompressorOutputStream(fout);
+      TarArchiveOutputStream taos = new TarArchiveOutputStream(cout);
 
-         FileOutputStream fout = new FileOutputStream(filename);
-         CompressorOutputStream cout = new GzipCompressorOutputStream(fout);
-         TarArchiveOutputStream taos = new TarArchiveOutputStream(cout);
+      taos.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_STAR);
+      taos.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
+      archiveResultsTar(archiveFileName, taos, srcDir, "", true);
+      taos.close();
 
-         taos.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_STAR);
-         taos.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
-         archiveResultsTar(archiveFileName, taos, srcDir, "", true);
-         taos.close();
-
-         logger.info(Constants.CONSOLE,  "Archive: " + filename + " was created");
-
-      } catch (Exception ioe) {
-         logger.error( "Couldn't create archive.", ioe);
-         return false;
-      }
-
-      return true;
-
+      logger.info(Constants.CONSOLE,  "Archive: " + filename + " was created");
    }
 
    public static void archiveResultsZip(String archiveFilename, ZipArchiveOutputStream taos, File file, String path, boolean append) {

--- a/src/main/java/com/elastic/support/util/ArchiveUtils.java
+++ b/src/main/java/com/elastic/support/util/ArchiveUtils.java
@@ -23,14 +23,14 @@ public class ArchiveUtils {
 
    private static final Logger logger = LogManager.getLogger(ArchiveUtils.class);
 
-   public static void createArchive(String dir, String archiveFileName) throws DiagnosticException {
+   public static File createArchive(String dir, String archiveFileName) throws DiagnosticException {
       try {
-         createZipArchive(dir, archiveFileName);
+         return createZipArchive(dir, archiveFileName);
       } catch (Exception zipException) {
          logger.info(Constants.CONSOLE, "Couldn't create zip archive. Trying tar.gz");
 
          try {
-            createTarArchive(dir, archiveFileName);
+            return createTarArchive(dir, archiveFileName);
          } catch (Exception tarException) {
             logger.info(Constants.CONSOLE, "Couldn't create tar.gz archive.");
             tarException.addSuppressed(zipException);
@@ -39,22 +39,24 @@ public class ArchiveUtils {
       }
    }
 
-   public static void createZipArchive(String dir, String archiveFileName) throws IOException {
+   public static File createZipArchive(String dir, String archiveFileName) throws IOException {
       File srcDir = new File(dir);
       String filename = dir + "-" + archiveFileName + ".zip";
-
+      File file = new File(filename);
       FileOutputStream fout = new FileOutputStream(filename);
       ZipArchiveOutputStream taos = new ZipArchiveOutputStream(fout);
       archiveResultsZip(archiveFileName, taos, srcDir, "", true);
       taos.close();
 
       logger.info(Constants.CONSOLE, "Archive: " + filename + " was created");
+
+      return file;
    }
 
-   public static void createTarArchive(String dir, String archiveFileName)throws IOException {
+   public static File createTarArchive(String dir, String archiveFileName) throws IOException {
       File srcDir = new File(dir);
       String filename = dir + "-" + archiveFileName + ".tar.gz";
-
+      File file = new File(filename);
       FileOutputStream fout = new FileOutputStream(filename);
       CompressorOutputStream cout = new GzipCompressorOutputStream(fout);
       TarArchiveOutputStream taos = new TarArchiveOutputStream(cout);
@@ -65,6 +67,8 @@ public class ArchiveUtils {
       taos.close();
 
       logger.info(Constants.CONSOLE,  "Archive: " + filename + " was created");
+
+      return file;
    }
 
    public static void archiveResultsZip(String archiveFilename, ZipArchiveOutputStream taos, File file, String path, boolean append) {

--- a/src/main/java/com/elastic/support/util/RemoteSystem.java
+++ b/src/main/java/com/elastic/support/util/RemoteSystem.java
@@ -34,7 +34,7 @@ public class RemoteSystem extends SystemCommand {
                         String keyFilePass,
                         String knownHostsFile,
                         boolean trustRemote,
-                        boolean isSudo){
+                        boolean isSudo) throws DiagnosticException {
 
         this.osName = osName;
 

--- a/src/main/java/com/elastic/support/util/SystemUtils.java
+++ b/src/main/java/com/elastic/support/util/SystemUtils.java
@@ -31,7 +31,7 @@ public class SystemUtils {
         System.exit(0);
     }
 
-    public static void writeToFile(String content, String dest) {
+    public static void writeToFile(String content, String dest) throws DiagnosticException {
         try {
             logger.info(Constants.CONSOLE,  "Writing to {}", dest);
             File outFile = new File(dest);

--- a/src/test/java/com/elastic/support/diagnostics/commands/TestCheckKibanaVersion.java
+++ b/src/test/java/com/elastic/support/diagnostics/commands/TestCheckKibanaVersion.java
@@ -1,6 +1,7 @@
-package com.elastic.support.diagnostics;
+package com.elastic.support.diagnostics.commands;
 
 import com.elastic.support.Constants;
+import com.elastic.support.diagnostics.DiagnosticException;
 import com.elastic.support.util.*;
 import org.junit.jupiter.api.Test;
 import com.elastic.support.diagnostics.commands.CheckKibanaVersion;
@@ -84,7 +85,7 @@ public class TestCheckKibanaVersion {
     }
 
     @Test
-    public void testQueriesForKibana() {
+    public void testQueriesForKibana() throws DiagnosticException {
 		initializeKibana();
         Semver version = new CheckKibanaVersion().getKibanaVersion(httpRestClient);
         // the version 6.5.0 was defined on the json object on the mockServer boby.
@@ -115,7 +116,7 @@ public class TestCheckKibanaVersion {
             Semver version = new CheckKibanaVersion().getKibanaVersion(httpRestClient);
             // if they are more than one node in Kibana we need to throw an Exception
             assertTrue(false);
-        } catch (RuntimeException e) {
+        } catch (DiagnosticException e) {
             assertEquals(e.getMessage(), "Kibana version format is wrong - unable to continue. ()");
         }
     }
@@ -144,7 +145,7 @@ public class TestCheckKibanaVersion {
             Semver version = new CheckKibanaVersion().getKibanaVersion(httpRestClient);
             // if they are more than one node in Kibana we need to throw an Exception
             assertTrue(false);
-        } catch (RuntimeException e) {
+        } catch (DiagnosticException e) {
             assertEquals(e.getMessage(), "Kibana version format is wrong - unable to continue. (a.v.c)");
         }
     }
@@ -173,7 +174,7 @@ public class TestCheckKibanaVersion {
             Semver version = new CheckKibanaVersion().getKibanaVersion(httpRestClient);
             // if they are more than one node in Kibana we need to throw an Exception
             assertTrue(false);
-        } catch (RuntimeException e) {
+        } catch (DiagnosticException e) {
             assertEquals(e.getMessage(), "Kibana version format is wrong - unable to continue. (test-6.5.1)");
         }
     }

--- a/src/test/java/com/elastic/support/diagnostics/commands/TestKibanaGetDetails.java
+++ b/src/test/java/com/elastic/support/diagnostics/commands/TestKibanaGetDetails.java
@@ -1,6 +1,8 @@
-package com.elastic.support.diagnostics;
+package com.elastic.support.diagnostics.commands;
 
 import com.elastic.support.Constants;
+import com.elastic.support.diagnostics.DiagnosticException;
+import com.elastic.support.diagnostics.ProcessProfile;
 import com.elastic.support.util.*;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;

--- a/src/test/java/com/elastic/support/diagnostics/commands/TestRunKibanaQueries.java
+++ b/src/test/java/com/elastic/support/diagnostics/commands/TestRunKibanaQueries.java
@@ -1,6 +1,7 @@
-package com.elastic.support.diagnostics;
+package com.elastic.support.diagnostics.commands;
 
 import com.elastic.support.Constants;
+import com.elastic.support.diagnostics.DiagnosticException;
 import com.elastic.support.util.*;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
@@ -251,7 +252,7 @@ public class TestRunKibanaQueries {
     }
 
     @Test
-    public void testQueriesForKibana() {
+    public void testQueriesForKibana() throws DiagnosticException {
 
 		DiagnosticContext context = initializeKibana("6.5.0");
     	int totalRetries = new RunKibanaQueries().runBasicQueries(httpRestClient, context);
@@ -285,7 +286,7 @@ public class TestRunKibanaQueries {
     }
 
     @Test
-	public void testSixversion() {
+	public void testSixversion() throws DiagnosticException {
 
 		DiagnosticContext context = initializeKibana("6.5.0");
     	int totalRetries = new RunKibanaQueries().runBasicQueries(httpRestClient, context);
@@ -304,7 +305,7 @@ public class TestRunKibanaQueries {
 	}
 
 	@Test
-    public void testQueriesForKibana711() {
+    public void testQueriesForKibana711() throws DiagnosticException {
 
 		DiagnosticContext context = initializeKibana("7.11.0");
     	int totalRetries = new RunKibanaQueries().runBasicQueries(httpRestClient, context);
@@ -374,7 +375,7 @@ public class TestRunKibanaQueries {
 
 
     @Test
-    public void testQueriesForKibanaWithHeaders() {
+    public void testQueriesForKibanaWithHeaders() throws DiagnosticException {
 
         DiagnosticContext context = initializeKibana("7.10.0");
         int totalRetries = new RunKibanaQueries().runBasicQueries(httpRestClient, context);
@@ -394,7 +395,7 @@ public class TestRunKibanaQueries {
     }
 
     @Test
-    public void testQueriesRemovingHeaders() {
+    public void testQueriesRemovingHeaders() throws DiagnosticException {
 
       mockServer
             .when(
@@ -422,7 +423,7 @@ public class TestRunKibanaQueries {
     * This test is to be sure we have no issues in case the webhook come with no config or headers
     */
     @Test
-    public void testQueriesWithoutHeaders() {
+    public void testQueriesWithoutHeaders() throws DiagnosticException {
 
       mockServer
             .when(


### PR DESCRIPTION
We need to be able to use the diagnostic tool as a Java library as described in #485.

This PR makes 2 main changes:

 1. `DiagnosticService#exec` and `ScrubService` should return `java.io.File` instead of `void`. This makes it easier for callers to know where the zip file was saved, otherwise they would need to list which files are present in the `outputDir` after the tool is finished.
2. `DiagnosticService#exec` and `ScrubService` should throw `DiagnosticException` instead of logging and swallowing errors. `DiagnosticException` is a `RuntimeException` which makes harder for consumers be aware of errors and catch them properly.