### PR TITLE
Fix multithreading

### DIFF
--- a/src/main/java/co/elastic/support/diagnostics/DiagnosticApp.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagnosticApp.java
@@ -54,7 +54,7 @@ public class DiagnosticApp {
             logger.error(Constants.CONSOLE,"Fatal error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
             logger.error( e);
         } finally {
-            resourceCache.closeAll();
+            resourceCache.close();
             textIOManager.close();
         }
     }

--- a/src/main/java/co/elastic/support/diagnostics/DiagnosticApp.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagnosticApp.java
@@ -22,10 +22,10 @@ public class DiagnosticApp {
     private static final Logger logger = LogManager.getLogger(DiagnosticApp.class);
 
     public static void main(String[] args) {
-        ResourceCache resourceCache = new ResourceCache();
-        TextIOManager textIOManager = new TextIOManager();
-
-        try {
+        try(
+            ResourceCache resourceCache = new ResourceCache();
+            TextIOManager textIOManager = new TextIOManager();
+        ) {
             DiagnosticInputs diagnosticInputs = new DiagnosticInputs();
             if (args.length == 0) {
                 logger.info(Constants.CONSOLE, Constants.interactiveMsg);
@@ -53,9 +53,6 @@ public class DiagnosticApp {
         } catch (Exception e) {
             logger.error(Constants.CONSOLE,"Fatal error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
             logger.error( e);
-        } finally {
-            resourceCache.close();
-            textIOManager.close();
         }
     }
 

--- a/src/main/java/co/elastic/support/diagnostics/DiagnosticApp.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagnosticApp.java
@@ -45,7 +45,7 @@ public class DiagnosticApp {
             Map diagMap = JsonYamlUtils.readYamlFromClasspath(Constants.DIAG_CONFIG, true);
             DiagConfig diagConfig = new DiagConfig(diagMap);
             DiagnosticService diag = new DiagnosticService();
-            DiagnosticContext context = new DiagnosticContext(diagConfig, diagnosticInputs, resourceCache);
+            DiagnosticContext context = new DiagnosticContext(diagConfig, diagnosticInputs, resourceCache, true);
 
             diag.exec(context);
         } catch (ShowHelpException she){

--- a/src/main/java/co/elastic/support/diagnostics/DiagnosticService.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagnosticService.java
@@ -95,7 +95,6 @@ public class DiagnosticService extends ElasticRestClientService {
             }
             file = createArchive(context.tempDir, ArchiveType.fromString(inputs.archiveType));
             SystemUtils.nukeDirectory(context.tempDir);
-            context.resourceCache.close();
         }
 
         return file;

--- a/src/main/java/co/elastic/support/diagnostics/DiagnosticService.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagnosticService.java
@@ -6,7 +6,6 @@
 package co.elastic.support.diagnostics;
 
 import co.elastic.support.rest.ElasticRestClientService;
-import co.elastic.support.util.ResourceCache;
 import co.elastic.support.util.SystemProperties;
 import co.elastic.support.util.SystemUtils;
 import co.elastic.support.Constants;
@@ -27,10 +26,9 @@ public class DiagnosticService extends ElasticRestClientService {
 
     private Logger logger = LogManager.getLogger(DiagnosticService.class);
 
-    public File exec(DiagnosticInputs inputs, DiagConfig config) throws DiagnosticException {
-        DiagnosticContext ctx = new DiagnosticContext();
-        ctx.diagsConfig = config;
-        ctx.diagnosticInputs = inputs;
+    public File exec(DiagnosticContext context) throws DiagnosticException {
+        DiagConfig config = context.diagsConfig;
+        DiagnosticInputs inputs = context.diagnosticInputs;
         File file;
 
         try(
@@ -53,16 +51,16 @@ public class DiagnosticService extends ElasticRestClientService {
                     config.socketTimeout
             )){
 
-            ResourceCache.addRestClient(Constants.restInputHost, esRestClient);
+            context.resourceCache.addRestClient(Constants.restInputHost, esRestClient);
 
             // Create the temp directory - delete if first if it exists from a previous run
             String outputDir = inputs.outputDir;
-            ctx.tempDir = outputDir + SystemProperties.fileSeparator + inputs.diagType + "-" + Constants.ES_DIAG;
-            logger.info(Constants.CONSOLE, "{}Creating temp directory: {}", SystemProperties.lineSeparator, ctx.tempDir);
+            context.tempDir = outputDir + SystemProperties.fileSeparator + inputs.diagType + "-" + Constants.ES_DIAG;
+            logger.info(Constants.CONSOLE, "{}Creating temp directory: {}", SystemProperties.lineSeparator, context.tempDir);
 
             try {
-                FileUtils.deleteDirectory(new File(ctx.tempDir));
-                Files.createDirectories(Paths.get(ctx.tempDir));
+                FileUtils.deleteDirectory(new File(context.tempDir));
+                Files.createDirectories(Paths.get(context.tempDir));
             }
             catch (IOException ioe) {
                 logger.error("Temp directory error", ioe);
@@ -81,19 +79,19 @@ public class DiagnosticService extends ElasticRestClientService {
             // To just log to the file log as normal: logger.info/error/warn/debug("Log mewssage");
 
             logger.info(Constants.CONSOLE, "Configuring log file.");
-            createFileAppender(ctx.tempDir, "diagnostics.log");
-            DiagnosticChainExec.runDiagnostic(ctx, inputs.diagType);
+            createFileAppender(context.tempDir, "diagnostics.log");
+            DiagnosticChainExec.runDiagnostic(context, inputs.diagType);
 
-            if (ctx.dockerPresent) {
+            if (context.dockerPresent) {
                 logger.info(Constants.CONSOLE, "Identified Docker installations - bypassed log collection and some system calls.");
             }
 
-            checkAuthLevel(ctx.diagnosticInputs.user, ctx.isAuthorized);
+            checkAuthLevel(context.diagnosticInputs.user, context.isAuthorized);
         } finally {
             closeLogs();
-            file = createArchive(ctx.tempDir, ArchiveType.fromString(inputs.archiveType));
-            SystemUtils.nukeDirectory(ctx.tempDir);
-            ResourceCache.closeAll();
+            file = createArchive(context.tempDir, ArchiveType.fromString(inputs.archiveType));
+            SystemUtils.nukeDirectory(context.tempDir);
+            context.resourceCache.closeAll();
         }
 
         return file;

--- a/src/main/java/co/elastic/support/diagnostics/DiagnosticService.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagnosticService.java
@@ -95,7 +95,7 @@ public class DiagnosticService extends ElasticRestClientService {
             }
             file = createArchive(context.tempDir, ArchiveType.fromString(inputs.archiveType));
             SystemUtils.nukeDirectory(context.tempDir);
-            context.resourceCache.closeAll();
+            context.resourceCache.close();
         }
 
         return file;

--- a/src/main/java/co/elastic/support/diagnostics/DiagnosticService.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagnosticService.java
@@ -78,8 +78,10 @@ public class DiagnosticService extends ElasticRestClientService {
             // This will also log that same output to the diagnostic log file.
             // To just log to the file log as normal: logger.info/error/warn/debug("Log mewssage");
 
-            logger.info(Constants.CONSOLE, "Configuring log file.");
-            createFileAppender(context.tempDir, "diagnostics.log");
+            if (context.includeLogs) {
+                logger.info(Constants.CONSOLE, "Configuring log file.");
+                createFileAppender(context.tempDir, "diagnostics.log");
+            }
             DiagnosticChainExec.runDiagnostic(context, inputs.diagType);
 
             if (context.dockerPresent) {
@@ -88,7 +90,9 @@ public class DiagnosticService extends ElasticRestClientService {
 
             checkAuthLevel(context.diagnosticInputs.user, context.isAuthorized);
         } finally {
-            closeLogs();
+            if (context.includeLogs) {
+                closeLogs();
+            }
             file = createArchive(context.tempDir, ArchiveType.fromString(inputs.archiveType));
             SystemUtils.nukeDirectory(context.tempDir);
             context.resourceCache.closeAll();

--- a/src/main/java/co/elastic/support/diagnostics/chain/DiagnosticContext.java
+++ b/src/main/java/co/elastic/support/diagnostics/chain/DiagnosticContext.java
@@ -9,6 +9,7 @@ import co.elastic.support.diagnostics.DiagnosticInputs;
 import co.elastic.support.diagnostics.ProcessProfile;
 import co.elastic.support.rest.RestEntry;
 import co.elastic.support.diagnostics.DiagConfig;
+import co.elastic.support.util.ResourceCache;
 import com.vdurmont.semver4j.Semver;
 
 import java.util.ArrayList;
@@ -35,7 +36,11 @@ public class DiagnosticContext {
    public List<String> dockerContainers = new ArrayList<String>();
    public Map<String, RestEntry> elasticRestCalls;
 
+   public ResourceCache resourceCache;
 
-
-
+   public DiagnosticContext(DiagConfig diagConfig, DiagnosticInputs diagnosticInputs, ResourceCache resourceCache) {
+      this.diagsConfig = diagConfig;
+      this.diagnosticInputs = diagnosticInputs;
+      this.resourceCache = resourceCache;
+   }
 }

--- a/src/main/java/co/elastic/support/diagnostics/chain/DiagnosticContext.java
+++ b/src/main/java/co/elastic/support/diagnostics/chain/DiagnosticContext.java
@@ -22,6 +22,8 @@ public class DiagnosticContext {
    public boolean isAuthorized = true;
    public boolean dockerPresent = false;
    public int perPage = 0;
+   /** whether to include log file in generated diagnostic bundle */
+   public boolean includeLogs;
 
    public String clusterName = "";
    public String tempDir = "";
@@ -38,9 +40,10 @@ public class DiagnosticContext {
 
    public ResourceCache resourceCache;
 
-   public DiagnosticContext(DiagConfig diagConfig, DiagnosticInputs diagnosticInputs, ResourceCache resourceCache) {
+   public DiagnosticContext(DiagConfig diagConfig, DiagnosticInputs diagnosticInputs, ResourceCache resourceCache, Boolean includeLogs) {
       this.diagsConfig = diagConfig;
       this.diagnosticInputs = diagnosticInputs;
       this.resourceCache = resourceCache;
+      this.includeLogs = includeLogs;
    }
 }

--- a/src/main/java/co/elastic/support/diagnostics/chain/DiagnosticContext.java
+++ b/src/main/java/co/elastic/support/diagnostics/chain/DiagnosticContext.java
@@ -40,7 +40,7 @@ public class DiagnosticContext {
 
    public ResourceCache resourceCache;
 
-   public DiagnosticContext(DiagConfig diagConfig, DiagnosticInputs diagnosticInputs, ResourceCache resourceCache, Boolean includeLogs) {
+   public DiagnosticContext(DiagConfig diagConfig, DiagnosticInputs diagnosticInputs, ResourceCache resourceCache, boolean includeLogs) {
       this.diagsConfig = diagConfig;
       this.diagnosticInputs = diagnosticInputs;
       this.resourceCache = resourceCache;

--- a/src/main/java/co/elastic/support/diagnostics/commands/CheckElasticsearchVersion.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CheckElasticsearchVersion.java
@@ -62,7 +62,7 @@ public class CheckElasticsearchVersion implements Command {
                     context.diagsConfig.socketTimeout);
 
            // Add it to the global cache - automatically closed on exit.
-            ResourceCache.addRestClient(Constants.restInputHost, restClient);
+            context.resourceCache.addRestClient(Constants.restInputHost, restClient);
             context.version = getElasticsearchVersion(restClient);
             String version = context.version.getValue();
             RestEntryConfig builder = new RestEntryConfig(version);

--- a/src/main/java/co/elastic/support/diagnostics/commands/CheckKibanaVersion.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CheckKibanaVersion.java
@@ -66,7 +66,7 @@ public class CheckKibanaVersion implements Command {
                     context.diagsConfig.socketTimeout);
 
            // Add it to the global cache - automatically closed on exit.
-            ResourceCache.addRestClient(Constants.restInputHost, restClient);
+            context.resourceCache.addRestClient(Constants.restInputHost, restClient);
             context.version = getKibanaVersion(restClient);
             String version = context.version.getValue();
             RestEntryConfig builder = new RestEntryConfig(version);

--- a/src/main/java/co/elastic/support/diagnostics/commands/CheckPlatformDetails.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CheckPlatformDetails.java
@@ -37,7 +37,7 @@ public class CheckPlatformDetails implements Command {
 
         try {
             // Cached from previous executions
-            RestClient restClient = ResourceCache.getRestClient(Constants.restInputHost);
+            RestClient restClient = context.resourceCache.getRestClient(Constants.restInputHost);
 
             // Populate the node metadata
             Map<String, RestEntry> calls = context.elasticRestCalls;
@@ -136,7 +136,7 @@ public class CheckPlatformDetails implements Command {
                             context.diagnosticInputs.trustRemote,
                             context.diagnosticInputs.isSudo
                     );
-                    ResourceCache.addSystemCommand(Constants.systemCommands, syscmd);
+                    context.resourceCache.addSystemCommand(Constants.systemCommands, syscmd);
 
                     break;
 
@@ -146,7 +146,7 @@ public class CheckPlatformDetails implements Command {
 
                         // We do need a system command local to run the docker calls
                         syscmd = new LocalSystem(SystemUtils.parseOperatingSystemName(SystemProperties.osName));
-                        ResourceCache.addSystemCommand(Constants.systemCommands, syscmd);
+                        context.resourceCache.addSystemCommand(Constants.systemCommands, syscmd);
                         break;
                     }
 
@@ -161,7 +161,7 @@ public class CheckPlatformDetails implements Command {
                             context.diagnosticInputs.host, nodeProfiles);
 
                     syscmd = new LocalSystem(context.targetNode.os);
-                    ResourceCache.addSystemCommand(Constants.systemCommands, syscmd);
+                    context.resourceCache.addSystemCommand(Constants.systemCommands, syscmd);
 
                     break;
 

--- a/src/main/java/co/elastic/support/diagnostics/commands/CheckUserAuthLevel.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CheckUserAuthLevel.java
@@ -40,7 +40,7 @@ public class CheckUserAuthLevel implements Command {
         String username = UrlUtils.encodeValue(context.diagnosticInputs.user);
 
         // Should already be there.
-        RestClient restClient = ResourceCache.getRestClient(Constants.restInputHost);
+        RestClient restClient = context.resourceCache.getRestClient(Constants.restInputHost);
 
         boolean hasAuthorization = false;
         Semver version = context.version;

--- a/src/main/java/co/elastic/support/diagnostics/commands/CollectDockerInfo.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CollectDockerInfo.java
@@ -29,7 +29,7 @@ public class CollectDockerInfo implements Command {
 
     public void execute(DiagnosticContext context) {
 
-        SystemCommand systemCommand = ResourceCache.getSystemCommand(Constants.systemCommands);
+        SystemCommand systemCommand = context.resourceCache.getSystemCommand(Constants.systemCommands);
 
         // Run the system calls first to get the host's stats
         String targetDir = context.tempDir + SystemProperties.fileSeparator + "syscalls";

--- a/src/main/java/co/elastic/support/diagnostics/commands/CollectKibanaLogs.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CollectKibanaLogs.java
@@ -47,7 +47,7 @@ public  class CollectKibanaLogs implements Command {
             return;
         }
 
-        SystemCommand sysCmd = ResourceCache.getSystemCommand(Constants.systemCommands);
+        SystemCommand sysCmd = context.resourceCache.getSystemCommand(Constants.systemCommands);
         String targetDir = context.tempDir + SystemProperties.fileSeparator + "logs";
         ProcessProfile targetNode = context.targetNode;
 

--- a/src/main/java/co/elastic/support/diagnostics/commands/CollectLogs.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CollectLogs.java
@@ -37,7 +37,7 @@ public  class CollectLogs implements Command {
         }
 
         // Should be cached from the PlatformDetails check.
-        SystemCommand sysCmd = ResourceCache.getSystemCommand(Constants.systemCommands);
+        SystemCommand sysCmd = context.resourceCache.getSystemCommand(Constants.systemCommands);
         String targetDir = context.tempDir + SystemProperties.fileSeparator + "logs";
         ProcessProfile targetNode = context.targetNode;
         JavaPlatform javaPlatform = targetNode.javaPlatform;

--- a/src/main/java/co/elastic/support/diagnostics/commands/CollectSystemCalls.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CollectSystemCalls.java
@@ -31,7 +31,7 @@ public class CollectSystemCalls implements Command {
         }
 
         // Should be cached from the PlatformDetails check.
-        SystemCommand sysCmd = ResourceCache.getSystemCommand(Constants.systemCommands);
+        SystemCommand sysCmd = context.resourceCache.getSystemCommand(Constants.systemCommands);
         String targetDir = context.tempDir + SystemProperties.fileSeparator + "syscalls";
         String pid = context.targetNode.pid;
         ProcessProfile targetNode = context.targetNode;

--- a/src/main/java/co/elastic/support/diagnostics/commands/KibanaGetDetails.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/KibanaGetDetails.java
@@ -94,7 +94,7 @@ public class KibanaGetDetails extends CheckPlatformDetails {
             targetOS = context.targetNode.os;
         }
 
-        ResourceCache.addSystemCommand(Constants.systemCommands, new RemoteSystem(
+        context.resourceCache.addSystemCommand(Constants.systemCommands, new RemoteSystem(
                 targetOS,
                 context.diagnosticInputs.remoteUser,
                 context.diagnosticInputs.remotePassword,
@@ -124,7 +124,7 @@ public class KibanaGetDetails extends CheckPlatformDetails {
             context.runSystemCalls = false;
             // We do need a system command local to run the docker calls
             SystemCommand syscmd = new LocalSystem(SystemUtils.parseOperatingSystemName(SystemProperties.osName));
-            ResourceCache.addSystemCommand(Constants.systemCommands, syscmd);
+            context.resourceCache.addSystemCommand(Constants.systemCommands, syscmd);
             return;
         }
 
@@ -136,7 +136,7 @@ public class KibanaGetDetails extends CheckPlatformDetails {
         context.targetNode = findTargetNode(profiles);
 
         SystemCommand syscmd = new LocalSystem(context.targetNode.os);
-        ResourceCache.addSystemCommand(Constants.systemCommands, syscmd);
+        context.resourceCache.addSystemCommand(Constants.systemCommands, syscmd);
     }
 
 
@@ -179,7 +179,7 @@ public class KibanaGetDetails extends CheckPlatformDetails {
     /**
      * Get the Kibana server instance's profile.
      *
-     * @param  host
+     * @param  context
      * @param  profiles list of network information for each kibana instance running
      * @return return the profile for the kibana process
      * @throws RuntimeException if there is not exactly one profile.
@@ -220,7 +220,7 @@ public class KibanaGetDetails extends CheckPlatformDetails {
      */
     public JsonNode getStats(DiagnosticContext context) throws DiagnosticException {
 
-        RestClient restClient = ResourceCache.getRestClient(Constants.restInputHost);
+        RestClient restClient = context.resourceCache.getRestClient(Constants.restInputHost);
         String url = context.elasticRestCalls.get("kibana_stats").getUrl();
         RestResult result = restClient.execQuery(url);
 

--- a/src/main/java/co/elastic/support/diagnostics/commands/RunClusterQueries.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/RunClusterQueries.java
@@ -34,7 +34,7 @@ public class RunClusterQueries extends BaseQuery {
             List<RestEntry> entries = new ArrayList<>();
             entries.addAll(context.elasticRestCalls.values());
             RestClient client;
-            client = ResourceCache.getRestClient(Constants.restInputHost);
+            client = context.resourceCache.getRestClient(Constants.restInputHost);
 /*            if(ResourceCache.resourceExists(Constants.restTargetHost)){
                 client = ResourceCache.getRestClient(Constants.restTargetHost);
             }

--- a/src/main/java/co/elastic/support/diagnostics/commands/RunKibanaQueries.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/RunKibanaQueries.java
@@ -137,10 +137,10 @@ public class RunKibanaQueries extends BaseQuery {
     *
     * @return LocalSytem that will allow us to communicate with docker
     */
-    private LocalSystem getDockerSystem() {
+    private LocalSystem getDockerSystem(ResourceCache resourceCache) {
         String osName = SystemUtils.parseOperatingSystemName(SystemProperties.osName);
         LocalSystem syscmd = new LocalSystem(osName);
-        ResourceCache.addSystemCommand(Constants.systemCommands, syscmd);
+        resourceCache.addSystemCommand(Constants.systemCommands, syscmd);
         return syscmd;
     }
 
@@ -172,14 +172,14 @@ public class RunKibanaQueries extends BaseQuery {
                     targetOS = profile.os;
                 }
                 
-                syscmd = ResourceCache.getSystemCommand(Constants.systemCommands);
+                syscmd = context.resourceCache.getSystemCommand(Constants.systemCommands);
                 break;
 
             case Constants.kibanaLocal:
                 if (context.dockerPresent) {
-                    syscmd = getDockerSystem();
+                    syscmd = getDockerSystem(context.resourceCache);
                 } else {
-                    syscmd = ResourceCache.getSystemCommand(Constants.systemCommands);
+                    syscmd = context.resourceCache.getSystemCommand(Constants.systemCommands);
                 }
                 break;
         }
@@ -248,7 +248,7 @@ public class RunKibanaQueries extends BaseQuery {
 
         try {
             context.perPage         = 100;
-            RestClient client       = ResourceCache.getRestClient(Constants.restInputHost);
+            RestClient client       = context.resourceCache.getRestClient(Constants.restInputHost);
             int totalRetries        = runBasicQueries(client, context);
             filterActionsHeaders(context);
             execSystemCommands(context);

--- a/src/main/java/co/elastic/support/diagnostics/commands/RunLogstashQueries.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/RunLogstashQueries.java
@@ -40,7 +40,7 @@ public class RunLogstashQueries extends BaseQuery {
     public void execute(DiagnosticContext context) throws DiagnosticException {
 
         try {
-            RestClient client = ResourceCache.getRestClient(Constants.restInputHost);
+            RestClient client = context.resourceCache.getRestClient(Constants.restInputHost);
 
             RestEntryConfig builder = new RestEntryConfig("1.0.0");
             Map restCalls = JsonYamlUtils.readYamlFromClasspath(Constants.LS_REST, true);
@@ -86,7 +86,7 @@ public class RunLogstashQueries extends BaseQuery {
                             context.diagnosticInputs.trustRemote,
                             context.diagnosticInputs.isSudo
                     );
-                    ResourceCache.addSystemCommand(Constants.systemCommands, syscmd);
+                    context.resourceCache.addSystemCommand(Constants.systemCommands, syscmd);
                     break;
 
                 case Constants.logstashLocal:
@@ -95,7 +95,7 @@ public class RunLogstashQueries extends BaseQuery {
                     } else {
                         syscmd = new LocalSystem(nodeProfile.os);
                     }
-                    ResourceCache.addSystemCommand(Constants.systemCommands, syscmd);
+                    context.resourceCache.addSystemCommand(Constants.systemCommands, syscmd);
 
                     break;
 

--- a/src/main/java/co/elastic/support/monitoring/MonitoringExportApp.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringExportApp.java
@@ -45,7 +45,7 @@ public class MonitoringExportApp {
         } catch (Exception e) {
             logger.error(Constants.CONSOLE, "Fatal error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
         } finally {
-            resourceCache.closeAll();
+            resourceCache.close();
             textIOManager.close();
         }
     }

--- a/src/main/java/co/elastic/support/monitoring/MonitoringExportApp.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringExportApp.java
@@ -9,6 +9,7 @@ import co.elastic.support.util.ResourceCache;
 import co.elastic.support.Constants;
 import co.elastic.support.diagnostics.ShowHelpException;
 import co.elastic.support.util.SystemUtils;
+import co.elastic.support.util.TextIOManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -20,12 +21,14 @@ public class MonitoringExportApp {
 
     public static void main(String[] args) {
 
+        ResourceCache resourceCache = new ResourceCache();
+        TextIOManager textIOManager = new TextIOManager();
         try {
             MonitoringExportInputs monitoringExportInputs = new MonitoringExportInputs();
             if (args.length == 0) {
                 logger.info(Constants.CONSOLE,  Constants.interactiveMsg);
                 monitoringExportInputs.interactive = true;
-                monitoringExportInputs.runInteractive();
+                monitoringExportInputs.runInteractive(textIOManager);
             } else {
                 List<String> errors = monitoringExportInputs.parseInputs(args);
                 if (errors.size() > 0) {
@@ -36,16 +39,14 @@ public class MonitoringExportApp {
                     SystemUtils.quitApp();
                 }
             }
-            // Needs to be done for both because in command line it
-            // may be used for passwords.
-            ResourceCache.terminal.dispose();
             new MonitoringExportService().execExtract(monitoringExportInputs);
         } catch (ShowHelpException she){
             SystemUtils.quitApp();
         } catch (Exception e) {
             logger.error(Constants.CONSOLE, "Fatal error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
         } finally {
-            ResourceCache.closeAll();
+            resourceCache.closeAll();
+            textIOManager.close();
         }
     }
 }

--- a/src/main/java/co/elastic/support/monitoring/MonitoringExportApp.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringExportApp.java
@@ -21,14 +21,16 @@ public class MonitoringExportApp {
 
     public static void main(String[] args) {
 
-        ResourceCache resourceCache = new ResourceCache();
-        TextIOManager textIOManager = new TextIOManager();
         try {
             MonitoringExportInputs monitoringExportInputs = new MonitoringExportInputs();
             if (args.length == 0) {
                 logger.info(Constants.CONSOLE,  Constants.interactiveMsg);
                 monitoringExportInputs.interactive = true;
-                monitoringExportInputs.runInteractive(textIOManager);
+                try(
+                    TextIOManager textIOManager = new TextIOManager();
+                ) {
+                    monitoringExportInputs.runInteractive(textIOManager);
+                }
             } else {
                 List<String> errors = monitoringExportInputs.parseInputs(args);
                 if (errors.size() > 0) {
@@ -44,9 +46,6 @@ public class MonitoringExportApp {
             SystemUtils.quitApp();
         } catch (Exception e) {
             logger.error(Constants.CONSOLE, "Fatal error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
-        } finally {
-            resourceCache.close();
-            textIOManager.close();
         }
     }
 }

--- a/src/main/java/co/elastic/support/monitoring/MonitoringExportInputs.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringExportInputs.java
@@ -7,6 +7,7 @@ package co.elastic.support.monitoring;
 
 import co.elastic.support.util.ResourceCache;
 import co.elastic.support.util.SystemProperties;
+import co.elastic.support.util.TextIOManager;
 import com.beust.jcommander.Parameter;
 import co.elastic.support.Constants;
 import co.elastic.support.rest.ElasticRestClientInputs;
@@ -14,6 +15,7 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.beryx.textio.TextIO;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -52,38 +54,38 @@ public class MonitoringExportInputs extends ElasticRestClientInputs {
     public String queryStartDate;
     public String queryEndDate;
 
-    public boolean runInteractive() {
+    public boolean runInteractive(TextIOManager textIOManager) {
 
-        runHttpInteractive();
+        runHttpInteractive(textIOManager);
 
-        String operation = standardStringReader
+        String operation = textIOManager.standardStringReader
                 .withNumberedPossibleValues("List", "Extract")
                 .withIgnoreCase()
                 .read(SystemProperties.lineSeparator + "List monitored clusters available or extract data from a cluster." );
 
         operation = operation.toLowerCase();
         if(operation.equals("extract")){
-            type = ResourceCache.textIO.newStringInputReader()
+            type = textIOManager.textIO.newStringInputReader()
                     .withInputTrimming(true)
                     .withDefaultValue("monitoring")
                     .read(SystemProperties.lineSeparator + "Enter monitoring for ES and Logstash monitoring data, metric for metricbeat system data, or all.");
 
-            clusterId = ResourceCache.textIO.newStringInputReader()
+            clusterId = textIOManager.textIO.newStringInputReader()
                     .withInputTrimming(true)
                     .withValueChecker((String val, String propname) -> validateCluster(val))
                     .read(SystemProperties.lineSeparator + "Enter the cluster id to for the cluster you wish to extract.");
 
-            cutoffDate = ResourceCache.textIO.newStringInputReader()
+            cutoffDate = textIOManager.textIO.newStringInputReader()
                     .withInputTrimming(true)
                     .withMinLength(0)
                     .read(SystemProperties.lineSeparator + "Enter the date for the cutoff point of the extraction. Defaults to today's date. Must be in the format yyyy-MM-dd.");
 
-            cutoffTime = ResourceCache.textIO.newStringInputReader()
+            cutoffTime = textIOManager.textIO.newStringInputReader()
                     .withInputTrimming(true)
                     .withMinLength(0)
                     .read(SystemProperties.lineSeparator + "Enter the time for the cutoff point of the extraction. Defaults to the current UTC time. Must be in the 24 hour format HH:mm.");
 
-            interval = ResourceCache.textIO.newIntInputReader()
+            interval = textIOManager.textIO.newIntInputReader()
                     .withInputTrimming(true)
                     .withDefaultValue(interval)
                     .withValueChecker((Integer val, String propname) -> validateInterval(val))
@@ -92,7 +94,7 @@ public class MonitoringExportInputs extends ElasticRestClientInputs {
             validateTimeWindow();
         }
 
-        runOutputDirInteractive();
+        runOutputDirInteractive(textIOManager);
 
         return true;
     }

--- a/src/main/java/co/elastic/support/monitoring/MonitoringExportInputs.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringExportInputs.java
@@ -5,7 +5,6 @@
  */
 package co.elastic.support.monitoring;
 
-import co.elastic.support.util.ResourceCache;
 import co.elastic.support.util.SystemProperties;
 import co.elastic.support.util.TextIOManager;
 import com.beust.jcommander.Parameter;
@@ -15,7 +14,6 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.beryx.textio.TextIO;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;

--- a/src/main/java/co/elastic/support/monitoring/MonitoringExportService.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringExportService.java
@@ -129,7 +129,6 @@ public class MonitoringExportService extends ElasticRestClientService {
             logger.error( "Unexpected error occurred", t);
             logger.error(Constants.CONSOLE, "Unexpected error. {}", Constants.CHECK_LOG);
         } finally {
-            // resourceCache.textIO.dispose();
             closeLogs();
             createArchive(tempDir, ArchiveUtils.ArchiveType.fromString(inputs.archiveType));
             client.close();

--- a/src/main/java/co/elastic/support/monitoring/MonitoringExportService.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringExportService.java
@@ -129,7 +129,7 @@ public class MonitoringExportService extends ElasticRestClientService {
             logger.error( "Unexpected error occurred", t);
             logger.error(Constants.CONSOLE, "Unexpected error. {}", Constants.CHECK_LOG);
         } finally {
-            ResourceCache.textIO.dispose();
+            // resourceCache.textIO.dispose();
             closeLogs();
             createArchive(tempDir, ArchiveUtils.ArchiveType.fromString(inputs.archiveType));
             client.close();

--- a/src/main/java/co/elastic/support/monitoring/MonitoringImportApp.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringImportApp.java
@@ -9,6 +9,7 @@ import co.elastic.support.Constants;
 import co.elastic.support.diagnostics.ShowHelpException;
 import co.elastic.support.util.ResourceCache;
 import co.elastic.support.util.SystemUtils;
+import co.elastic.support.util.TextIOManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -21,12 +22,15 @@ public class MonitoringImportApp {
 
     public static void main(String[] args) {
 
+        ResourceCache resourceCache = new ResourceCache();
+        TextIOManager textIOManager = new TextIOManager();
+
         try {
             MonitoringImportInputs monitoringImportInputs = new MonitoringImportInputs();
             if (args.length == 0) {
                 logger.info(Constants.CONSOLE,  Constants.interactiveMsg);
                 monitoringImportInputs.interactive = true;
-                monitoringImportInputs.runInteractive();
+                monitoringImportInputs.runInteractive(textIOManager);
             } else {
                 List<String> errors = monitoringImportInputs.parseInputs(args);
                 if (errors.size() > 0) {
@@ -37,14 +41,14 @@ public class MonitoringImportApp {
                     SystemUtils.quitApp();
                 }
             }
-            ResourceCache.terminal.dispose();
             new MonitoringImportService().execImport(monitoringImportInputs);
         } catch (ShowHelpException she){
             SystemUtils.quitApp();
         } catch (Exception e) {
             logger.error(Constants.CONSOLE,  "Error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
         } finally {
-            ResourceCache.closeAll();
+            resourceCache.closeAll();
+            textIOManager.close();
         }
     }
 

--- a/src/main/java/co/elastic/support/monitoring/MonitoringImportApp.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringImportApp.java
@@ -47,7 +47,7 @@ public class MonitoringImportApp {
         } catch (Exception e) {
             logger.error(Constants.CONSOLE,  "Error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
         } finally {
-            resourceCache.closeAll();
+            resourceCache.close();
             textIOManager.close();
         }
     }

--- a/src/main/java/co/elastic/support/monitoring/MonitoringImportApp.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringImportApp.java
@@ -21,11 +21,9 @@ public class MonitoringImportApp {
     private static final Logger logger = LogManager.getLogger(MonitoringImportApp.class);
 
     public static void main(String[] args) {
-
-        ResourceCache resourceCache = new ResourceCache();
-        TextIOManager textIOManager = new TextIOManager();
-
-        try {
+        try(
+            TextIOManager textIOManager = new TextIOManager();
+        ) {
             MonitoringImportInputs monitoringImportInputs = new MonitoringImportInputs();
             if (args.length == 0) {
                 logger.info(Constants.CONSOLE,  Constants.interactiveMsg);
@@ -46,9 +44,6 @@ public class MonitoringImportApp {
             SystemUtils.quitApp();
         } catch (Exception e) {
             logger.error(Constants.CONSOLE,  "Error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
-        } finally {
-            resourceCache.close();
-            textIOManager.close();
         }
     }
 

--- a/src/main/java/co/elastic/support/monitoring/MonitoringImportInputs.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringImportInputs.java
@@ -5,7 +5,6 @@
  */
 package co.elastic.support.monitoring;
 
-import co.elastic.support.util.ResourceCache;
 import co.elastic.support.util.TextIOManager;
 import com.beust.jcommander.Parameter;
 import co.elastic.support.rest.ElasticRestClientInputs;
@@ -14,7 +13,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.beryx.textio.StringInputReader;
-import org.beryx.textio.TextIO;
 
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/co/elastic/support/monitoring/MonitoringImportInputs.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringImportInputs.java
@@ -6,6 +6,7 @@
 package co.elastic.support.monitoring;
 
 import co.elastic.support.util.ResourceCache;
+import co.elastic.support.util.TextIOManager;
 import com.beust.jcommander.Parameter;
 import co.elastic.support.rest.ElasticRestClientInputs;
 import org.apache.commons.lang3.ObjectUtils;
@@ -13,6 +14,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.beryx.textio.StringInputReader;
+import org.beryx.textio.TextIO;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -32,24 +35,26 @@ public class MonitoringImportInputs extends ElasticRestClientInputs {
 
     // Start Input Readers
 
-    protected StringInputReader proxyHostReader = ResourceCache.textIO.newStringInputReader()
-            .withInputTrimming(true)
-            .withValueChecker((String val, String propname) -> validateId(val));
+    protected StringInputReader proxyHostReader;
 
     // End Input Readers
 
-    public boolean runInteractive(){
+    public boolean runInteractive(TextIOManager textIOManager){
 
-        clusterName = ResourceCache.textIO.newStringInputReader()
+        proxyHostReader = textIOManager.textIO.newStringInputReader()
+                .withInputTrimming(true)
+                .withValueChecker((String val, String propname) -> validateId(val));
+
+        clusterName = textIOManager.textIO.newStringInputReader()
                 .withMinLength(0)
                 .read("Specify an alternate name for the imported cluster or hit enter to use original cluster name:");
 
-        input = ResourceCache.textIO.newStringInputReader()
+        input = textIOManager.textIO.newStringInputReader()
                 .withInputTrimming(true)
                 .withValueChecker((String val, String propname) -> validateRequiredFile(val))
                 .read("Enter the full path of the archvive you wish to import.");
 
-        runHttpInteractive();
+        runHttpInteractive(textIOManager);
 
         return true;
     }

--- a/src/main/java/co/elastic/support/scrub/ScrubApp.java
+++ b/src/main/java/co/elastic/support/scrub/ScrubApp.java
@@ -48,7 +48,7 @@ public class ScrubApp {
         } catch (Exception e) {
             logger.error(Constants.CONSOLE,  "Fatal error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
         } finally {
-            resourceCache.closeAll();
+            resourceCache.close();
             textIOManager.close();
         }
     }

--- a/src/main/java/co/elastic/support/scrub/ScrubApp.java
+++ b/src/main/java/co/elastic/support/scrub/ScrubApp.java
@@ -22,10 +22,9 @@ public class ScrubApp {
     private static Logger logger = LogManager.getLogger(ScrubApp.class);
 
     public static void main(String[] args) {
-        ResourceCache resourceCache = new ResourceCache();
-        TextIOManager textIOManager = new TextIOManager();
-
-        try {
+        try(
+            TextIOManager textIOManager = new TextIOManager();
+        ) {
             ScrubInputs scrubInputs = new ScrubInputs();
             if (args.length == 0) {
                 logger.error(Constants.CONSOLE,  Constants.interactiveMsg);
@@ -47,9 +46,6 @@ public class ScrubApp {
             SystemUtils.quitApp();
         } catch (Exception e) {
             logger.error(Constants.CONSOLE,  "Fatal error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
-        } finally {
-            resourceCache.close();
-            textIOManager.close();
         }
     }
 

--- a/src/main/java/co/elastic/support/scrub/ScrubApp.java
+++ b/src/main/java/co/elastic/support/scrub/ScrubApp.java
@@ -10,6 +10,7 @@ import co.elastic.support.Constants;
 import co.elastic.support.diagnostics.ShowHelpException;
 import co.elastic.support.util.ResourceCache;
 import co.elastic.support.util.SystemUtils;
+import co.elastic.support.util.TextIOManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -21,13 +22,15 @@ public class ScrubApp {
     private static Logger logger = LogManager.getLogger(ScrubApp.class);
 
     public static void main(String[] args) {
+        ResourceCache resourceCache = new ResourceCache();
+        TextIOManager textIOManager = new TextIOManager();
 
         try {
             ScrubInputs scrubInputs = new ScrubInputs();
             if (args.length == 0) {
                 logger.error(Constants.CONSOLE,  Constants.interactiveMsg);
                 scrubInputs.interactive = true;
-                scrubInputs.runInteractive();
+                scrubInputs.runInteractive(textIOManager);
             } else {
                 List<String> errors = scrubInputs.parseIinputs(args);
                 if (errors.size() > 0) {
@@ -38,7 +41,6 @@ public class ScrubApp {
                     SystemUtils.quitApp();
                 }
             }
-            ResourceCache.terminal.dispose();
             logger.info(Constants.CONSOLE, "Using version: {} of diagnostic-utiliy", GenerateManifest.class.getPackage().getImplementationVersion());
             new ScrubService().exec(scrubInputs);
         } catch (ShowHelpException she){
@@ -46,7 +48,8 @@ public class ScrubApp {
         } catch (Exception e) {
             logger.error(Constants.CONSOLE,  "Fatal error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
         } finally {
-            ResourceCache.closeAll();
+            resourceCache.closeAll();
+            textIOManager.close();
         }
     }
 

--- a/src/main/java/co/elastic/support/scrub/ScrubInputs.java
+++ b/src/main/java/co/elastic/support/scrub/ScrubInputs.java
@@ -8,6 +8,7 @@ package co.elastic.support.scrub;
 import co.elastic.support.BaseInputs;
 import co.elastic.support.util.ResourceCache;
 import co.elastic.support.util.SystemProperties;
+import co.elastic.support.util.TextIOManager;
 import com.beust.jcommander.Parameter;
 import co.elastic.support.Constants;
 import org.apache.commons.lang3.StringUtils;
@@ -36,14 +37,14 @@ public class ScrubInputs extends BaseInputs {
     public boolean isArchive = true;
     public String scrubbedFileBaseName;
 
-    public boolean runInteractive() {
+    public boolean runInteractive(TextIOManager textIOManager) {
 
-        scrub = ResourceCache.textIO.newStringInputReader()
+        scrub = textIOManager.textIO.newStringInputReader()
                 .withInputTrimming(true)
                 .withValueChecker((String val, String propname) -> validateScrubInput(val))
                 .read("Enter the full path of the archive you wish to import.");
 
-        workers = ResourceCache.textIO.newIntInputReader()
+        workers = textIOManager.textIO.newIntInputReader()
                 .withMinVal(0)
                 .withDefaultValue(workers)
                 .read("Enter the number of workers to run in parallel. Defaults to the detected number of processors: " + workers);
@@ -56,7 +57,7 @@ public class ScrubInputs extends BaseInputs {
         if (runningInDocker) {
             logger.info(Constants.CONSOLE, "Result will be written to the configured Docker volume.");
         } else {
-            runOutputDirInteractive();
+            runOutputDirInteractive(textIOManager);
         }
 
         return true;

--- a/src/main/java/co/elastic/support/util/ResourceCache.java
+++ b/src/main/java/co/elastic/support/util/ResourceCache.java
@@ -13,7 +13,7 @@ import java.io.Closeable;
 import java.util.concurrent.ConcurrentHashMap;
 
 
-public class ResourceCache{
+public class ResourceCache implements AutoCloseable {
 
     private final Logger logger = LogManager.getLogger(ResourceCache.class);
     private ConcurrentHashMap<String, Closeable> resources = new ConcurrentHashMap();
@@ -42,8 +42,8 @@ public class ResourceCache{
         throw new IllegalStateException("RestClient instance does not exist");
     }
 
-    // Centralized method for cleaning up ssh and http clients
-    public void closeAll() {
+    @Override
+    public void close() {
         resources.forEach((name, resource)->{
                 try{
                     resource.close();

--- a/src/main/java/co/elastic/support/util/ResourceCache.java
+++ b/src/main/java/co/elastic/support/util/ResourceCache.java
@@ -6,13 +6,8 @@
 package co.elastic.support.util;
 
 import co.elastic.support.rest.RestClient;
-import jline.console.ConsoleReader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.beryx.textio.TextIO;
-import org.beryx.textio.TextIoFactory;
-import org.beryx.textio.TextTerminal;
-import org.beryx.textio.jline.JLineTextTerminal;
 
 import java.io.Closeable;
 import java.util.concurrent.ConcurrentHashMap;
@@ -20,30 +15,15 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class ResourceCache{
 
-    private static final Logger logger = LogManager.getLogger(ResourceCache.class);
-    private static ConcurrentHashMap<String, Closeable> resources = new ConcurrentHashMap();
+    private final Logger logger = LogManager.getLogger(ResourceCache.class);
+    private ConcurrentHashMap<String, Closeable> resources = new ConcurrentHashMap();
 
-    public static final TextIO textIO = TextIoFactory.getTextIO();
-    public static final TextTerminal terminal = textIO.getTextTerminal();
-
-    static {
-        if(terminal instanceof JLineTextTerminal){
-            JLineTextTerminal jltt = (JLineTextTerminal)terminal;
-            ConsoleReader reader = jltt.getReader();
-            reader.setExpandEvents(false);
-        }
-    }
-
-    public static boolean resourceExists(String name){
-        return resources.containsKey(name);
-    }
-
-    public static void addSystemCommand(String name, SystemCommand systemCommand){
+    public void addSystemCommand(String name, SystemCommand systemCommand){
         // Log the error if they tried to overlay with a dupe but don't throw an exception.
         resources.putIfAbsent(name, systemCommand );
     }
 
-    public static SystemCommand getSystemCommand(String name){
+    public SystemCommand getSystemCommand(String name){
         if(resources.containsKey(name)){
             return (SystemCommand)resources.get(name);
         }
@@ -51,19 +31,19 @@ public class ResourceCache{
         throw new IllegalStateException("SystemCommand instance requested does not exist");
     }
 
-    public static void addRestClient(String name, RestClient client){
+    public void addRestClient(String name, RestClient client){
         resources.putIfAbsent(name, client);
     }
 
-    public static RestClient getRestClient(String name){
+    public RestClient getRestClient(String name){
         if (resources.containsKey(name)){
             return (RestClient)resources.get(name);
         }
         throw new IllegalStateException("RestClient instance does not exist");
     }
 
-    // Centralized method for cleaning up console, ssh and http clients
-    public static void closeAll() {
+    // Centralized method for cleaning up ssh and http clients
+    public void closeAll() {
         resources.forEach((name, resource)->{
                 try{
                     resource.close();
@@ -72,6 +52,5 @@ public class ResourceCache{
                     logger.error( "Failed to close resource {}", name);
                 }
         });
-        textIO.dispose();
     }
 }

--- a/src/main/java/co/elastic/support/util/TextIOManager.java
+++ b/src/main/java/co/elastic/support/util/TextIOManager.java
@@ -13,7 +13,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 
-public class TextIOManager {
+public class TextIOManager implements AutoCloseable {
 
     public TextIO textIO;
 
@@ -57,13 +57,15 @@ public class TextIOManager {
         File file = new File(val);
 
         if (!file.exists()) {
-            return Collections.singletonList("Specified file could not be located.");
+            return Collections.singletonList(
+                    String.format("Specified file [%s] could not be located.", file.getPath())
+            );
         }
 
         return null;
-
     }
 
+    @Override
     public void close() {
         textIO.dispose();
     }

--- a/src/main/java/co/elastic/support/util/TextIOManager.java
+++ b/src/main/java/co/elastic/support/util/TextIOManager.java
@@ -1,0 +1,70 @@
+package co.elastic.support.util;
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import jline.console.ConsoleReader;
+import org.apache.commons.lang3.StringUtils;
+import org.beryx.textio.*;
+import org.beryx.textio.jline.JLineTextTerminal;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+public class TextIOManager {
+
+    public TextIO textIO;
+
+    public StringInputReader standardStringReader;
+    public BooleanInputReader standardBooleanReader;
+    public StringInputReader  standardPasswordReader;
+    public StringInputReader standardFileReader;
+
+    public TextIOManager() {
+        textIO = TextIoFactory.getTextIO();
+        TextTerminal terminal = textIO.getTextTerminal();
+
+        if(terminal instanceof JLineTextTerminal){
+            JLineTextTerminal jltt = (JLineTextTerminal)terminal;
+            ConsoleReader reader = jltt.getReader();
+            reader.setExpandEvents(false);
+        }
+
+        // Input Readers
+        // Generic - change the read label only
+        // Warning: Setting default values may leak into later prompts if not reset. Better to use a new Reader.
+        standardStringReader = textIO.newStringInputReader()
+                .withMinLength(0)
+                .withInputTrimming(true);
+        standardBooleanReader = textIO.newBooleanInputReader();
+        standardPasswordReader = textIO.newStringInputReader()
+                .withInputMasking(true)
+                .withInputTrimming(true)
+                .withMinLength(0);
+        standardFileReader = textIO.newStringInputReader()
+                .withInputTrimming(true)
+                .withValueChecker((String val, String propname) -> validateFile(val));
+        // End Input Readers
+    }
+
+    static public List<String> validateFile(String val) {
+        if (StringUtils.isEmpty(val.trim())) {
+            return null;
+        }
+
+        File file = new File(val);
+
+        if (!file.exists()) {
+            return Collections.singletonList("Specified file could not be located.");
+        }
+
+        return null;
+
+    }
+
+    public void close() {
+        textIO.dispose();
+    }
+}

--- a/src/test/java/co/elastic/support/diagnostics/TestDiagnosticService.java
+++ b/src/test/java/co/elastic/support/diagnostics/TestDiagnosticService.java
@@ -171,16 +171,14 @@ class TestDiagnosticService {
         diagConfig.extraHeaders = extraHeaders;
         DiagnosticService diag = new DiagnosticService();
 
-        ResourceCache resourceCache = new ResourceCache();
-        DiagnosticContext context = new DiagnosticContext(diagConfig, newDiagnosticInputs(), resourceCache, true);
-
-        try {
+        try(
+            ResourceCache resourceCache = new ResourceCache();
+        ) {
+            DiagnosticContext context = new DiagnosticContext(diagConfig, newDiagnosticInputs(), resourceCache, true);
             File result = diag.exec(context);
             checkResult(result, true);
         } catch (DiagnosticException e) {
             fail(e);
-        } finally {
-            context.resourceCache.close();
         }
     }
 
@@ -189,16 +187,15 @@ class TestDiagnosticService {
         setupResponse(false);
 
         DiagnosticService diag = new DiagnosticService();
-        ResourceCache resourceCache = new ResourceCache();
-        DiagnosticContext context = new DiagnosticContext(newDiagConfig(), newDiagnosticInputs(), resourceCache, true);
 
-        try {
+        try(
+            ResourceCache resourceCache = new ResourceCache();
+        ) {
+            DiagnosticContext context = new DiagnosticContext(newDiagConfig(), newDiagnosticInputs(), resourceCache, true);
             File result = diag.exec(context);
             checkResult(result, true);
         } catch (DiagnosticException e) {
             fail(e);
-        } finally {
-            resourceCache.close();
         }
     }
 
@@ -212,16 +209,15 @@ class TestDiagnosticService {
             @Override
             public void run() {
                 DiagnosticService diag = new DiagnosticService();
-                ResourceCache resourceCache = new ResourceCache();
 
-                try {
+                try(
+                    ResourceCache resourceCache = new ResourceCache();
+                ) {
                     DiagnosticContext context = new DiagnosticContext(newDiagConfig(), newDiagnosticInputs(), resourceCache, false);
                     File result = diag.exec(context);
                     results.put(i, result);
                 } catch (DiagnosticException e) {
                     System.out.println(e.getStackTrace());
-                } finally {
-                    resourceCache.close();
                 }
             }
         };

--- a/src/test/java/co/elastic/support/diagnostics/TestDiagnosticService.java
+++ b/src/test/java/co/elastic/support/diagnostics/TestDiagnosticService.java
@@ -180,7 +180,7 @@ class TestDiagnosticService {
         } catch (DiagnosticException e) {
             fail(e);
         } finally {
-            context.resourceCache.closeAll();
+            context.resourceCache.close();
         }
     }
 
@@ -198,7 +198,7 @@ class TestDiagnosticService {
         } catch (DiagnosticException e) {
             fail(e);
         } finally {
-            resourceCache.closeAll();
+            resourceCache.close();
         }
     }
 
@@ -221,7 +221,7 @@ class TestDiagnosticService {
                 } catch (DiagnosticException e) {
                     System.out.println(e.getStackTrace());
                 } finally {
-                    resourceCache.closeAll();
+                    resourceCache.close();
                 }
             }
         };

--- a/src/test/java/co/elastic/support/diagnostics/TestDiagnosticService.java
+++ b/src/test/java/co/elastic/support/diagnostics/TestDiagnosticService.java
@@ -112,7 +112,7 @@ class TestDiagnosticService {
         DiagnosticService diag = new DiagnosticService();
 
         ResourceCache resourceCache = new ResourceCache();
-        DiagnosticContext context = new DiagnosticContext(diagConfig, newDiagnosticInputs(), resourceCache);
+        DiagnosticContext context = new DiagnosticContext(diagConfig, newDiagnosticInputs(), resourceCache, true);
 
         try {
             File result = diag.exec(context);
@@ -145,7 +145,7 @@ class TestDiagnosticService {
 
         DiagnosticService diag = new DiagnosticService();
         ResourceCache resourceCache = new ResourceCache();
-        DiagnosticContext context = new DiagnosticContext(newDiagConfig(), newDiagnosticInputs(), resourceCache);
+        DiagnosticContext context = new DiagnosticContext(newDiagConfig(), newDiagnosticInputs(), resourceCache, true);
 
         try {
             File result = diag.exec(context);
@@ -167,7 +167,7 @@ class TestDiagnosticService {
                 ResourceCache resourceCache = new ResourceCache();
 
                 try {
-                    DiagnosticContext context = new DiagnosticContext(newDiagConfig(), newDiagnosticInputs(), resourceCache);
+                    DiagnosticContext context = new DiagnosticContext(newDiagConfig(), newDiagnosticInputs(), resourceCache, false);
                     File result = diag.exec(context);
                 } catch (DiagnosticException e) {
                     System.out.println(e.getStackTrace());

--- a/src/test/java/co/elastic/support/diagnostics/commands/TestKibanaGetDetails.java
+++ b/src/test/java/co/elastic/support/diagnostics/commands/TestKibanaGetDetails.java
@@ -160,7 +160,7 @@ public class TestKibanaGetDetails {
         ResourceCache resourceCache = new ResourceCache();
         resourceCache.addRestClient(Constants.restInputHost, httpRestClient);
         Map diagMap = JsonYamlUtils.readYamlFromClasspath(Constants.DIAG_CONFIG, true);
-        DiagnosticContext context = new DiagnosticContext(new DiagConfig(diagMap), new DiagnosticInputs(), resourceCache);
+        DiagnosticContext context = new DiagnosticContext(new DiagConfig(diagMap), new DiagnosticInputs(), resourceCache, true);
         Map restCalls = JsonYamlUtils.readYamlFromClasspath(Constants.KIBANA_REST, true);
         RestEntryConfig builder = new RestEntryConfig("7.10.0");
         Map<String, RestEntry> entries = builder.buildEntryMap(restCalls);

--- a/src/test/java/co/elastic/support/diagnostics/commands/TestKibanaGetDetails.java
+++ b/src/test/java/co/elastic/support/diagnostics/commands/TestKibanaGetDetails.java
@@ -157,22 +157,21 @@ public class TestKibanaGetDetails {
                             .withStatusCode(401)
                 );
 
-        ResourceCache resourceCache = new ResourceCache();
-        resourceCache.addRestClient(Constants.restInputHost, httpRestClient);
         Map diagMap = JsonYamlUtils.readYamlFromClasspath(Constants.DIAG_CONFIG, true);
-        DiagnosticContext context = new DiagnosticContext(new DiagConfig(diagMap), new DiagnosticInputs(), resourceCache, true);
         Map restCalls = JsonYamlUtils.readYamlFromClasspath(Constants.KIBANA_REST, true);
         RestEntryConfig builder = new RestEntryConfig("7.10.0");
         Map<String, RestEntry> entries = builder.buildEntryMap(restCalls);
-        context.elasticRestCalls = entries;
 
         KibanaGetDetails testClass = new KibanaGetDetails();
-        try {
+        try(
+            ResourceCache resourceCache = new ResourceCache();
+        ) {
+            DiagnosticContext context = new DiagnosticContext(new DiagConfig(diagMap), new DiagnosticInputs(), resourceCache, true);
+            context.elasticRestCalls = entries;
+            resourceCache.addRestClient(Constants.restInputHost, httpRestClient);
             testClass.getStats(context);
         } catch (DiagnosticException e) {
             assertEquals(e.getMessage(), "Kibana responded with [401] for [/api/stats]. Unable to proceed.");
-        } finally {
-            resourceCache.close();
         }
     }
 }

--- a/src/test/java/co/elastic/support/diagnostics/commands/TestKibanaGetDetails.java
+++ b/src/test/java/co/elastic/support/diagnostics/commands/TestKibanaGetDetails.java
@@ -5,6 +5,8 @@
  */
 package co.elastic.support.diagnostics.commands;
 
+import co.elastic.support.diagnostics.DiagConfig;
+import co.elastic.support.diagnostics.DiagnosticInputs;
 import co.elastic.support.util.JsonYamlUtils;
 import co.elastic.support.util.ResourceCache;
 import co.elastic.support.Constants;
@@ -155,8 +157,10 @@ public class TestKibanaGetDetails {
                             .withStatusCode(401)
                 );
 
-        ResourceCache.addRestClient(Constants.restInputHost, httpRestClient);
-        DiagnosticContext context = new DiagnosticContext();
+        ResourceCache resourceCache = new ResourceCache();
+        resourceCache.addRestClient(Constants.restInputHost, httpRestClient);
+        Map diagMap = JsonYamlUtils.readYamlFromClasspath(Constants.DIAG_CONFIG, true);
+        DiagnosticContext context = new DiagnosticContext(new DiagConfig(diagMap), new DiagnosticInputs(), resourceCache);
         Map restCalls = JsonYamlUtils.readYamlFromClasspath(Constants.KIBANA_REST, true);
         RestEntryConfig builder = new RestEntryConfig("7.10.0");
         Map<String, RestEntry> entries = builder.buildEntryMap(restCalls);
@@ -167,6 +171,8 @@ public class TestKibanaGetDetails {
             testClass.getStats(context);
         } catch (DiagnosticException e) {
             assertEquals(e.getMessage(), "Kibana responded with [401] for [/api/stats]. Unable to proceed.");
+        } finally {
+            resourceCache.closeAll();
         }
     }
 }

--- a/src/test/java/co/elastic/support/diagnostics/commands/TestKibanaGetDetails.java
+++ b/src/test/java/co/elastic/support/diagnostics/commands/TestKibanaGetDetails.java
@@ -172,7 +172,7 @@ public class TestKibanaGetDetails {
         } catch (DiagnosticException e) {
             assertEquals(e.getMessage(), "Kibana responded with [401] for [/api/stats]. Unable to proceed.");
         } finally {
-            resourceCache.closeAll();
+            resourceCache.close();
         }
     }
 }

--- a/src/test/java/co/elastic/support/diagnostics/commands/TestRunKibanaQueries.java
+++ b/src/test/java/co/elastic/support/diagnostics/commands/TestRunKibanaQueries.java
@@ -86,7 +86,7 @@ public class TestRunKibanaQueries {
 
         mockServer.reset();
         FileUtils.deleteQuietly(tempDir);
-		resourceCache.closeAll();
+		resourceCache.close();
     }
 
     private DiagnosticContext initializeKibana(String version) throws DiagnosticException {

--- a/src/test/java/co/elastic/support/diagnostics/commands/TestRunKibanaQueries.java
+++ b/src/test/java/co/elastic/support/diagnostics/commands/TestRunKibanaQueries.java
@@ -92,7 +92,7 @@ public class TestRunKibanaQueries {
     private DiagnosticContext initializeKibana(String version) throws DiagnosticException {
 		Map diagMap = JsonYamlUtils.readYamlFromClasspath(Constants.DIAG_CONFIG, true);
 		DiagConfig diagConfig = new DiagConfig(diagMap);
-		DiagnosticContext context = new DiagnosticContext(diagConfig, new DiagnosticInputs(), resourceCache);
+		DiagnosticContext context = new DiagnosticContext(diagConfig, new DiagnosticInputs(), resourceCache, true);
     	RestEntryConfig builder = new RestEntryConfig(version);
 
         Map restCalls = JsonYamlUtils.readYamlFromClasspath(Constants.KIBANA_REST, true);

--- a/src/test/java/co/elastic/support/diagnostics/commands/TestRunKibanaQueries.java
+++ b/src/test/java/co/elastic/support/diagnostics/commands/TestRunKibanaQueries.java
@@ -78,7 +78,7 @@ public class TestRunKibanaQueries {
            3000);
         tempDir.mkdir();
 
-		resourceCache = new ResourceCache();
+        resourceCache = new ResourceCache();
     }
 
     @AfterEach
@@ -86,13 +86,13 @@ public class TestRunKibanaQueries {
 
         mockServer.reset();
         FileUtils.deleteQuietly(tempDir);
-		resourceCache.close();
+        resourceCache.close();
     }
 
     private DiagnosticContext initializeKibana(String version) throws DiagnosticException {
-		Map diagMap = JsonYamlUtils.readYamlFromClasspath(Constants.DIAG_CONFIG, true);
-		DiagConfig diagConfig = new DiagConfig(diagMap);
-		DiagnosticContext context = new DiagnosticContext(diagConfig, new DiagnosticInputs(), resourceCache, true);
+        Map diagMap = JsonYamlUtils.readYamlFromClasspath(Constants.DIAG_CONFIG, true);
+        DiagConfig diagConfig = new DiagConfig(diagMap);
+        DiagnosticContext context = new DiagnosticContext(diagConfig, new DiagnosticInputs(), resourceCache, true);
     	RestEntryConfig builder = new RestEntryConfig(version);
 
         Map restCalls = JsonYamlUtils.readYamlFromClasspath(Constants.KIBANA_REST, true);

--- a/src/test/java/co/elastic/support/diagnostics/commands/TestRunKibanaQueries.java
+++ b/src/test/java/co/elastic/support/diagnostics/commands/TestRunKibanaQueries.java
@@ -5,7 +5,10 @@
  */
 package co.elastic.support.diagnostics.commands;
 
+import co.elastic.support.diagnostics.DiagConfig;
+import co.elastic.support.diagnostics.DiagnosticInputs;
 import co.elastic.support.util.JsonYamlUtils;
+import co.elastic.support.util.ResourceCache;
 import co.elastic.support.util.SystemProperties;
 import co.elastic.support.Constants;
 import co.elastic.support.diagnostics.DiagnosticException;
@@ -41,6 +44,7 @@ public class TestRunKibanaQueries {
     private RestClient httpRestClient, httpsRestClient;
     private String temp = SystemProperties.userDir + SystemProperties.fileSeparator + "temp";
     private File tempDir = new File(temp);
+    private ResourceCache resourceCache;
 
     @BeforeAll
     public void globalSetup() {
@@ -74,6 +78,7 @@ public class TestRunKibanaQueries {
            3000);
         tempDir.mkdir();
 
+		resourceCache = new ResourceCache();
     }
 
     @AfterEach
@@ -81,12 +86,13 @@ public class TestRunKibanaQueries {
 
         mockServer.reset();
         FileUtils.deleteQuietly(tempDir);
-
+		resourceCache.closeAll();
     }
 
     private DiagnosticContext initializeKibana(String version) throws DiagnosticException {
-
-    	DiagnosticContext context = new DiagnosticContext();
+		Map diagMap = JsonYamlUtils.readYamlFromClasspath(Constants.DIAG_CONFIG, true);
+		DiagConfig diagConfig = new DiagConfig(diagMap);
+		DiagnosticContext context = new DiagnosticContext(diagConfig, new DiagnosticInputs(), resourceCache);
     	RestEntryConfig builder = new RestEntryConfig(version);
 
         Map restCalls = JsonYamlUtils.readYamlFromClasspath(Constants.KIBANA_REST, true);
@@ -396,7 +402,6 @@ public class TestRunKibanaQueries {
 
     @Test
     public void testQueriesRemovingHeaders() throws DiagnosticException {
-
       mockServer
             .when(
                     request()
@@ -424,7 +429,6 @@ public class TestRunKibanaQueries {
     */
     @Test
     public void testQueriesWithoutHeaders() throws DiagnosticException {
-
       mockServer
             .when(
                     request()
@@ -446,6 +450,5 @@ public class TestRunKibanaQueries {
         JsonNode config = nodeData.get(0).get("config");
         assertEquals(nodeData.get(0).path("id").asText(), "eec7ee50-7129-3333-9b41-17a1879ebc72");
         assertTrue((config == null || config.isNull()));
-
     }
 }


### PR DESCRIPTION
This PR makes the library more multithreading-friendly, allowing concurrent executions of the diagnostic generation in the same process.

It achieves that by:
- making `ResourceCache` a non-global
- adding a separate `TextIOManager` which needs to be explicitly instantiated for interactive use cases
- allowing the exclusion of log files from the diagnostics, since those rely on global log4j settings which won't behave properly in a multithreading setting.
