### PR TITLE
Update license header to Elastic License v2

### DIFF
--- a/HEADER.txt
+++ b/HEADER.txt
@@ -1,3 +1,4 @@
 Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-or more contributor license agreements. Licensed under the Elastic License;
-you may not use this file except in compliance with the Elastic License.
+ or more contributor license agreements. Licensed under the Elastic License
+ 2.0; you may not use this file except in compliance with the Elastic License
+ 2.0.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,223 +1,93 @@
-ELASTIC LICENSE AGREEMENT
+Elastic License 2.0
 
-PLEASE READ CAREFULLY THIS ELASTIC LICENSE AGREEMENT (THIS "AGREEMENT"), WHICH
-CONSTITUTES A LEGALLY BINDING AGREEMENT AND GOVERNS ALL OF YOUR USE OF ALL OF
-THE ELASTIC SOFTWARE WITH WHICH THIS AGREEMENT IS INCLUDED ("ELASTIC SOFTWARE")
-THAT IS PROVIDED IN OBJECT CODE FORMAT, AND, IN ACCORDANCE WITH SECTION 2 BELOW,
-CERTAIN OF THE ELASTIC SOFTWARE THAT IS PROVIDED IN SOURCE CODE FORMAT. BY
-INSTALLING OR USING ANY OF THE ELASTIC SOFTWARE GOVERNED BY THIS AGREEMENT, YOU
-ARE ASSENTING TO THE TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE
-WITH SUCH TERMS AND CONDITIONS, YOU MAY NOT INSTALL OR USE THE ELASTIC SOFTWARE
-GOVERNED BY THIS AGREEMENT. IF YOU ARE INSTALLING OR USING THE SOFTWARE ON
-BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL
-AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF
-SUCH ENTITY.
+URL: https://www.elastic.co/licensing/elastic-license
 
-Posted Date: April 20, 2018
+## Acceptance
 
-This Agreement is entered into by and between Elasticsearch BV ("Elastic") and
-You, or the legal entity on behalf of whom You are acting (as applicable,
-"You").
+By using the software, you agree to all of the terms and conditions below.
 
-1. OBJECT CODE END USER LICENSES, RESTRICTIONS AND THIRD PARTY OPEN SOURCE
-SOFTWARE
+## Copyright License
 
-  1.1 Object Code End User License. Subject to the terms and conditions of
-  Section 1.2 of this Agreement, Elastic hereby grants to You, AT NO CHARGE and
-  for so long as you are not in breach of any provision of this Agreement, a
-  License to the Basic Features and Functions of the Elastic Software.
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
 
-  1.2 Reservation of Rights; Restrictions. As between Elastic and You, Elastic
-  and its licensors own all right, title and interest in and to the Elastic
-  Software, and except as expressly set forth in Sections 1.1, and 2.1 of this
-  Agreement, no other license to the Elastic Software is granted to You under
-  this Agreement, by implication, estoppel or otherwise. You agree not to: (i)
-  reverse engineer or decompile, decrypt, disassemble or otherwise reduce any
-  Elastic Software provided to You in Object Code, or any portion thereof, to
-  Source Code, except and only to the extent any such restriction is prohibited
-  by applicable law, (ii) except as expressly permitted in this Agreement,
-  prepare derivative works from, modify, copy or use the Elastic Software Object
-  Code or the Commercial Software Source Code in any manner; (iii) except as
-  expressly permitted in Section 1.1 above, transfer, sell, rent, lease,
-  distribute, sublicense, loan or otherwise transfer, Elastic Software Object
-  Code, in whole or in part, to any third party; (iv) use Elastic Software
-  Object Code for providing time-sharing services, any software-as-a-service,
-  service bureau services or as part of an application services provider or
-  other service offering (collectively, "SaaS Offering") where obtaining access
-  to the Elastic Software or the features and functions of the Elastic Software
-  is a primary reason or substantial motivation for users of the SaaS Offering
-  to access and/or use the SaaS Offering ("Prohibited SaaS Offering"); (v)
-  circumvent the limitations on use of Elastic Software provided to You in
-  Object Code format that are imposed or preserved by any License Key, or (vi)
-  alter or remove any Marks and Notices in the Elastic Software. If You have any
-  question as to whether a specific SaaS Offering constitutes a Prohibited SaaS
-  Offering, or are interested in obtaining Elastic's permission to engage in
-  commercial or non-commercial distribution of the Elastic Software, please
-  contact elastic_license@elastic.co.
+## Limitations
 
