### PR TITLE
Should always create archive file when failures happen

### DIFF
--- a/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
+++ b/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
@@ -23,6 +23,7 @@ public class DiagnosticService extends ElasticRestClientService {
         DiagnosticContext ctx = new DiagnosticContext();
         ctx.diagsConfig = config;
         ctx.diagnosticInputs = inputs;
+        File file;
 
         try(
                 RestClient esRestClient = RestClient.getClient(
@@ -79,12 +80,13 @@ public class DiagnosticService extends ElasticRestClientService {
             }
 
             checkAuthLevel(ctx.diagnosticInputs.user, ctx.isAuthorized);
-
-            return createArchive(ctx.tempDir);
         } finally {
             closeLogs();
+            file = createArchive(ctx.tempDir);
             SystemUtils.nukeDirectory(ctx.tempDir);
             ResourceCache.closeAll();
         }
+
+        return file;
     }
 }

--- a/src/main/java/com/elastic/support/diagnostics/JavaPlatform.java
+++ b/src/main/java/com/elastic/support/diagnostics/JavaPlatform.java
@@ -3,8 +3,6 @@ package com.elastic.support.diagnostics;
 import com.elastic.support.Constants;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import java.io.BufferedReader;
-import java.io.StringReader;
 
 public class JavaPlatform {
 
@@ -16,7 +14,6 @@ public class JavaPlatform {
     public String javac = "javac";
 
     public JavaPlatform(String osName){
-
         switch (osName){
             case Constants.linuxPlatform:
                 this.platform = Constants.linuxPlatform;
@@ -38,41 +35,12 @@ public class JavaPlatform {
         }
     }
 
-    public String extractJdkPath(String processList) throws DiagnosticException {
-
-        String line;
-        try (BufferedReader br = new BufferedReader(new StringReader(processList))) {
-            while ((line = br.readLine()) != null) {
-                if (line.contains(javaExecutable) && line.contains("-Des.")) {
-                    String javaHome =  extractJavaHome(line);
-                }
-                else {
-                    continue;
-                }
-            }
-        } catch (Exception e) {
-            logger.error( "Error obtaining the path for the JDK", e);
-        }
-
-        // If we got this far we couldn't find a JDK
-        logger.info(Constants.CONSOLE, "Could not locate the location of the java executable used to launch Elasticsearch");
-        throw new DiagnosticException("JDK not found.");
-    }
-
     public String extractJavaHome(String jdkProcessString){
-
         // After the preceding cols are stripped, truncate the output behind the path to the executable.
         int jpathIndex = jdkProcessString.indexOf(javaExecutable);
         javaHome = jdkProcessString.substring(0, jpathIndex);
 
         return javaHome;
-    }
-
-    public boolean isJdkPresent(String result){
-        if(result.contains(javac)){
-            return true;
-        }
-        return false;
     }
 
 }


### PR DESCRIPTION
In #486, I changed the order in which `createArchive` was called, leaving it outside the `finally` block.

This may be problematic because the zip fule won't be created if `DiagnosticChainExec.runDiagnostic` fails with a `DiagnosticException`.

I'm changing it back to make it work as it used to work, that is, exceptions should always be printed to console AND to the `diagnostics.log` file inside the zip file.