### PR TITLE
changed  version check error message to warning.

### DIFF
--- a/src/main/java/co/elastic/support/rest/RestEntryConfig.java
+++ b/src/main/java/co/elastic/support/rest/RestEntryConfig.java
@@ -28,7 +28,7 @@ public class RestEntryConfig {
         for(Map.Entry<String, Object> entry: config.entrySet()){
             RestEntry re = build(entry);
             if(re.getUrl().equals(RestEntry.MISSING) ){
-                logger.error( "{} was bypassed due by version check.", re.getName());
+                logger.warn( "{} was bypassed due by version check.", re.getName());
             }
             else{
                 entries.put(re.getName(), re);


### PR DESCRIPTION
A user ran into this message `was bypassed due by version check` and asked me if this was of any concern.
I think the log type can be relaxed to `warn` perhaps?