-  1.3 Third Party Open Source Software. The Commercial Software may contain or
-  be provided with third party open source libraries, components, utilities and
-  other open source software (collectively, "Open Source Software"), which Open
-  Source Software may have applicable license terms as identified on a website
-  designated by Elastic. Notwithstanding anything to the contrary herein, use of
-  the Open Source Software shall be subject to the license terms and conditions
-  applicable to such Open Source Software, to the extent required by the
-  applicable licensor (which terms shall not restrict the license rights granted
-  to You hereunder, but may contain additional rights). To the extent any
-  condition of this Agreement conflicts with any license to the Open Source
-  Software, the Open Source Software license will govern with respect to such
-  Open Source Software only. Elastic may also separately provide you with
-  certain open source software that is licensed by Elastic. Your use of such
-  Elastic open source software will not be governed by this Agreement, but by
-  the applicable open source license terms.
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
 
-2. COMMERCIAL SOFTWARE SOURCE CODE
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
 
-  2.1 Limited License. Subject to the terms and conditions of Section 2.2 of
-  this Agreement, Elastic hereby grants to You, AT NO CHARGE and for so long as
-  you are not in breach of any provision of this Agreement, a limited,
-  non-exclusive, non-transferable, fully paid up royalty free right and license
-  to the Commercial Software in Source Code format, without the right to grant
-  or authorize sublicenses, to prepare Derivative Works of the Commercial
-  Software, provided You (i) do not hack the licensing mechanism, or otherwise
-  circumvent the intended limitations on the use of Elastic Software to enable
-  features other than Basic Features and Functions or those features You are
-  entitled to as part of a Subscription, and (ii) use the resulting object code
-  only for reasonable testing purposes.
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor’s trademarks is subject
+to applicable law.
 
-  2.2 Restrictions. Nothing in Section 2.1 grants You the right to (i) use the
-  Commercial Software Source Code other than in accordance with Section 2.1
-  above, (ii) use a Derivative Work of the Commercial Software outside of a
-  Non-production Environment, in any production capacity, on a temporary or
-  permanent basis, or (iii) transfer, sell, rent, lease, distribute, sublicense,
-  loan or otherwise make available the Commercial Software Source Code, in whole
-  or in part, to any third party. Notwithstanding the foregoing, You may
-  maintain a copy of the repository in which the Source Code of the Commercial
-  Software resides and that copy may be publicly accessible, provided that you
-  include this Agreement with Your copy of the repository.
+## Patents
 
-3. TERMINATION
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
 
-  3.1 Termination. This Agreement will automatically terminate, whether or not
-  You receive notice of such Termination from Elastic, if You breach any of its
-  provisions.
+## Notices
 
-  3.2 Post Termination. Upon any termination of this Agreement, for any reason,
-  You shall promptly cease the use of the Elastic Software in Object Code format
-  and cease use of the Commercial Software in Source Code format. For the
-  avoidance of doubt, termination of this Agreement will not affect Your right
-  to use Elastic Software, in either Object Code or Source Code formats, made
-  available under the Apache License Version 2.0.
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
 
-  3.3 Survival. Sections 1.2, 2.2. 3.3, 4 and 5 shall survive any termination or
-  expiration of this Agreement.
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
 
-4. DISCLAIMER OF WARRANTIES AND LIMITATION OF LIABILITY
+## No Other Rights
 
-  4.1 Disclaimer of Warranties. TO THE MAXIMUM EXTENT PERMITTED UNDER APPLICABLE
-  LAW, THE ELASTIC SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
-  AND ELASTIC AND ITS LICENSORS MAKE NO WARRANTIES WHETHER EXPRESSED, IMPLIED OR
-  STATUTORY REGARDING OR RELATING TO THE ELASTIC SOFTWARE. TO THE MAXIMUM EXTENT
-  PERMITTED UNDER APPLICABLE LAW, ELASTIC AND ITS LICENSORS SPECIFICALLY
-  DISCLAIM ALL IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
-  PURPOSE AND NON-INFRINGEMENT WITH RESPECT TO THE ELASTIC SOFTWARE, AND WITH
-  RESPECT TO THE USE OF THE FOREGOING. FURTHER, ELASTIC DOES NOT WARRANT RESULTS
-  OF USE OR THAT THE ELASTIC SOFTWARE WILL BE ERROR FREE OR THAT THE USE OF THE
-  ELASTIC SOFTWARE WILL BE UNINTERRUPTED.
+These terms do not imply any licenses other than those expressly granted in
+these terms.
 
-  4.2 Limitation of Liability. IN NO EVENT SHALL ELASTIC OR ITS LICENSORS BE
-  LIABLE TO YOU OR ANY THIRD PARTY FOR ANY DIRECT OR INDIRECT DAMAGES,
-  INCLUDING, WITHOUT LIMITATION, FOR ANY LOSS OF PROFITS, LOSS OF USE, BUSINESS
-  INTERRUPTION, LOSS OF DATA, COST OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY
-  SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES OF ANY KIND, IN CONNECTION WITH
-  OR ARISING OUT OF THE USE OR INABILITY TO USE THE ELASTIC SOFTWARE, OR THE
-  PERFORMANCE OF OR FAILURE TO PERFORM THIS AGREEMENT, WHETHER ALLEGED AS A
-  BREACH OF CONTRACT OR TORTIOUS CONDUCT, INCLUDING NEGLIGENCE, EVEN IF ELASTIC
-  HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+## Termination
 
