### PR TITLE
Close streams properly

### DIFF
--- a/src/main/java/com/elastic/support/diagnostics/commands/RetrieveSystemDigest.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/RetrieveSystemDigest.java
@@ -27,52 +27,55 @@ public class RetrieveSystemDigest implements Command {
     private final Logger logger = LogManager.getLogger(RetrieveSystemDigest.class);
 
     public void execute(DiagnosticContext context) {
-
         try {
             SystemInfo si = new SystemInfo();
             HardwareAbstractionLayer hal = si.getHardware();
             OperatingSystem os = si.getOperatingSystem();
             File sysFileJson = new File(context.tempDir + SystemProperties.fileSeparator + "system-digest.json");
-            OutputStream outputStreamJson = new FileOutputStream(sysFileJson);
-            BufferedWriter jsonWriter = new BufferedWriter(new OutputStreamWriter(outputStreamJson));
-            String jsonInfo = si.toPrettyJSON();
-            jsonWriter.write(jsonInfo);
-            jsonWriter.close();
+
+            try (
+                OutputStream outputStreamJson = new FileOutputStream(sysFileJson);
+                BufferedWriter jsonWriter = new BufferedWriter(new OutputStreamWriter(outputStreamJson));
+            ) {
+                String jsonInfo = si.toPrettyJSON();
+                jsonWriter.write(jsonInfo);
+            }
 
             File sysFile = new File(context.tempDir + SystemProperties.fileSeparator + "system-digest.txt");
-            OutputStream outputStream = new FileOutputStream(sysFile);
-            BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(outputStream));
 
-            printComputerSystem(writer, hal.getComputerSystem());
-            writer.newLine();
+            try (
+                OutputStream outputStream = new FileOutputStream(sysFile);
+                BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(outputStream));
+            ) {
+                printComputerSystem(writer, hal.getComputerSystem());
+                writer.newLine();
 
-            printProcessor(writer, hal.getProcessor());
-            writer.newLine();
+                printProcessor(writer, hal.getProcessor());
+                writer.newLine();
 
-            printMemory(writer, hal.getMemory());
-            writer.newLine();
+                printMemory(writer, hal.getMemory());
+                writer.newLine();
 
-            printCpu(writer, hal.getProcessor());
-            writer.newLine();
+                printCpu(writer, hal.getProcessor());
+                writer.newLine();
 
-            printProcesses(writer, os, hal.getMemory());
-            writer.newLine();
+                printProcesses(writer, os, hal.getMemory());
+                writer.newLine();
 
-            printDisks(writer, hal.getDiskStores());
-            writer.newLine();
+                printDisks(writer, hal.getDiskStores());
+                writer.newLine();
 
-            printFileSystem(writer, os.getFileSystem());
-            writer.newLine();
+                printFileSystem(writer, os.getFileSystem());
+                writer.newLine();
 
-            printNetworkInterfaces(writer, hal.getNetworkIFs());
-            writer.newLine();
+                printNetworkInterfaces(writer, hal.getNetworkIFs());
+                writer.newLine();
 
-            printNetworkParameters(writer, os.getNetworkParams());
-            writer.newLine();
+                printNetworkParameters(writer, os.getNetworkParams());
+                writer.newLine();
+            }
 
-            writer.close();
             logger.info("Finished querying SysInfo.");
-
         } catch (final Exception e) {
             logger.info("Failed saving system-digest.txt file.", e);
         }

