### PR TITLE
Collect all data streams (including system/hidden ones)

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -515,3 +515,4 @@ data_stream:
   subdir: "commercial"
   versions:
     ">= 7.9.0": "/_data_stream?pretty"
+    ">= 7.11.0": "/_data_stream?pretty&expand_wildcards=all"


### PR DESCRIPTION
Adjust the collection of `_data_stream` to get also hidden/system indices.

This is particularly useful for 8.0 where some system data is in hidden/system data streams instead of normal indices