### PR TITLE
Trim 'v' from GitHub tag name

### DIFF
--- a/src/main/java/co/elastic/support/diagnostics/commands/CheckDiagnosticVersion.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CheckDiagnosticVersion.java
@@ -76,7 +76,9 @@ public class CheckDiagnosticVersion implements Command {
             RestResult restResult = new RestResult(restClient.execGet(
                     context.diagsConfig.diagLatestRelease), context.diagsConfig.diagLatestRelease);
             JsonNode rootNode = JsonYamlUtils.createJsonNodeFromString(restResult.toString());
-            String ver = rootNode.path("tag_name").asText();
+            // newer tags are prefixed with `v`, so remove it
+            String ver = rootNode.path("tag_name").asText().replaceAll("^v", "");
+
             Semver diagVer = new Semver(context.diagVersion, Semver.SemverType.NPM);
             String rule = ">= " + ver;
 


### PR DESCRIPTION
This trims the leading 'v' from the version number in the Git tag
so that the semver comparison works.

Closes https://github.com/elastic/support-diagnostics/issues/518