### PR TITLE
URL Encode Username

### DIFF
--- a/src/main/java/com/elastic/support/diagnostics/commands/CheckUserAuthLevel.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/CheckUserAuthLevel.java
@@ -8,6 +8,7 @@ import com.elastic.support.rest.RestEntry;
 import com.elastic.support.rest.RestResult;
 import com.elastic.support.util.JsonYamlUtils;
 import com.elastic.support.util.ResourceCache;
+import com.elastic.support.util.UrlUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vdurmont.semver4j.Semver;
@@ -19,16 +20,19 @@ import java.util.List;
 import java.util.Map;
 
 public class CheckUserAuthLevel implements Command {
-
     Logger logger = LogManager.getLogger(CheckUserAuthLevel.class);
 
     @Override
     public void execute(DiagnosticContext context) {
-
         // No user, it's not secured so no auth level.
-        if(StringUtils.isEmpty(context.diagnosticInputs.user) ){
+        if (StringUtils.isEmpty(context.diagnosticInputs.user)) {
             return;
         }
+
+        // Unlike most APIs, the username is passed as a part of the URL and
+        // thus it needs to be URL-encoded for the rare instance where special
+        // characters are used
+        String username = UrlUtils.encodeValue(context.diagnosticInputs.user);
 
         // Should already be there.
         RestClient restClient = ResourceCache.getRestClient(Constants.restInputHost);
@@ -37,7 +41,7 @@ public class CheckUserAuthLevel implements Command {
         Semver version = context.version;
         Map<String, RestEntry> calls = context.elasticRestCalls;
         RestEntry entry =  calls.get("security_users");
-        String url = entry.getUrl().replace("?pretty", "/" + context.diagnosticInputs.user);
+        String url = entry.getUrl().replace("?pretty", "/" + username);
 
         RestResult result = restClient.execQuery(url);
 
@@ -48,11 +52,9 @@ public class CheckUserAuthLevel implements Command {
         }
 
         context.isAuthorized = hasAuthorization;
-
     }
 
     public boolean checkForAuth(int major, String user, JsonNode userNode){
-
         JsonNode rolesNode = userNode.path(user).path("roles");
         List<String> roles = null;
         boolean hasAuthorization = false;
@@ -69,6 +71,5 @@ public class CheckUserAuthLevel implements Command {
         }
 
         return hasAuthorization;
-
     }
 }

--- a/src/main/java/com/elastic/support/util/UrlUtils.java
+++ b/src/main/java/com/elastic/support/util/UrlUtils.java
@@ -1,0 +1,25 @@
+package com.elastic.support.util;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.io.UnsupportedEncodingException;
+
+/**
+ * {@code UrlUtils} contains helpful methods for dealing with URLs.
+ */
+public class UrlUtils {
+    /**
+     * URL Encode the {@code value}.
+     *
+     * @param value The value to URL encode.
+     * @return Never {@code null}.
+     * @throws RuntimeException if encoding throws an exception.
+     */
+    public static String encodeValue(String value) {
+        try {
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
This URL encodes the username when supplying it as part of the URL
(rather than as part of an auth header).

I tested this by creating a user named `temp\user`. Using the existing diagnostic fails as noted in the linked issue. After using the code in this branch, it works successfully.

Closes https://github.com/elastic/support-diagnostics/issues/489