### PR TITLE
Add archive type option

### DIFF
--- a/src/main/java/com/elastic/support/BaseInputs.java
+++ b/src/main/java/com/elastic/support/BaseInputs.java
@@ -3,6 +3,7 @@ package com.elastic.support;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.elastic.support.diagnostics.ShowHelpException;
+import com.elastic.support.util.ArchiveUtils.ArchiveType;
 import com.elastic.support.util.ResourceCache;
 import com.elastic.support.util.SystemProperties;
 
@@ -23,6 +24,7 @@ public abstract class BaseInputs {
     private static final Logger logger = LogManager.getLogger(BaseInputs.class);
     public static final String outputDirDescription = "Fully qualified path to an output directory. If it does not exist the diagnostic will attempt to create it. If not specified the diagnostic directory will be used: ";
     public static final String bypassDiagVerifyDescription = "Bypass the diagnostic version check. Use when internet outbound HTTP access is blocked by a firewall.";
+    public static final String archiveTypeDescription = "Output file type. Choose between: 'zip', 'tar' or 'any'. 'any' will try to zip first and fallback to tar if the zip fails. Defaults to any.";
     protected List<String> emptyList = new ArrayList<>();
     protected JCommander jCommander;
 
@@ -39,6 +41,9 @@ public abstract class BaseInputs {
     // Stop the diag from checking itself for latest version.
     @Parameter(names = {"--bypassDiagVerify"}, description = bypassDiagVerifyDescription)
     public boolean bypassDiagVerify = false;
+
+    @Parameter(names = {"--archiveType"}, description = archiveTypeDescription)
+    public String archiveType = "any";
 
     // End Input Fields
 
@@ -79,8 +84,12 @@ public abstract class BaseInputs {
             throw new ShowHelpException();
         }
 
-        return ObjectUtils.defaultIfNull(validateDir(outputDir), emptyList);
+        List<String> errors = new ArrayList<>();
 
+        errors.addAll(ObjectUtils.defaultIfNull(validateDir(outputDir), emptyList));
+        errors.addAll(ObjectUtils.defaultIfNull(validateArchiveType(archiveType), emptyList));
+
+        return errors;
     }
 
     public void usage(){
@@ -97,9 +106,17 @@ public abstract class BaseInputs {
                 .withMinLength(0)
                 .withValueChecker(( String val, String propname) -> validateOutputDirectory(val))
                 .read(SystemProperties.lineSeparator + outputDirDescription);
-        if(StringUtils.isNotEmpty(output)){
+
+        if (StringUtils.isNotEmpty(output)){
             outputDir = output;
         }
+
+        archiveType = ResourceCache.textIO.newStringInputReader()
+                .withDefaultValue(archiveType)
+                .withIgnoreCase()
+                .withInputTrimming(true)
+                .withValueChecker(( String val, String propname) -> validateArchiveType(val))
+                .read(SystemProperties.lineSeparator + outputDirDescription);
     }
 
     public List<String> validatePort(int val){
@@ -126,6 +143,16 @@ public abstract class BaseInputs {
 
         return null;
 
+    }
+
+    public List<String> validateArchiveType(String archiveType) {
+        for (ArchiveType type : ArchiveType.values()) {
+            if (type.name().equalsIgnoreCase(archiveType)) {
+                return null;
+            }
+        }
+
+        return Collections.singletonList("Provided archive type" + archiveType + " is not supported.");
     }
 
     public List<String> validateFile(String val) {

--- a/src/main/java/com/elastic/support/BaseService.java
+++ b/src/main/java/com/elastic/support/BaseService.java
@@ -2,6 +2,7 @@ package com.elastic.support;
 
 import com.elastic.support.diagnostics.DiagnosticException;
 import com.elastic.support.util.ArchiveUtils;
+import com.elastic.support.util.ArchiveUtils.ArchiveType;
 import com.elastic.support.util.SystemProperties;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -72,9 +73,9 @@ public abstract  class BaseService {
 
     }
 
-    public File createArchive(String tempDir) throws DiagnosticException {
+    public File createArchive(String tempDir, ArchiveType archiveType) throws DiagnosticException {
         logger.info(Constants.CONSOLE, "Archiving diagnostic results.");
-        return ArchiveUtils.createArchive(tempDir, SystemProperties.getFileDateString());
+        return ArchiveUtils.createArchive(tempDir, SystemProperties.getFileDateString(), archiveType);
     }
 
 }

--- a/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
+++ b/src/main/java/com/elastic/support/diagnostics/DiagnosticService.java
@@ -5,7 +5,10 @@ import com.elastic.support.Constants;
 import com.elastic.support.diagnostics.chain.DiagnosticChainExec;
 import com.elastic.support.diagnostics.chain.DiagnosticContext;
 import com.elastic.support.rest.RestClient;
-import com.elastic.support.util.*;
+import com.elastic.support.util.ArchiveUtils.ArchiveType;
+import com.elastic.support.util.ResourceCache;
+import com.elastic.support.util.SystemProperties;
+import com.elastic.support.util.SystemUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -82,7 +85,7 @@ public class DiagnosticService extends ElasticRestClientService {
             checkAuthLevel(ctx.diagnosticInputs.user, ctx.isAuthorized);
         } finally {
             closeLogs();
-            file = createArchive(ctx.tempDir);
+            file = createArchive(ctx.tempDir, ArchiveType.fromString(inputs.archiveType));
             SystemUtils.nukeDirectory(ctx.tempDir);
             ResourceCache.closeAll();
         }

--- a/src/main/java/com/elastic/support/monitoring/MonitoringExportInputs.java
+++ b/src/main/java/com/elastic/support/monitoring/MonitoringExportInputs.java
@@ -132,8 +132,7 @@ public class MonitoringExportInputs extends ElasticRestClientInputs {
             return Collections.singletonList("Invalid Date or Time format. Please enter the date in format YYYY-MM-dd HH:mm");
         }
 
-        return emptyList;
-
+        return null;
     }
 
     public List<String> validateCluster(String val){

--- a/src/main/java/com/elastic/support/monitoring/MonitoringExportService.java
+++ b/src/main/java/com/elastic/support/monitoring/MonitoringExportService.java
@@ -4,10 +4,8 @@ import com.elastic.support.Constants;
 import com.elastic.support.diagnostics.DiagnosticException;
 import com.elastic.support.diagnostics.commands.CheckElasticsearchVersion;
 import com.elastic.support.rest.*;
-import com.elastic.support.util.JsonYamlUtils;
-import com.elastic.support.util.ResourceCache;
-import com.elastic.support.util.SystemProperties;
-import com.elastic.support.util.SystemUtils;
+import com.elastic.support.util.*;
+import com.elastic.support.util.ArchiveUtils.ArchiveType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -120,7 +118,7 @@ public class MonitoringExportService extends ElasticRestClientService {
         } finally {
             ResourceCache.textIO.dispose();
             closeLogs();
-            createArchive(tempDir);
+            createArchive(tempDir, ArchiveUtils.ArchiveType.fromString(inputs.archiveType));
             client.close();
             SystemUtils.nukeDirectory(tempDir);
         }

--- a/src/main/java/com/elastic/support/scrub/ScrubService.java
+++ b/src/main/java/com/elastic/support/scrub/ScrubService.java
@@ -4,6 +4,7 @@ import com.elastic.support.BaseService;
 import com.elastic.support.Constants;
 import com.elastic.support.diagnostics.DiagnosticException;
 import com.elastic.support.util.*;
+import com.elastic.support.util.ArchiveUtils.ArchiveType;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.commons.io.FileUtils;
@@ -84,7 +85,7 @@ public class ScrubService extends BaseService {
             });
 
             // Finish up by zipping it.
-            return createArchive(scrubDir);
+            return createArchive(scrubDir, ArchiveType.fromString(inputs.archiveType));
         } catch (Throwable throwable) {
             throw new DiagnosticException("Could not scrub archive", throwable);
         } finally {


### PR DESCRIPTION
Part of #485.

Right, the utility tries to zip the output dir, if zip fails, it fallbacks to tar.gz.

However, this should be deterministic, devs should be able to choose which output file type they want: zip or tar.gz.