### PR TITLE
Add geoip stats API request

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -198,6 +198,10 @@ fielddata_stats:
     ">= 0.9.0 < 5.0.0": "/_nodes/stats/indices/fielddata?pretty=true&fields=*"
     ">= 5.0.0": "/_nodes/stats/indices/fielddata?level=shards&pretty=true&fields=*"
 
+geoip_stats:
+  versions:
+    ">= 7.13.0": "/_ingest/geoip/stats?pretty"
+
 index_templates:
   retry: true
   versions:


### PR DESCRIPTION
[GeoIP stats endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/7.13/geoip-stats-api.html) has been included since 7.13.0 under https://github.com/elastic/elasticsearch/pull/70282
It gets download statistics for GeoIP2 databases used with the geoip processor, which is useful for troubleshooting.

Resolves https://github.com/elastic/support-diagnostics/issues/549