### PR TITLE
+ilmExplainOnlyErrors

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -342,7 +342,7 @@ ilm_explain:
   versions:
     ">= 6.6.0": "/*/_ilm/explain?human&pretty"
 
-ilm_explain_errors:
+ilm_explain_only_errors:
   subdir: "commercial"
   versions:
     ">= 7.4.0": "/*/_ilm/explain?only_errors=true&human&pretty"

--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -342,6 +342,11 @@ ilm_explain:
   versions:
     ">= 6.6.0": "/*/_ilm/explain?human&pretty"
 
+ilm_explain_errors:
+  subdir: "commercial"
+  versions:
+    ">= 7.4.0": "/*/_ilm/explain?only_errors=true&human&pretty"
+
 ilm_policies:
   subdir: "commercial"
   versions:


### PR DESCRIPTION
ILM explain created in 6.6, but starting 7.4 there's a `only_errors=true` flag which would help narrow down into erring ILM explains a lot faster for users.

🙏🏼 When users ask for help with ILM errors we get the entire ILM explain file which sometimes breaks out
- 1-2/100 have errors => search for string `"step" : "ERROR"`
- 99/100 have errors => if so, usually same root config issue & can kick out all at once
- 30/100 have errors => copy file, {Python JSON, manually} lookup to filter `ilm_explain.json` into a sub file `ilm_explain_errors.json` to actually work from.

In my today example, my Python script wasn't working for some reason, so I just manually narrowed in from 700 indices to 32 which took about 25mins.