--- a/src/main/java/com/elastic/support/monitoring/MonitoringImportService.java
+++ b/src/main/java/com/elastic/support/monitoring/MonitoringImportService.java
@@ -24,9 +24,8 @@ public class MonitoringImportService extends ElasticRestClientService {
     private Logger logger = LogManager.getLogger(MonitoringImportService.class);
     private static final String SCROLL_ID = "{ \"scroll_id\" : \"{{scrollId}}\" }";
 
-    void execImport(MonitoringImportInputs inputs){
-
-        Map configMap = JsonYamlUtils.readYamlFromClasspath(Constants.DIAG_CONFIG, true);
+    void execImport(MonitoringImportInputs inputs) throws DiagnosticException {
+        Map<String, Object> configMap = JsonYamlUtils.readYamlFromClasspath(Constants.DIAG_CONFIG, true);
         MonitoringImportConfig config = new MonitoringImportConfig(configMap);
 
         try (RestClient client = getClient(inputs, config)){

--- a/src/main/java/com/elastic/support/scrub/ScrubProcessor.java
+++ b/src/main/java/com/elastic/support/scrub/ScrubProcessor.java
@@ -1,6 +1,7 @@
 package com.elastic.support.scrub;
 
 import com.elastic.support.Constants;
+import com.elastic.support.diagnostics.DiagnosticException;
 import com.elastic.support.util.JsonYamlUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.lang3.ObjectUtils;
@@ -33,8 +34,7 @@ public class ScrubProcessor {
 
 
 
-    public ScrubProcessor(String nodes) {
-
+    public ScrubProcessor(String nodes) throws DiagnosticException {
         this();
 
         if (StringUtils.isNotEmpty(nodes)) {
@@ -42,9 +42,9 @@ public class ScrubProcessor {
         }
     }
 
-    public ScrubProcessor() {
-        scrubConfig =
-                JsonYamlUtils.readYamlFromClasspath("scrub.yml", false);
+    public ScrubProcessor() throws DiagnosticException {
+        scrubConfig = JsonYamlUtils.readYamlFromClasspath("scrub.yml", false);
+
         Collection auto = (Collection) scrubConfig.get("auto-scrub");
         if (auto != null) {
             autoScrub.addAll(auto);

--- a/src/main/java/com/elastic/support/util/JsonYamlUtils.java
+++ b/src/main/java/com/elastic/support/util/JsonYamlUtils.java
@@ -3,9 +3,7 @@ package com.elastic.support.util;
 import com.elastic.support.diagnostics.DiagnosticException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,8 +11,6 @@ import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
@@ -24,12 +20,6 @@ public class JsonYamlUtils {
    private static final Logger logger = LoggerFactory.getLogger(JsonYamlUtils.class);
 
    public static ObjectMapper mapper = new ObjectMapper();
-   public static ObjectMapper formatMapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
-
-   public static JsonNode createJsonNodeFromFileName(String fileName) {
-      File jsonFile = FileUtils.getFile(fileName);
-      return createJsonNodeFromFile(jsonFile);
-   }
 
    public static JsonNode createJsonNodeFromFileName(String dir, String fileName) {
       File jsonFile = FileUtils.getFile(dir, fileName);
@@ -56,46 +46,9 @@ public class JsonYamlUtils {
       }
    }
 
-   public static JsonNode createJsonNodeFromClasspath(String path) {
-      try (InputStream is = JsonYamlUtils.class.getClassLoader().getResourceAsStream(path)) {
-         String nodeString = new String(IOUtils.toByteArray(is));
-         ObjectMapper mapper = new ObjectMapper();
-         return mapper.readTree(nodeString);
-      } catch (IOException e) {
-         logger.info("Error creating JSON node {}", path);
-         throw new RuntimeException(e);
-      }
-   }
-
-   public static void writeYaml(String path, Map tree) {
-      try {
-         DumperOptions options = new DumperOptions();
-         options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-         Yaml yaml = new Yaml(options);
-         try (FileWriter writer = new FileWriter(path)) {
-            yaml.dump(tree, writer);
-         }
-      } catch (IOException e) {
-         logger.info("Error writing YAML to: {}", path);
-         throw new RuntimeException(e);
-      }
-   }
-
    public static Map<String, Object> readYamlFromClasspath(String path, boolean isBlock) throws DiagnosticException {
       try (
          InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(path);
-      ) {
-         return JsonYamlUtils.readYaml(inputStream, isBlock);
-      }
-      catch (Exception e) {
-         logger.info("Error reading YAML from {}", path);
-         throw new DiagnosticException("Error reading YAML file",e);
-      }
-   }
-
-   public static Map readYamlFromPath(String path, boolean isBlock) throws DiagnosticException {
-      try (
-         InputStream inputStream = new FileInputStream(FileUtils.getFile(path))
       ) {
          return JsonYamlUtils.readYaml(inputStream, isBlock);
       }
@@ -124,16 +77,10 @@ public class JsonYamlUtils {
       return result;
    }
 
-   public static Map flattenMap(Map map){
-      return flattenYaml(map);
-   }
-
    public static Map flattenNode(JsonNode node) {
       try {
          ObjectMapper mapper = new ObjectMapper();
          Map jsonMap = mapper.convertValue(node, Map.class);
-         //String json = mapper.writeValueAsString(node)
-         //Map jsonMap = mapper.readValue(json, new TypeReference<Map>() {});
          Map flat = flattenYaml(jsonMap);
          return flat;
       } catch (Exception e) {
@@ -158,14 +105,10 @@ public class JsonYamlUtils {
          if (value instanceof String) {
             result.put(key, value);
          } else if (value instanceof Map) {
-            // Need a compound key
             @SuppressWarnings("unchecked")
             Map<String, Object> map = (Map<String, Object>) value;
             buildFlattenedMap(result, map, key);
-         //} else if (value instanceof List) {
-         //   result.put(key, value);
          } else if (value instanceof Collection) {
-            // Need a compound key
             @SuppressWarnings("unchecked")
             Collection<Object> collection = (Collection<Object>) value;
             int count = 0;
@@ -185,16 +128,5 @@ public class JsonYamlUtils {
       }
 
       return doc;
-   }
-
-   private static Map listToMap(List input){
-      int sz = input.size();
-      Map output = new LinkedHashMap<>();
-      for(int i=0; i < sz; i++){
-         output.put("idx_" + i, input.get(i));
-      }
-
-      return output;
-
    }
 }

--- a/src/main/java/com/elastic/support/util/JsonYamlUtils.java
+++ b/src/main/java/com/elastic/support/util/JsonYamlUtils.java
@@ -4,7 +4,6 @@ import com.elastic.support.diagnostics.DiagnosticException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.DumperOptions;
@@ -23,12 +22,10 @@ public class JsonYamlUtils {
 
    public static JsonNode createJsonNodeFromFileName(String dir, String fileName) {
       File jsonFile = FileUtils.getFile(dir, fileName);
-      return createJsonNodeFromFile(jsonFile);
-   }
 
-   public static JsonNode createJsonNodeFromFile(File jsonFile)  {
       try {
          String fileString = FileUtils.readFileToString(jsonFile, "UTF8");
+
          return JsonYamlUtils.createJsonNodeFromString(fileString);
       } catch (IOException e) {
          logger.info("Error reading in JSON string from file: {}", jsonFile);
@@ -38,8 +35,7 @@ public class JsonYamlUtils {
 
    public static JsonNode createJsonNodeFromString(String nodeString) {
       try {
-         ObjectMapper mapper = new ObjectMapper();
-         return mapper.readTree(nodeString);
+         return new ObjectMapper().readTree(nodeString);
       } catch (IOException e) {
          logger.info("Error creating JSON node from input string: {}", nodeString);
          throw new RuntimeException(e);
@@ -52,13 +48,13 @@ public class JsonYamlUtils {
       ) {
          return JsonYamlUtils.readYaml(inputStream, isBlock);
       }
-      catch (Exception e) {
+      catch (IOException e) {
          logger.info("Error reading YAML from {}", path);
          throw new DiagnosticException("Error reading YAML file",e);
       }
    }
 
-   public static Map<String, Object> readYaml(InputStream in, boolean isBlock) {
+   private static Map<String, Object> readYaml(InputStream in, boolean isBlock) {
       DumperOptions options = new DumperOptions();
 
       if (isBlock) {
@@ -68,63 +64,8 @@ public class JsonYamlUtils {
       Yaml yaml = new Yaml(options);
       Map<String, Object> doc = yaml.load(in);
 
-      return nullSafeYamlMap(doc);
-}
-
-   public static Map<String, Object> flattenYaml(Map<String, Object> map) {
-      Map<String, Object> result = new LinkedHashMap<>();
-      buildFlattenedMap(result, map, null);
-      return result;
-   }
-
-   public static Map flattenNode(JsonNode node) {
-      try {
-         ObjectMapper mapper = new ObjectMapper();
-         Map jsonMap = mapper.convertValue(node, Map.class);
-         Map flat = flattenYaml(jsonMap);
-         return flat;
-      } catch (Exception e) {
-         throw new RuntimeException(e);
-      }
-   }
-
-   public static void buildFlattenedMap(Map<String, Object> result, Map<String, Object> source, String path) {
-      for (Map.Entry<String, Object> entry : source.entrySet()) {
-         String key = entry.getKey();
-
-         if (StringUtils.isNoneEmpty(path)) {
-            if (key.startsWith("[")) {
-               key = path + key;
-            } else {
-               key = path + "." + key;
-            }
-         }
-
-         Object value = entry.getValue();
-
-         if (value instanceof String) {
-            result.put(key, value);
-         } else if (value instanceof Map) {
-            @SuppressWarnings("unchecked")
-            Map<String, Object> map = (Map<String, Object>) value;
-            buildFlattenedMap(result, map, key);
-         } else if (value instanceof Collection) {
-            @SuppressWarnings("unchecked")
-            Collection<Object> collection = (Collection<Object>) value;
-            int count = 0;
-            for (Object object : collection) {
-               buildFlattenedMap(result,
-                  Collections.singletonMap("[" + (count++) + "]", object), key);
-            }
-         } else {
-            result.put(key, value == null ? "" : value);
-         }
-      }
-   }
-
-   private static Map<String, Object> nullSafeYamlMap(Map<String, Object> doc){
       if (doc == null){
-         doc = new HashMap<>();
+         return new HashMap<>();
       }
 
       return doc;

--- a/src/main/java/com/elastic/support/util/SystemUtils.java
+++ b/src/main/java/com/elastic/support/util/SystemUtils.java
@@ -42,20 +42,6 @@ public class SystemUtils {
         }
     }
 
-    public static void streamClose(String path, InputStream instream) {
-
-        if (instream != null) {
-            try {
-                instream.close();
-            } catch (Throwable t) {
-                logger.error(Constants.CONSOLE, "Error encountered when attempting to close file {}", path);
-            }
-        } else {
-            logger.error(Constants.CONSOLE, "Error encountered when attempting to close file: null InputStream {}", path);
-        }
-
-    }
-
     public static void nukeDirectory(String dir){
         try {
             File tmp = new File(dir);

--- a/src/test/java/com/elastic/support/diagnostics/commands/TestKibanaGetDetails.java
+++ b/src/test/java/com/elastic/support/diagnostics/commands/TestKibanaGetDetails.java
@@ -147,7 +147,7 @@ public class TestKibanaGetDetails {
     }
 
     @Test
-    public void testFunctionGetStats() {
+    public void testFunctionGetStats() throws DiagnosticException {
 
         mockServer
                 .when(

--- a/src/test/java/com/elastic/support/diagnostics/commands/TestRunKibanaQueries.java
+++ b/src/test/java/com/elastic/support/diagnostics/commands/TestRunKibanaQueries.java
@@ -84,7 +84,7 @@ public class TestRunKibanaQueries {
 
     }
 
-    private DiagnosticContext initializeKibana(String version) {
+    private DiagnosticContext initializeKibana(String version) throws DiagnosticException {
 
     	DiagnosticContext context = new DiagnosticContext();
     	RestEntryConfig builder = new RestEntryConfig(version);

--- a/src/test/java/com/elastic/support/rest/TestRestConfigFileValidity.java
+++ b/src/test/java/com/elastic/support/rest/TestRestConfigFileValidity.java
@@ -1,5 +1,6 @@
 package com.elastic.support.rest;
 
+import com.elastic.support.diagnostics.DiagnosticException;
 import com.elastic.support.util.JsonYamlUtils;
 import com.vdurmont.semver4j.Semver;
 import org.apache.logging.log4j.LogManager;
@@ -17,7 +18,7 @@ public class TestRestConfigFileValidity {
     protected static Semver sem= new Semver("9.9.999", Semver.SemverType.NPM);
 
     @Test
-    public void validateElasticConfigVersioning(){
+    public void validateElasticConfigVersioning() throws DiagnosticException {
         // validates whether each set of version entries has exactly one valid outcome.
         Map<String, Object> restEntriesConfig = JsonYamlUtils.readYamlFromClasspath("elastic-rest.yml", true);
         validateEntries(restEntriesConfig);


### PR DESCRIPTION
Part of #485.

In many places `Closeable` instances such as `OutputStream`, `InputStream` and `Writer` weren't being closed properly in finally blocks. This may cause memory leaks if exceptions are thrown while writing/reading to those streams.

Tried to use try-with-resources as much as possible, only in few cases closing in finally blocks made sense.

