### PR TITLE
Append Kibana Security APIs

### DIFF
--- a/src/main/resources/kibana-rest.yml
+++ b/src/main/resources/kibana-rest.yml
@@ -40,7 +40,7 @@ kibana_roles:
 
 kibana_spaces:
   versions:
-    ">= 6.4.0": "/api/spaces/space?include_authorized_purposes=true"
+    ">= 6.5.0": "/api/spaces/space"
 
 kibana_settings:
   versions:
@@ -57,3 +57,4 @@ kibana_task_manager_help:
 kibana_user:
   versions:
     ">= 7.6.0": "/internal/security/me"
+    ">= 5.0.0 < 7.6.0": "/api/security/v1/me"

--- a/src/main/resources/kibana-rest.yml
+++ b/src/main/resources/kibana-rest.yml
@@ -34,6 +34,14 @@ kibana_detection_engine_signals:
   versions:
     "> 7.10.0": "/api/detection_engine/prepackaged"
 
+kibana_roles:
+  versions:
+    ">= 6.4.0": "/api/security/role"
+
+kibana_spaces:
+  versions:
+    ">= 6.4.0": "/api/spaces/space?include_authorized_purposes=true"
+
 kibana_settings:
   versions:
     ">= 6.5.0 < 8.0.0": "/api/settings"
@@ -45,3 +53,7 @@ kibana_stats:
 kibana_task_manager_help:
   versions:
     ">= 7.11.0": "/api/task_manager/_health"
+
+kibana_user:
+  versions:
+    ">= 7.6.0": "/internal/security/me"


### PR DESCRIPTION
@pmuellr @jportner to better introspect Kibana Security/Space issues, adds APIs into Kibana diagnostic: 
- [List Kibana Roles](https://www.elastic.co/guide/en/kibana/current/role-management-api-get.html)
- [List Kibana Spaces](https://www.elastic.co/guide/en/kibana/current/spaces-api-get-all.html)
    - Enables some introspection to mitigate [this](https://github.com/elastic/support-diagnostics/issues/578)'s impact.
- Get Current Kibana User
    - URL marks internal, but this is documented [here](https://github.com/elastic/support-diagnostics/issues/479#issuecomment-825148583) & is frequently used to diagnose Kibana permission issues.

Kindly review
1. If endpoints return user private/sensitive data.
2. Initial available versions.
    - I pulled via Github search / oldest doc, but there's been a lot of migrations to pinpoint oldest well.

cc: @pickypg