### PR TITLE
Add leading / to elastic rest endpoints which were missing it.

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -477,14 +477,14 @@ slm_status:
 transform:
   subdir: "commercial"
   versions:
-    ">= 7.2.0 < 7.5.0": "_data_frame/transforms?pretty"
-    ">= 7.5.0": "_transform?pretty"
+    ">= 7.2.0 < 7.5.0": "/_data_frame/transforms?pretty"
+    ">= 7.5.0": "/_transform?pretty"
 
 transform_stats:
   subdir: "commercial"
   versions:
-    ">= 7.2.0 < 7.5.0": "_data_frame/transforms/_stats?pretty"
-    ">= 7.5.0": "_transform/_stats?pretty"
+    ">= 7.2.0 < 7.5.0": "/_data_frame/transforms/_stats?pretty"
+    ">= 7.5.0": "/_transform/_stats?pretty"
 
 watcher_stats:
   subdir: "commercial"

--- a/src/test/java/co/elastic/support/rest/TestRestConfigFileValidity.java
+++ b/src/test/java/co/elastic/support/rest/TestRestConfigFileValidity.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Map;
 
 import static org.junit.Assert.*;
@@ -21,20 +22,20 @@ public class TestRestConfigFileValidity {
 
     private static final Logger logger = LogManager.getLogger(TestRestConfigFileValidity.class);
 
-    protected static Semver sem= new Semver("9.9.999", Semver.SemverType.NPM);
+    protected static Semver sem = new Semver("9.9.999", Semver.SemverType.NPM);
 
     @Test
     public void validateElasticConfigVersioning() throws DiagnosticException {
-        // validates whether each set of version entries has exactly one valid outcome.
-        Map<String, Object> restEntriesConfig = JsonYamlUtils.readYamlFromClasspath("elastic-rest.yml", true);
-        validateEntries(restEntriesConfig);
-        restEntriesConfig = JsonYamlUtils.readYamlFromClasspath("logstash-rest.yml", true);
-        validateEntries(restEntriesConfig);
+        // validates each set of version entries.
+        for (String yamlfile : Arrays.asList("elastic-rest.yml", "logstash-rest.yml", "kibana-rest.yml", "monitoring-rest.yml")) {
+            Map<String, Object> restEntriesConfig = JsonYamlUtils.readYamlFromClasspath(yamlfile, true);
+            validateEntries(restEntriesConfig);
+        }
     }
 
 
     private void validateEntries(Map<String, Object> config) {
-        for( Map.Entry<String, Object>entry : config.entrySet() ) {
+        for (Map.Entry<String, Object> entry : config.entrySet()) {
 
             Map<String, Object> values = (Map) entry.getValue();
 
@@ -42,14 +43,16 @@ public class TestRestConfigFileValidity {
 
             int nbrValid = 0;
 
+            // Urls should have a leading /
             // For each entry there should be only 1 valid url.
             for (Map.Entry<String, String> url : urls.entrySet()) {
+                assertTrue(url.getValue(), url.getValue().startsWith("/"));
                 if (sem.satisfies(url.getKey())) {
                     nbrValid++;
                 }
             }
 
-            assertTrue( nbrValid == 1 );
+            assertTrue(nbrValid == 1);
 
         }
 


### PR DESCRIPTION
## Description

The two ES endpoints related to transforms are not retrieved properly when the tool is used in library-mode. It turns out that they are the only ones missing a leading / in the configuration file `elastic-rest.yml`.
This PR adds the leading / and adds a related check to `TestRestConfigFileValidity.java`.