### PR TITLE
Add textIOManager to add parseInputs

### DIFF
--- a/src/main/java/co/elastic/support/BaseInputs.java
+++ b/src/main/java/co/elastic/support/BaseInputs.java
@@ -63,7 +63,7 @@ public abstract class BaseInputs {
 
     public abstract boolean runInteractive(TextIOManager textIOManager);
 
-    public List<String> parseInputs(String[] args){
+    public List<String> parseInputs(TextIOManager textIOManager, String[] args){
         logger.info(Constants.CONSOLE, "Processing diagnosticInputs...");
         jCommander = new JCommander(this);
         jCommander.setCaseSensitiveOptions(true);

--- a/src/main/java/co/elastic/support/diagnostics/DiagnosticApp.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagnosticApp.java
@@ -33,7 +33,7 @@ public class DiagnosticApp {
                 diagnosticInputs.interactive = true;
                 diagnosticInputs.runInteractive(textIOManager);
             } else {
-                List<String> errors = diagnosticInputs.parseInputs(args);
+                List<String> errors = diagnosticInputs.parseInputs(textIOManager, args);
                 if (errors.size() > 0) {
                     for (String err : errors) {
                         logger.error(Constants.CONSOLE, err);
@@ -60,4 +60,3 @@ public class DiagnosticApp {
 
 
 }
-

--- a/src/main/java/co/elastic/support/diagnostics/DiagnosticInputs.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagnosticInputs.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 public class DiagnosticInputs extends ElasticRestClientInputs {
 
-    
+
     public final static String[]
             diagnosticTypeValues = {
             Constants.local,
@@ -234,8 +234,9 @@ public class DiagnosticInputs extends ElasticRestClientInputs {
         return true;
     }
 
+    @Override
     public List<String> parseInputs(TextIOManager textIOManager, String[] args){
-        List<String> errors = super.parseInputs(args);
+        List<String> errors = super.parseInputs(textIOManager, args);
 
         errors.addAll(ObjectUtils.defaultIfNull(validateDiagType(diagType), emptyList));
         errors.addAll(ObjectUtils.defaultIfNull(setDefaultPortForDiagType(diagType), emptyList));

--- a/src/main/java/co/elastic/support/monitoring/MonitoringExportApp.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringExportApp.java
@@ -22,18 +22,14 @@ public class MonitoringExportApp {
 
     public static void main(String[] args) {
 
-        try {
+        try (TextIOManager textIOManager = new TextIOManager()) {
             MonitoringExportInputs monitoringExportInputs = new MonitoringExportInputs();
             if (args.length == 0) {
                 logger.info(Constants.CONSOLE,  Constants.interactiveMsg);
                 monitoringExportInputs.interactive = true;
-                try(
-                    TextIOManager textIOManager = new TextIOManager();
-                ) {
-                    monitoringExportInputs.runInteractive(textIOManager);
-                }
+                monitoringExportInputs.runInteractive(textIOManager);
             } else {
-                List<String> errors = monitoringExportInputs.parseInputs(args);
+                List<String> errors = monitoringExportInputs.parseInputs(textIOManager, args);
                 if (errors.size() > 0) {
                     for (String err : errors) {
                         logger.error(Constants.CONSOLE, err);

--- a/src/main/java/co/elastic/support/monitoring/MonitoringExportInputs.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringExportInputs.java
@@ -98,9 +98,9 @@ public class MonitoringExportInputs extends ElasticRestClientInputs {
         return true;
     }
 
-    public List<String> parseInputs(String[] args) {
-
-        List<String> errors = super.parseInputs(args);
+    @Override
+    public List<String> parseInputs(TextIOManager textIOManager, String[] args) {
+        List<String> errors = super.parseInputs(textIOManager, args);
 
         if (!listClusters) {
             errors.addAll(ObjectUtils.defaultIfNull(validateCluster(clusterId), emptyList));
@@ -109,7 +109,6 @@ public class MonitoringExportInputs extends ElasticRestClientInputs {
         }
 
         return errors;
-
     }
 
     public List<String> validateTimeWindow(){

--- a/src/main/java/co/elastic/support/monitoring/MonitoringImportApp.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringImportApp.java
@@ -31,7 +31,7 @@ public class MonitoringImportApp {
                 monitoringImportInputs.interactive = true;
                 monitoringImportInputs.runInteractive(textIOManager);
             } else {
-                List<String> errors = monitoringImportInputs.parseInputs(args);
+                List<String> errors = monitoringImportInputs.parseInputs(textIOManager, args);
                 if (errors.size() > 0) {
                     for (String err : errors) {
                         logger.error(Constants.CONSOLE,  err);

--- a/src/main/java/co/elastic/support/monitoring/MonitoringImportInputs.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringImportInputs.java
@@ -58,15 +58,14 @@ public class MonitoringImportInputs extends ElasticRestClientInputs {
         return true;
     }
 
-    public List<String> parseInputs(String[] args){
-
-        List<String> errors = super.parseInputs(args);
+    @Override
+    public List<String> parseInputs(TextIOManager textIOManager, String[] args){
+        List<String> errors = super.parseInputs(textIOManager, args);
 
         errors.addAll(ObjectUtils.defaultIfNull(validateId(clusterName), emptyList));
         errors.addAll(ObjectUtils.defaultIfNull(validateRequiredFile(input), emptyList));
 
         return errors;
-
     }
 
     public List<String> validateId(String val){

--- a/src/main/java/co/elastic/support/rest/ElasticRestClientInputs.java
+++ b/src/main/java/co/elastic/support/rest/ElasticRestClientInputs.java
@@ -99,8 +99,9 @@ public abstract class ElasticRestClientInputs extends BaseInputs {
         }
     }
 
+    @Override
     public List<String> parseInputs(TextIOManager textIOManager, String args[]){
-        List<String> errors = super.parseInputs(args);
+        List<String> errors = super.parseInputs(textIOManager, args);
         scheme = isSsl ? "https": "http";
 
         errors.addAll(ObjectUtils.defaultIfNull(validateHost(host), emptyList));
@@ -114,8 +115,8 @@ public abstract class ElasticRestClientInputs extends BaseInputs {
 
         // If we got this far, get the passwords.
         if(isPassword){
-                password = textIOManager.standardPasswordReader
-                        .read(passwordDescription);
+            password = textIOManager.standardPasswordReader
+                    .read(passwordDescription);
         }
 
         if(StringUtils.isNotEmpty(pkiKeystore)){
@@ -133,7 +134,6 @@ public abstract class ElasticRestClientInputs extends BaseInputs {
         }
 
         return errors;
-
     }
 
     protected void runHttpInteractive(TextIOManager textIOManager){

--- a/src/main/java/co/elastic/support/scrub/ScrubApp.java
+++ b/src/main/java/co/elastic/support/scrub/ScrubApp.java
@@ -32,7 +32,7 @@ public class ScrubApp {
                 scrubInputs.interactive = true;
                 scrubInputs.runInteractive(textIOManager);
             } else {
-                List<String> errors = scrubInputs.parseIinputs(args);
+                List<String> errors = scrubInputs.parseInputs(textIOManager, args);
                 if (errors.size() > 0) {
                     for (String err : errors) {
                         logger.error(Constants.CONSOLE,  err);

--- a/src/main/java/co/elastic/support/scrub/ScrubInputs.java
+++ b/src/main/java/co/elastic/support/scrub/ScrubInputs.java
@@ -64,8 +64,9 @@ public class ScrubInputs extends BaseInputs {
         return true;
     }
 
-    public List<String> parseIinputs(String[] args) {
-        List<String> errors = super.parseInputs(args);
+    @Override
+    public List<String> parseInputs(TextIOManager textIOManager, String[] args) {
+        List<String> errors = super.parseInputs(textIOManager, args);
 
         List valid = validateScrubInput(scrub);
         if(valid != null){


### PR DESCRIPTION
This adds `@Override` to all `parseInputs` methods to guarantee that they're overriding the root implementation rather than serving as overloads that were going uninvoked.

The root failure of _not_ doing that was that inputs that required user inputs were not triggered (e.g., `-p`).

This also fixes a typo in the ScrubApp's version.