### PR TITLE
double ampersand in cat_indices call

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -53,7 +53,7 @@ cat_indices:
     ">= 0.9.0 < 5.1.1": "/_cat/indices?v"
     ">= 5.1.1 < 6.7.0": "/_cat/indices?v&s=index"
     ">= 6.7.0 < 7.7.0": "/_cat/indices?v&s&h=health,status,index,uuid,pri,rep,docs.count,docs.deleted,store.size,pri.store.size,sth"
-    ">= 7.7.0": "/_cat/indices?v&&h=health,status,index,uuid,pri,rep,docs.count,docs.deleted,store.size,pri.store.size,sth&expand_wildcards=all"
+    ">= 7.7.0": "/_cat/indices?v&s=index&h=health,status,index,uuid,pri,rep,docs.count,docs.deleted,store.size,pri.store.size,sth&expand_wildcards=all"
 
 cat_master:
   extension: ".txt"


### PR DESCRIPTION
i have included the s=index which i guess it was missing, and also fixed the double ampersand that didn't look good