### PR TITLE
close #562 - fix message when running bash file from sources

### DIFF
--- a/scripts/diagnostics.sh
+++ b/scripts/diagnostics.sh
@@ -5,9 +5,13 @@ scriptDir="${scriptDir/\/diagnostics.sh/$''}"
 libDir="$scriptDir"'/lib'
 
 if [ ! -d "$libDir" ]; then
-    echo "Runtimes library does not exist - make sure you are running the "
-    echo "archive with 'dist-' in the name, not the one labeled: 'source'."
-    exit
+    echo "Diagnostic executable not found:"
+    echo ""
+    echo "Please make sure that you are running with the archive ending with"
+    echo "'-dist.zip' in the name and not the one labeled 'Source code'."
+    echo ""
+    echo "Download at https://github.com/elastic/support-diagnostics/releases/latest"
+    exit 400
 fi
 
 if [ -x "${JAVA_HOME}/bin/java" ]; then

--- a/scripts/diagnostics.sh
+++ b/scripts/diagnostics.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 
-scriptDir=$0
-scriptDir=${scriptDir/\/diagnostics.sh/$''}
-libDir=$scriptDir'/lib'
+scriptDir="$0"
+scriptDir="${scriptDir/\/diagnostics.sh/$''}"
+libDir="$scriptDir"'/lib'
 
-if [  -d "libDir" ]; then
+if [ ! -d "$libDir" ]; then
     echo "Runtimes library does not exist - make sure you are running the "
     echo "archive with 'dist-' in the name, not the one labeled: 'source'."
     exit
 fi
 
-if [ -x "$JAVA_HOME/bin/java" ]; then
-    JAVA="$JAVA_HOME/bin/java"
+if [ -x "${JAVA_HOME}/bin/java" ]; then
+    JAVA="${JAVA_HOME}/bin/java"
 else
     JAVA=`which java`
 fi
@@ -23,9 +23,9 @@ if [ ! -x "$JAVA" ]; then
     exit 1
 fi
 
-[[ ${DIAG_DEBUG} != "" ]] && export DIAG_DEBUG_OPTS=" -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=y"
+[[ "${DIAG_DEBUG}" != "" ]] && export DIAG_DEBUG_OPTS=" -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=y"
 
-[[ ${DIAG_JAVA_OPTS} == "" ]] && export DIAG_JAVA_OPTS="-Xms256m -Xmx2000m"
+[[ "${DIAG_JAVA_OPTS}" == "" ]] && export DIAG_JAVA_OPTS="-Xms256m -Xmx2000m"
 
 echo "Using ${DIAG_JAVA_OPTS} ${DIAG_DEBUG_OPTS} for options."
-"$JAVA" $DIAG_JAVA_OPTS ${DIAG_DEBUG_OPTS} -cp ${scriptDir}/config:${scriptDir}/lib/* co.elastic.support.diagnostics.DiagnosticApp "$@"
+"$JAVA" $DIAG_JAVA_OPTS ${DIAG_DEBUG_OPTS} -cp "${scriptDir}/config:${scriptDir}/lib/*" co.elastic.support.diagnostics.DiagnosticApp "$@"


### PR DESCRIPTION
This code fixes incorrect check for lib directory for `diagnostics.sh`

I also added double quotes for variables that contain a path to prevent globing and word splitting.