-5. MISCELLANEOUS
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
 
-  This Agreement completely and exclusively states the entire agreement of the
-  parties regarding the subject matter herein, and it supersedes, and its terms
-  govern, all prior proposals, agreements, or other communications between the
-  parties, oral or written, regarding such subject matter. This Agreement may be
-  modified by Elastic from time to time, and any such modifications will be
-  effective upon the "Posted Date" set forth at the top of the modified
-  Agreement. If any provision hereof is held unenforceable, this Agreement will
-  continue without said provision and be interpreted to reflect the original
-  intent of the parties. This Agreement and any non-contractual obligation
-  arising out of or in connection with it, is governed exclusively by Dutch law.
-  This Agreement shall not be governed by the 1980 UN Convention on Contracts
-  for the International Sale of Goods. All disputes arising out of or in
-  connection with this Agreement, including its existence and validity, shall be
-  resolved by the courts with jurisdiction in Amsterdam, The Netherlands, except
-  where mandatory law provides for the courts at another location in The
-  Netherlands to have jurisdiction. The parties hereby irrevocably waive any and
-  all claims and defenses either might otherwise have in any such action or
-  proceeding in any of such courts based upon any alleged lack of personal
-  jurisdiction, improper venue, forum non conveniens or any similar claim or
-  defense. A breach or threatened breach, by You of Section 2 may cause
-  irreparable harm for which damages at law may not provide adequate relief, and
-  therefore Elastic shall be entitled to seek injunctive relief without being
-  required to post a bond. You may not assign this Agreement (including by
-  operation of law in connection with a merger or acquisition), in whole or in
-  part to any third party without the prior written consent of Elastic, which
-  may be withheld or granted by Elastic in its sole and absolute discretion.
-  Any assignment in violation of the preceding sentence is void. Notices to
-  Elastic may also be sent to legal@elastic.co.
+## No Liability
 
-6. DEFINITIONS
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
 
-  The following terms have the meanings ascribed:
+## Definitions
 
-  6.1 "Affiliate" means, with respect to a party, any entity that controls, is
-  controlled by, or which is under common control with, such party, where
-  "control" means ownership of at least fifty percent (50%) of the outstanding
-  voting shares of the entity, or the contractual right to establish policy for,
-  and manage the operations of, the entity.
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
 
-  6.2 "Basic Features and Functions" means those features and functions of the
-  Elastic Software that are eligible for use under a Basic license, as set forth
-  at https://www.elastic.co/subscriptions, as may be modified by Elastic from
-  time to time.
+**you** refers to the individual or entity agreeing to these terms.
 
-  6.3 "Commercial Software" means the Elastic Software Source Code in any file
-  containing a header stating the contents are subject to the Elastic License or
-  which is contained in the repository folder labeled "x-pack", unless a LICENSE
-  file present in the directory subtree declares a different license.
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
 
-  6.4 "Derivative Work of the Commercial Software" means, for purposes of this
-  Agreement, any modification(s) or enhancement(s) to the Commercial Software,
-  which represent, as a whole, an original work of authorship.
+**your licenses** are all the licenses granted to you for the software under
+these terms.
 
-  6.5 "License" means a limited, non-exclusive, non-transferable, fully paid up,
-  royalty free, right and license, without the right to grant or authorize
-  sublicenses, solely for Your internal business operations to (i) install and
-  use the applicable Features and Functions of the Elastic Software in Object
-  Code, and (ii) permit Contractors and Your Affiliates to use the Elastic
-  software as set forth in (i) above, provided that such use by Contractors must
-  be solely for Your benefit and/or the benefit of Your Affiliates, and You
-  shall be responsible for all acts and omissions of such Contractors and
-  Affiliates in connection with their use of the Elastic software that are
-  contrary to the terms and conditions of this Agreement.
+**use** means anything you do with the software requiring one of your licenses.
 
-  6.6 "License Key" means a sequence of bytes, including but not limited to a
-  JSON blob, that is used to enable certain features and functions of the
-  Elastic Software.
-
-  6.7 "Marks and Notices" means all Elastic trademarks, trade names, logos and
-  notices present on the Documentation as originally provided by Elastic.
-
-  6.8 "Non-production Environment" means an environment for development, testing
-  or quality assurance, where software is not used for production purposes.
-
-  6.9 "Object Code" means any form resulting from mechanical transformation or
-  translation of Source Code form, including but not limited to compiled object
-  code, generated documentation, and conversions to other media types.
-
-  6.10 "Source Code" means the preferred form of computer software for making
-  modifications, including but not limited to software source code,
-  documentation source, and configuration files.
-
-  6.11 "Subscription" means the right to receive Support Services and a License
-  to the Commercial Software.
+**trademark** means trademarks, service marks, and similar rights.

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -25,14 +25,14 @@ Third party libraries used by the Support Diagnostics Utilities:
   Apache Velocity - Engine under Apache License 2.0
   Apache Velocity - JSR 223 Scripting under Apache License 2.0
   ASM based accessors helper used by json-smart under Apache License 2.0
