### PR TITLE
Update commons-io from 2.6 to 2.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.11.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This updates` commons-io` to the latest release.