### PR TITLE
+SSL Cert API Request

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -288,6 +288,11 @@ snapshot:
   versions:
     ">=7.15.0": "/_snapshot/*/*?verbose=false"
 
+ssl_certs:
+  versions:
+    ">= 6.2.0 < 7.0.0": "/_xpack/ssl/certificates"
+    ">= 7.0.0": "/_ssl/certificates"
+
 tasks:
   versions:
     ">=2.0.0": "/_tasks?pretty&human&detailed=true"


### PR DESCRIPTION
Adds API Request to [SSL Cert](https://www.elastic.co/guide/en/elasticsearch/reference/7.15/security-api-ssl.html#security-api-ssl-example) which wouldn't catch ALL but would help to discern certificate `expiry` or expiration dates to compare to forwarded logs.