-  ASM Core under BSD
+  ASM Core under BSD 2-Clause
   Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs under Bouncy Castle Licence
   Bouncy Castle Provider under Bouncy Castle Licence
   Extended StAX API under Dual license consisting of the CDDL v1.1 and GPL v2
   fastinfoset under Apache License 2.0
   FindBugs-jsr305 under Apache License 2.0
   Guava: Google Core Libraries for Java under Apache License 2.0
-  Hamcrest Core under New BSD License
+  Hamcrest Core under BSD 3-Clause
   istack common utility code runtime under CDDL 1.1 or GPL2 w/ CPE
   Jackson-annotations under Apache License 2.0
   Jackson-core under Apache License 2.0
@@ -47,10 +47,10 @@ Third party libraries used by the Support Diagnostics Utilities:
   JAXB Runtime under CDDL+GPL License
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   jcommander under Apache License 2.0
-  JLine under The BSD License
+  JLine under BSD 2-Clause
   Joda-Time under Apache License 2.0
   JOpt Simple under The MIT License
-  JSch under Revised BSD
+  JSch under BSD 3-Clause
   JSON library from Android SDK under Apache License 2.0
   JSON Small and Fast Parser under Apache License 2.0
   json-schema-core under Lesser General Public License, version 3 or greater or Apache License 2.0
@@ -65,7 +65,7 @@ Third party libraries used by the Support Diagnostics Utilities:
   JUnit Platform Launcher under Eclipse Public License v2.0
   JUnit Platform Surefire Provider under The Apache License 2.0
   JUnit Vintage Engine under Eclipse Public License v2.0
