### PR TITLE
Include *.yml files in jar file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,6 @@
                 <version>3.1.1</version>
                 <configuration>
                     <excludes>
-                        <exclude>**/*.yml</exclude>
                         <exclude>**/*.xml</exclude>
                         <exclude>**/*.json</exclude>
                     </excludes>


### PR DESCRIPTION
This is part of #485.

In order to use the diagnostic tool as a Java lib, all configuration files like `diags.yml`, `elastic-rest.yml`, etc, must exist in the classpath, otherwise calls to `JsonYamlUtils.readYamlFromClasspath(Constants.DIAG_CONFIG, true)` fail to load them.

I tested overriding values in `config/elastic-rest.yml` and it works as expected, that is, everything in `/config` take precedence over the same files in `support-diagnostics-*.jar`. Users will still be able to easily modify them without modifying the jar file, that's possible because of:

https://github.com/elastic/support-diagnostics/blob/6255ac5fdb1a45dfd5d2155a4d02af3cb7d5386f/scripts/diagnostics.sh#L31

Anything that comes first in `-cp` takes precedence over the ensuing paths.