### PR TITLE
Add "_snapshot" request for 7.15

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -284,6 +284,10 @@ shards:
   versions:
     ">=0.9.0": "/_cat/shards?format=json&bytes=b&pretty"
 
+snapshot:
+  versions:
+    ">=7.15.0": "/_snapshot/*/*?verbose=false"
+
 tasks:
   versions:
     ">=2.0.0": "/_tasks?pretty&human&detailed=true"


### PR DESCRIPTION
This adds the new API that becomes available in 7.15.

Closes https://github.com/elastic/support-diagnostics/issues/521