-  JZlib under BSD
+  JZlib under BSD 2-Clause
   libphonenumber under Apache License 2.0
   MockServer & Proxy Netty under Apache License 2.0
   MockServer Core under Apache License 2.0

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -8,54 +8,54 @@ Foundation (http://www.apache.org/).
 Third party libraries used by the Support Diagnostics Utilities:
 ================================================================
 
-  Apache Commons BeanUtils under Apache License, Version 2.0
-  Apache Commons Codec under Apache License, Version 2.0
-  Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons Compress under Apache License, Version 2.0
-  Apache Commons IO under Apache License, Version 2.0
-  Apache Commons Lang under Apache License, Version 2.0
-  Apache Commons Logging under The Apache Software License, Version 2.0
-  Apache Commons Text under Apache License, Version 2.0
-  Apache HttpClient under Apache License, Version 2.0
-  Apache HttpCore under Apache License, Version 2.0
-  Apache Log4j API under Apache License, Version 2.0
-  Apache Log4j Commons Logging Bridge under Apache License, Version 2.0
-  Apache Log4j Core under Apache License, Version 2.0
-  Apache Log4j SLF4J Binding under Apache License, Version 2.0
-  Apache Velocity - Engine under Apache License, Version 2.0
-  Apache Velocity - JSR 223 Scripting under Apache License, Version 2.0
-  ASM based accessors helper used by json-smart under The Apache Software License, Version 2.0
+  Apache Commons BeanUtils under Apache License 2.0
+  Apache Commons Codec under Apache License 2.0
+  Apache Commons Collections under Apache License 2.0
+  Apache Commons Compress under Apache License 2.0
+  Apache Commons IO under Apache License 2.0
+  Apache Commons Lang under Apache License 2.0
+  Apache Commons Logging under Apache License 2.0
+  Apache Commons Text under Apache License 2.0
+  Apache HttpClient under Apache License 2.0
+  Apache HttpCore under Apache License 2.0
+  Apache Log4j API under Apache License 2.0
+  Apache Log4j Commons Logging Bridge under Apache License 2.0
+  Apache Log4j Core under Apache License 2.0
+  Apache Log4j SLF4J Binding under Apache License 2.0
+  Apache Velocity - Engine under Apache License 2.0
+  Apache Velocity - JSR 223 Scripting under Apache License 2.0
+  ASM based accessors helper used by json-smart under Apache License 2.0
   ASM Core under BSD
   Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs under Bouncy Castle Licence
   Bouncy Castle Provider under Bouncy Castle Licence
   Extended StAX API under Dual license consisting of the CDDL v1.1 and GPL v2
-  fastinfoset under Apache License, Version 2.0
-  FindBugs-jsr305 under The Apache Software License, Version 2.0
-  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
+  fastinfoset under Apache License 2.0
+  FindBugs-jsr305 under Apache License 2.0
+  Guava: Google Core Libraries for Java under Apache License 2.0
   Hamcrest Core under New BSD License
   istack common utility code runtime under CDDL 1.1 or GPL2 w/ CPE
-  Jackson-annotations under The Apache Software License, Version 2.0
-  Jackson-core under The Apache Software License, Version 2.0
-  jackson-coreutils under Lesser General Public License, version 3 or greater or Apache Software License, version 2.0
-  jackson-databind under The Apache Software License, Version 2.0
-  Java Native Access under LGPL, version 2.1 or Apache License v2.0
-  Java Native Access Platform under LGPL, version 2.1 or Apache License v2.0
+  Jackson-annotations under Apache License 2.0
+  Jackson-core under Apache License 2.0
+  jackson-coreutils under Lesser General Public License, version 3 or greater or Apache License 2.0
+  jackson-databind under Apache License 2.0
+  Java Native Access under LGPL, version 2.1 or Apache License 2.0
+  Java Native Access Platform under LGPL, version 2.1 or Apache License 2.0
   Java Servlet API under CDDL + GPLv2 with classpath exception
   JavaBeans Activation Framework (JAF) under Common Development and Distribution License (CDDL) v1.0
   JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
   JavaMail API jar under CDDL or GPLv2+CE
   JAXB Runtime under CDDL+GPL License
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
-  jcommander under Apache License, Version 2.0
+  jcommander under Apache License 2.0
   JLine under The BSD License
-  Joda-Time under Apache 2
+  Joda-Time under Apache License 2.0
   JOpt Simple under The MIT License
   JSch under Revised BSD
   JSON library from Android SDK under Apache License 2.0
-  JSON Small and Fast Parser under The Apache Software License, Version 2.0
-  json-schema-core under Lesser General Public License, version 3 or greater or Apache Software License, version 2.0
-  json-schema-validator under Lesser General Public License, version 3 or greater or Apache Software License, version 2.0
-  JSONassert under The Apache Software License, Version 2.0
+  JSON Small and Fast Parser under Apache License 2.0
+  json-schema-core under Lesser General Public License, version 3 or greater or Apache License 2.0
+  json-schema-validator under Lesser General Public License, version 3 or greater or Apache License 2.0
+  JSONassert under Apache License 2.0
   JSR 353 (JSON Processing) Default Provider under Dual license consisting of the CDDL v1.1 and GPL v2
   JUnit under Eclipse Public License 1.0
   JUnit Jupiter API under Eclipse Public License v2.0
@@ -63,38 +63,36 @@ Third party libraries used by the Support Diagnostics Utilities:
   JUnit Platform Commons under Eclipse Public License v2.0
   JUnit Platform Engine API under Eclipse Public License v2.0
   JUnit Platform Launcher under Eclipse Public License v2.0
-  JUnit Platform Surefire Provider under The Apache License, Version 2.0
+  JUnit Platform Surefire Provider under The Apache License 2.0
   JUnit Vintage Engine under Eclipse Public License v2.0
   JZlib under BSD
-  libphonenumber under The Apache Software License, Version 2.0
-  MockServer & Proxy Netty under The Apache Software License, Version 2.0
-  MockServer Core under The Apache Software License, Version 2.0
-  MockServer Java Client under The Apache Software License, Version 2.0
+  libphonenumber under Apache License 2.0
+  MockServer & Proxy Netty under Apache License 2.0
+  MockServer Core under Apache License 2.0
+  MockServer Java Client under Apache License 2.0
   Module awt-color-factory under GNU General Public License, version 2, with the Classpath Exception
-  Module text-io under The Apache Software License, Version 2.0
+  Module text-io under Apache License 2.0
   Mozilla Rhino under Mozilla Public License, Version 2.0
-  Netty/Buffer under Apache License, Version 2.0
-  Netty/Codec under Apache License, Version 2.0
-  Netty/Codec/HTTP under Apache License, Version 2.0
-  Netty/Codec/Socks under Apache License, Version 2.0
-  Netty/Common under Apache License, Version 2.0
-  Netty/Handler under Apache License, Version 2.0
-  Netty/Handler/Proxy under Apache License, Version 2.0
-  Netty/Resolver under Apache License, Version 2.0
-  Netty/Transport under Apache License, Version 2.0
-  null under Lesser General Public License, version 3 or greater or Apache Software License, version 2.0
-  org.apiguardian:apiguardian-api under The Apache License, Version 2.0
-  org.opentest4j:opentest4j under The Apache License, Version 2.0
-  org.xmlunit:xmlunit-core under The Apache Software License, Version 2.0
+  Netty/Buffer under Apache License 2.0
+  Netty/Codec under Apache License 2.0
+  Netty/Codec/HTTP under Apache License 2.0
+  Netty/Codec/Socks under Apache License 2.0
+  Netty/Common under Apache License 2.0
+  Netty/Handler under Apache License 2.0
+  Netty/Handler/Proxy under Apache License 2.0
+  Netty/Resolver under Apache License 2.0
+  Netty/Transport under Apache License 2.0
+  org.apiguardian:apiguardian-api under The Apache License 2.0
+  org.opentest4j:opentest4j under The Apache License 2.0
+  org.xmlunit:xmlunit-core under Apache License 2.0
   oshi-core under MIT License
   oshi-json under MIT License
-  project ':json-path' under The Apache Software License, Version 2.0
+  json-path under Apache License 2.0
   semver4j under The MIT License
-  Shared Java 5 Provider Base under Apache License, Version 2.0
+  Shared Java 5 Provider Base under Apache License 2.0
   SLF4J API Module under MIT License
-  SnakeYAML under Apache License, Version 2.0
-  Support Diagnostics Utilities under Elastic License
-  SureFire API under Apache License, Version 2.0
-  SureFire Logger API under Apache License, Version 2.0
+  SnakeYAML under Apache License 2.0
+  SureFire API under Apache License 2.0
+  SureFire Logger API under Apache License 2.0
   TXW2 Runtime under CDDL+GPL License
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -5,7 +5,7 @@ This product includes software developed by The Apache Software
 Foundation (http://www.apache.org/).
 
 ================================================================
-Third party libraries used by the Support Diagnostics Utilities:
+Third party libraries used by the Support Diagnostics Utilities
 ================================================================
 
   Apache Commons BeanUtils under Apache License 2.0
@@ -96,3 +96,283 @@ Third party libraries used by the Support Diagnostics Utilities:
   SureFire Logger API under Apache License 2.0
   TXW2 Runtime under CDDL+GPL License
 
+===============================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+===============================================================================
+
+BSD 2-Clause License
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution. THIS SOFTWARE IS PROVIDED BY THE
+COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===============================================================================
+
+BSD 3-Clause License
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of Nova Generacija Softvera d.o.o. nor the names of its
+contributors may be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===============================================================================
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a 
+copy of this software and associated documentation files (the "Software"), 
+to deal in the Software without restriction, including without limitation 
+the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+and/or sell copies of the Software, and to permit persons to whom the 
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in 
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+DEALINGS IN THE SOFTWARE.
+
+===============================================================================

--- a/src/main/java/co/elastic/support/BaseConfig.java
+++ b/src/main/java/co/elastic/support/BaseConfig.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support;
 

--- a/src/main/java/co/elastic/support/BaseInputs.java
+++ b/src/main/java/co/elastic/support/BaseInputs.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support;
 

--- a/src/main/java/co/elastic/support/BaseService.java
+++ b/src/main/java/co/elastic/support/BaseService.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support;
 

--- a/src/main/java/co/elastic/support/Constants.java
+++ b/src/main/java/co/elastic/support/Constants.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support;
 

--- a/src/main/java/co/elastic/support/diagnostics/DiagConfig.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagConfig.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics;
 

--- a/src/main/java/co/elastic/support/diagnostics/DiagnosticApp.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagnosticApp.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics;
 

--- a/src/main/java/co/elastic/support/diagnostics/DiagnosticException.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagnosticException.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics;
 

--- a/src/main/java/co/elastic/support/diagnostics/DiagnosticInputs.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagnosticInputs.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics;
 

--- a/src/main/java/co/elastic/support/diagnostics/DiagnosticService.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagnosticService.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics;
 

--- a/src/main/java/co/elastic/support/diagnostics/JavaPlatform.java
+++ b/src/main/java/co/elastic/support/diagnostics/JavaPlatform.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics;
 

--- a/src/main/java/co/elastic/support/diagnostics/ProcessProfile.java
+++ b/src/main/java/co/elastic/support/diagnostics/ProcessProfile.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics;
 

--- a/src/main/java/co/elastic/support/diagnostics/ShowHelpException.java
+++ b/src/main/java/co/elastic/support/diagnostics/ShowHelpException.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics;
 

--- a/src/main/java/co/elastic/support/diagnostics/chain/Command.java
+++ b/src/main/java/co/elastic/support/diagnostics/chain/Command.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.chain;
 

--- a/src/main/java/co/elastic/support/diagnostics/chain/DiagnosticChainExec.java
+++ b/src/main/java/co/elastic/support/diagnostics/chain/DiagnosticChainExec.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.chain;
 

--- a/src/main/java/co/elastic/support/diagnostics/chain/DiagnosticContext.java
+++ b/src/main/java/co/elastic/support/diagnostics/chain/DiagnosticContext.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.chain;
 

--- a/src/main/java/co/elastic/support/diagnostics/commands/BaseQuery.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/BaseQuery.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.commands;
 

--- a/src/main/java/co/elastic/support/diagnostics/commands/CheckDiagnosticVersion.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CheckDiagnosticVersion.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.commands;
 

--- a/src/main/java/co/elastic/support/diagnostics/commands/CheckElasticsearchVersion.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CheckElasticsearchVersion.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.commands;
 

--- a/src/main/java/co/elastic/support/diagnostics/commands/CheckKibanaVersion.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CheckKibanaVersion.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.commands;
 

--- a/src/main/java/co/elastic/support/diagnostics/commands/CheckPlatformDetails.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CheckPlatformDetails.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.commands;
 

--- a/src/main/java/co/elastic/support/diagnostics/commands/CheckUserAuthLevel.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CheckUserAuthLevel.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.commands;
 

--- a/src/main/java/co/elastic/support/diagnostics/commands/CollectDockerInfo.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CollectDockerInfo.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.commands;
 

--- a/src/main/java/co/elastic/support/diagnostics/commands/CollectKibanaLogs.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CollectKibanaLogs.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.commands;
 

--- a/src/main/java/co/elastic/support/diagnostics/commands/CollectLogs.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CollectLogs.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.commands;
 

--- a/src/main/java/co/elastic/support/diagnostics/commands/CollectSystemCalls.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CollectSystemCalls.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.commands;
 

--- a/src/main/java/co/elastic/support/diagnostics/commands/GenerateManifest.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/GenerateManifest.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.commands;
 

--- a/src/main/java/co/elastic/support/diagnostics/commands/KibanaGetDetails.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/KibanaGetDetails.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.commands;
 

--- a/src/main/java/co/elastic/support/diagnostics/commands/RetrieveSystemDigest.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/RetrieveSystemDigest.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.commands;
 

--- a/src/main/java/co/elastic/support/diagnostics/commands/RunClusterQueries.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/RunClusterQueries.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.commands;
 

--- a/src/main/java/co/elastic/support/diagnostics/commands/RunKibanaQueries.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/RunKibanaQueries.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.commands;
 

--- a/src/main/java/co/elastic/support/diagnostics/commands/RunLogstashQueries.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/RunLogstashQueries.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.commands;
 

--- a/src/main/java/co/elastic/support/monitoring/MonitoringExportApp.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringExportApp.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.monitoring;
 

--- a/src/main/java/co/elastic/support/monitoring/MonitoringExportConfig.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringExportConfig.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.monitoring;
 

--- a/src/main/java/co/elastic/support/monitoring/MonitoringExportInputs.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringExportInputs.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.monitoring;
 

--- a/src/main/java/co/elastic/support/monitoring/MonitoringExportService.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringExportService.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.monitoring;
 

--- a/src/main/java/co/elastic/support/monitoring/MonitoringImportApp.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringImportApp.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.monitoring;
 

--- a/src/main/java/co/elastic/support/monitoring/MonitoringImportConfig.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringImportConfig.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.monitoring;
 

--- a/src/main/java/co/elastic/support/monitoring/MonitoringImportInputs.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringImportInputs.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.monitoring;
 

--- a/src/main/java/co/elastic/support/monitoring/MonitoringImportProcessor.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringImportProcessor.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.monitoring;
 

--- a/src/main/java/co/elastic/support/monitoring/MonitoringImportService.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringImportService.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.monitoring;
 

--- a/src/main/java/co/elastic/support/rest/ElasticRestClientInputs.java
+++ b/src/main/java/co/elastic/support/rest/ElasticRestClientInputs.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.rest;
 

--- a/src/main/java/co/elastic/support/rest/ElasticRestClientService.java
+++ b/src/main/java/co/elastic/support/rest/ElasticRestClientService.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.rest;
 

--- a/src/main/java/co/elastic/support/rest/RestClient.java
+++ b/src/main/java/co/elastic/support/rest/RestClient.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.rest;
 

--- a/src/main/java/co/elastic/support/rest/RestEntry.java
+++ b/src/main/java/co/elastic/support/rest/RestEntry.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.rest;
 

--- a/src/main/java/co/elastic/support/rest/RestEntryConfig.java
+++ b/src/main/java/co/elastic/support/rest/RestEntryConfig.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.rest;
 

--- a/src/main/java/co/elastic/support/rest/RestResult.java
+++ b/src/main/java/co/elastic/support/rest/RestResult.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.rest;
 

--- a/src/main/java/co/elastic/support/scrub/ScrubApp.java
+++ b/src/main/java/co/elastic/support/scrub/ScrubApp.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.scrub;
 

--- a/src/main/java/co/elastic/support/scrub/ScrubConfig.java
+++ b/src/main/java/co/elastic/support/scrub/ScrubConfig.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.scrub;
 

--- a/src/main/java/co/elastic/support/scrub/ScrubInputs.java
+++ b/src/main/java/co/elastic/support/scrub/ScrubInputs.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.scrub;
 

--- a/src/main/java/co/elastic/support/scrub/ScrubProcessor.java
+++ b/src/main/java/co/elastic/support/scrub/ScrubProcessor.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.scrub;
 

--- a/src/main/java/co/elastic/support/scrub/ScrubService.java
+++ b/src/main/java/co/elastic/support/scrub/ScrubService.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.scrub;
 

--- a/src/main/java/co/elastic/support/scrub/ScrubTask.java
+++ b/src/main/java/co/elastic/support/scrub/ScrubTask.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.scrub;
 

--- a/src/main/java/co/elastic/support/scrub/ScrubTokenEntry.java
+++ b/src/main/java/co/elastic/support/scrub/ScrubTokenEntry.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.scrub;
 

--- a/src/main/java/co/elastic/support/scrub/TokenGenerator.java
+++ b/src/main/java/co/elastic/support/scrub/TokenGenerator.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.scrub;
 

--- a/src/main/java/co/elastic/support/util/ArchiveEntryProcessor.java
+++ b/src/main/java/co/elastic/support/util/ArchiveEntryProcessor.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.util;
 

--- a/src/main/java/co/elastic/support/util/ArchiveUtils.java
+++ b/src/main/java/co/elastic/support/util/ArchiveUtils.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.util;
 

--- a/src/main/java/co/elastic/support/util/FileTaskEntry.java
+++ b/src/main/java/co/elastic/support/util/FileTaskEntry.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.util;
 

--- a/src/main/java/co/elastic/support/util/JsonYamlUtils.java
+++ b/src/main/java/co/elastic/support/util/JsonYamlUtils.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.util;
 

--- a/src/main/java/co/elastic/support/util/LocalSystem.java
+++ b/src/main/java/co/elastic/support/util/LocalSystem.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.util;
 

--- a/src/main/java/co/elastic/support/util/RemoteSystem.java
+++ b/src/main/java/co/elastic/support/util/RemoteSystem.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.util;
 

--- a/src/main/java/co/elastic/support/util/RemoteUserInfo.java
+++ b/src/main/java/co/elastic/support/util/RemoteUserInfo.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.util;
 

--- a/src/main/java/co/elastic/support/util/ResourceCache.java
+++ b/src/main/java/co/elastic/support/util/ResourceCache.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.util;
 

--- a/src/main/java/co/elastic/support/util/SystemCommand.java
+++ b/src/main/java/co/elastic/support/util/SystemCommand.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.util;
 

--- a/src/main/java/co/elastic/support/util/SystemProperties.java
+++ b/src/main/java/co/elastic/support/util/SystemProperties.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.util;
 

--- a/src/main/java/co/elastic/support/util/SystemUtils.java
+++ b/src/main/java/co/elastic/support/util/SystemUtils.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.util;
 

--- a/src/main/java/co/elastic/support/util/TaskEntry.java
+++ b/src/main/java/co/elastic/support/util/TaskEntry.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.util;
 

--- a/src/main/java/co/elastic/support/util/TextIOManager.java
+++ b/src/main/java/co/elastic/support/util/TextIOManager.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
+ */
 package co.elastic.support.util;
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one

--- a/src/main/java/co/elastic/support/util/UrlUtils.java
+++ b/src/main/java/co/elastic/support/util/UrlUtils.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.util;
 

--- a/src/main/java/co/elastic/support/util/ZipFileTaskEntry.java
+++ b/src/main/java/co/elastic/support/util/ZipFileTaskEntry.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.util;
 

--- a/src/test/java/co/elastic/support/diagnostics/TestDiagnosticService.java
+++ b/src/test/java/co/elastic/support/diagnostics/TestDiagnosticService.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics;
 

--- a/src/test/java/co/elastic/support/diagnostics/commands/TestCheckKibanaVersion.java
+++ b/src/test/java/co/elastic/support/diagnostics/commands/TestCheckKibanaVersion.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.commands;
 

--- a/src/test/java/co/elastic/support/diagnostics/commands/TestKibanaGetDetails.java
+++ b/src/test/java/co/elastic/support/diagnostics/commands/TestKibanaGetDetails.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.commands;
 

--- a/src/test/java/co/elastic/support/diagnostics/commands/TestRunKibanaQueries.java
+++ b/src/test/java/co/elastic/support/diagnostics/commands/TestRunKibanaQueries.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.diagnostics.commands;
 

--- a/src/test/java/co/elastic/support/rest/TestRestConfigFileValidity.java
+++ b/src/test/java/co/elastic/support/rest/TestRestConfigFileValidity.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.rest;
 

--- a/src/test/java/co/elastic/support/rest/TestRestExecCalls.java
+++ b/src/test/java/co/elastic/support/rest/TestRestExecCalls.java
@@ -1,7 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ *  or more contributor license agreements. Licensed under the Elastic License
+ *  2.0; you may not use this file except in compliance with the Elastic License
+ *  2.0.
  */
 package co.elastic.support.rest;
 


### PR DESCRIPTION
The source header was wrong, it was using the unversioned header. It should explicitly say it's ELv2.

Also updated `NOTICE.txt` manually to make license names consistent and added the full text of some.