### PR TITLE
feature: retrieve disk usage via _disk_usage API

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -189,6 +189,10 @@ dangling_indices:
   versions:
     ">= 7.9.0": "/_dangling?pretty&human"
 
+disk_usage:
+  versions:
+    ">= 7.15.0": "/*/_disk_usage?run_expensive_tasks=true&flush=false&ignore_unavailable=true"
+
 fielddata:
   versions:
     ">= 0.9.0": "/_cat/fielddata?format=json&bytes&pretty"


### PR DESCRIPTION
Add the new [_disk_usage](https://www.elastic.co/guide/en/elasticsearch/reference/7.15/indices-disk-usage.html) endpoint for Elasticsearch 