### PR TITLE
Add Runner to Manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>co.elastic.support</groupId>
     <artifactId>diagnostics</artifactId>
-    <version>8.2.9-SNAPSHOT</version>
+    <version>8.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Support Diagnostics Utilities</name>
     <description>Elastic Support Diagnostics Utilities</description>

--- a/src/main/java/co/elastic/support/BaseConfig.java
+++ b/src/main/java/co/elastic/support/BaseConfig.java
@@ -34,7 +34,6 @@ public class BaseConfig {
     protected Map configuration;
 
     public BaseConfig(Map configuration) {
-
         this.configuration = configuration;
 
         Map<String, String> githubSettings = (Map<String, String>) configuration.get("github-settings");
@@ -69,13 +68,10 @@ public class BaseConfig {
         extraHeaders = (Map<String, String>) configuration.get("extra-headers");
 
         dockerGlobal = (Map<String, String>) configuration.get("docker-global");
-        //kubernates = (Map<String, String>) configuration.get("kuberantes");
 
         dockerContainer = (Map<String, String>) configuration.get("docker-container");
         dockerContainerIds = (String) configuration.get("docker-container-ids");
         dockerExecutablePath = (String) configuration.get("docker-executable-location");
-
-
     }
 
 }

--- a/src/main/java/co/elastic/support/diagnostics/DiagConfig.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagConfig.java
@@ -13,13 +13,11 @@ import org.apache.logging.log4j.Logger;
 import java.util.Map;
 
 public class DiagConfig extends BaseConfig {
-
     private static Logger logger = LogManager.getLogger(DiagConfig.class);
 
-
     public int callRetries, pauseRetries, maxLogs, maxGcLogs;
-    public DiagConfig(Map configuration) {
 
+    public DiagConfig(Map configuration) {
         super(configuration);
 
         // When we retry a failed call how many times, and how long to wait before reattempting.
@@ -30,7 +28,6 @@ public class DiagConfig extends BaseConfig {
         Map<String, Integer> logSettings = (Map<String, Integer>) configuration.get("log-settings");
         maxGcLogs = logSettings.get("maxGcLogs");
         maxLogs = logSettings.get("maxLogs");
-
     }
 
     public Map<String, Map<String, String>> getSysCalls(String key){
@@ -38,4 +35,3 @@ public class DiagConfig extends BaseConfig {
     }
 
 }
-

--- a/src/main/java/co/elastic/support/diagnostics/DiagnosticApp.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagnosticApp.java
@@ -27,7 +27,7 @@ public class DiagnosticApp {
             ResourceCache resourceCache = new ResourceCache();
             TextIOManager textIOManager = new TextIOManager();
         ) {
-            DiagnosticInputs diagnosticInputs = new DiagnosticInputs();
+            DiagnosticInputs diagnosticInputs = new DiagnosticInputs("cli");
             if (args.length == 0) {
                 logger.info(Constants.CONSOLE, Constants.interactiveMsg);
                 diagnosticInputs.interactive = true;

--- a/src/main/java/co/elastic/support/diagnostics/DiagnosticInputs.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagnosticInputs.java
@@ -139,19 +139,28 @@ public class DiagnosticInputs extends ElasticRestClientInputs {
     public int remotePort = 22;
     // End Input Fields
 
+    /**
+     * The `runner` represents what ran the diagnostic. It defaults to
+     * `"unknown"` if unset.
+     */
+    public String runner = "unknown";
+
     String[] typeEntries;
 
-    public DiagnosticInputs(){
-        if(runningInDocker){
-            typeEntries = diagnosticTypeEntriesDocker;
-        }
-        else{
-            typeEntries = diagnosticTypeEntries;
-        }
+    public DiagnosticInputs() {
+        this.typeEntries =
+          runningInDocker ?
+            diagnosticTypeEntriesDocker :
+            diagnosticTypeEntries;
+    }
+
+    public DiagnosticInputs(String runner) {
+        this();
+
+        this.runner = runner;
     }
 
     public boolean runInteractive(TextIOManager textIOManager) {
-
         bypassDiagVerify = textIOManager.standardBooleanReader
                 .withDefaultValue(bypassDiagVerify)
                 .read(SystemProperties.lineSeparator + bypassDiagVerifyDescription);
@@ -316,6 +325,7 @@ public class DiagnosticInputs extends ElasticRestClientInputs {
                 ", knownHostsFile='" + knownHostsFile + '\'' +
                 ", sudo=" + isSudo + '\'' +
                 ", remotePort=" + remotePort +
+                ", runner='" + runner + "'" +
                 '}';
     }
 }

--- a/src/main/java/co/elastic/support/diagnostics/commands/GenerateManifest.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/GenerateManifest.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.TimeZone;
 
 public class GenerateManifest implements Command {
-
    /**
     * Generate a manifest containing the basic runtime info for the diagnostic runtime.
     * Some of the values we get, like the Diagnostic version will be used again
@@ -42,24 +41,16 @@ public class GenerateManifest implements Command {
 
          Map<String, Object> manifest = new HashMap<>();
 
-         String diagVersion = context.diagVersion;
-         manifest.put(Constants.DIAG_VERSION, diagVersion);
+         manifest.put(Constants.DIAG_VERSION, context.diagVersion);
          manifest.put("Product Version", context.version);
          manifest.put("collectionDate", SystemProperties.getUtcDateTimeString());
          manifest.put("diagnosticInputs", context.diagnosticInputs.toString());
+         manifest.put("runner", context.diagnosticInputs.runner);
 
          File manifestFile = new File(context.tempDir + SystemProperties.fileSeparator + "manifest.json");
          mapper.writeValue(manifestFile, manifest);
       } catch (Exception e) {
          logger.info(Constants.CONSOLE, "Error creating the manifest file", e);
       }
-   }
-
-   public String getIsoDate() {
-      TimeZone tz = TimeZone.getTimeZone("UTC");
-      DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mmZ");
-      df.setTimeZone(tz);
-      String nowAsISO = df.format(new Date());
-      return nowAsISO;
    }
 }

--- a/src/main/java/co/elastic/support/util/SystemProperties.java
+++ b/src/main/java/co/elastic/support/util/SystemProperties.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Level;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 public class SystemProperties {
 
@@ -33,25 +34,28 @@ public class SystemProperties {
 
    public static final String UTC_DATE_FORMAT = "yyyy-MM-dd";
 
-   public static final String UTC_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+   public static final String UTC_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
 
    public static final String FILE_DATE_FORMAT = "yyyyMMdd-HHmmss";
 
    public static String getUtcDateString() {
       Date curDate = new Date();
       SimpleDateFormat format = new SimpleDateFormat(UTC_DATE_FORMAT);
+      format.setTimeZone(TimeZone.getTimeZone("UTC"));
       return format.format(curDate);
    }
 
    public static String getUtcDateTimeString() {
       Date curDate = new Date();
       SimpleDateFormat format = new SimpleDateFormat(UTC_DATE_TIME_FORMAT);
+      format.setTimeZone(TimeZone.getTimeZone("UTC"));
       return format.format(curDate);
    }
 
    public static String getFileDateString() {
       Date curDate = new Date();
       SimpleDateFormat format = new SimpleDateFormat(FILE_DATE_FORMAT);
+      format.setTimeZone(TimeZone.getTimeZone("UTC"));
       return format.format(curDate);
    }
 }

--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -514,5 +514,5 @@ xpack:
 data_stream:
   subdir: "commercial"
   versions:
-    ">= 7.9.0": "/_data_stream?pretty"
+    ">= 7.9.0 < 7.11.0": "/_data_stream?pretty"
     ">= 7.11.0": "/_data_stream?pretty&expand_wildcards=all"

--- a/src/test/java/co/elastic/support/diagnostics/commands/TestKibanaGetDetails.java
+++ b/src/test/java/co/elastic/support/diagnostics/commands/TestKibanaGetDetails.java
@@ -51,10 +51,10 @@ public class TestKibanaGetDetails {
 
     @BeforeEach
     public void setup() {
-        
+
         httpRestClient = RestClient.getClient(
-            "localhost", 
-            9880, 
+            "localhost",
+            9880,
             "http",
             "elastic",
             "elastic",
@@ -119,7 +119,6 @@ public class TestKibanaGetDetails {
     */
     @Test
     public void testClusterFindTargetNode() {
-        
         KibanaGetDetails testClass = new KibanaGetDetails();
         List<ProcessProfile> nodeProfiles = new ArrayList<>();
         ProcessProfile diagNode = new ProcessProfile();
@@ -145,7 +144,6 @@ public class TestKibanaGetDetails {
 
     @Test
     public void testFunctionGetStats() throws DiagnosticException {
-
         mockServer
                 .when(
                         request()
@@ -167,7 +165,12 @@ public class TestKibanaGetDetails {
         try(
             ResourceCache resourceCache = new ResourceCache();
         ) {
-            DiagnosticContext context = new DiagnosticContext(new DiagConfig(diagMap), new DiagnosticInputs(), resourceCache, true);
+            DiagnosticContext context = new DiagnosticContext(
+                new DiagConfig(diagMap),
+                new DiagnosticInputs("testKibanaGetDetails"),
+                resourceCache,
+                true
+            );
             context.elasticRestCalls = entries;
             resourceCache.addRestClient(Constants.restInputHost, httpRestClient);
             testClass.getStats(context);

--- a/src/test/java/co/elastic/support/diagnostics/commands/TestRunKibanaQueries.java
+++ b/src/test/java/co/elastic/support/diagnostics/commands/TestRunKibanaQueries.java
@@ -40,7 +40,7 @@ import static org.mockserver.model.HttpResponse.response;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestRunKibanaQueries {
 
-	private static final Logger logger = LogManager.getLogger(RestClient.class);
+    private static final Logger logger = LogManager.getLogger(RestClient.class);
     private ClientAndServer mockServer;
     private RestClient httpRestClient, httpsRestClient;
     private String temp = SystemProperties.userDir + SystemProperties.fileSeparator + "temp";
@@ -59,13 +59,13 @@ public class TestRunKibanaQueries {
 
     @BeforeEach
     public void setup() {
-    	
+
         httpRestClient = RestClient.getClient(
-        	"localhost", 
-        	9880, 
-        	"http",
-        	"elastic",
-        	"elastic",
+            "localhost",
+            9880,
+            "http",
+            "elastic",
+            "elastic",
             "",
             0,
             "",
@@ -90,300 +90,96 @@ public class TestRunKibanaQueries {
         resourceCache.close();
     }
 
+    private void configMockServerRoute(String path, String body, Parameter... params) {
+        mockServer.when(
+          request()
+            .withMethod("GET")
+            .withPath(path)
+            .withQueryStringParameters(params)
+        ).respond(
+          response()
+            .withBody(body)
+            .withStatusCode(200)
+        );
+    }
+
     private DiagnosticContext initializeKibana(String version) throws DiagnosticException {
         Map diagMap = JsonYamlUtils.readYamlFromClasspath(Constants.DIAG_CONFIG, true);
         DiagConfig diagConfig = new DiagConfig(diagMap);
-        DiagnosticContext context = new DiagnosticContext(diagConfig, new DiagnosticInputs(), resourceCache, true);
-    	RestEntryConfig builder = new RestEntryConfig(version);
+        DiagnosticContext context = new DiagnosticContext(diagConfig, new DiagnosticInputs("testKibana"), resourceCache, true);
+        RestEntryConfig builder = new RestEntryConfig(version);
 
         Map restCalls = JsonYamlUtils.readYamlFromClasspath(Constants.KIBANA_REST, true);
         Map<String, RestEntry> entries = builder.buildEntryMap(restCalls);
-    	context.elasticRestCalls = entries;
+        context.elasticRestCalls = entries;
 
-    	context.tempDir = tempDir.getPath();
-    	context.perPage = 2;
-    	
-        mockServer
-                .when(
-                        request()
-                                .withMethod("GET")
-                                .withPath("/api/settings")
-                )
-                .respond(
-                        response()
-                                .withBody("{\"cluster_uuid\":\"RLtzkhfBRUadN4WZ8fnnog\",\"settings\":{\"xpack\":{\"default_admin_email\":null},\"kibana\":{\"uuid\":\"a4f369ef-fecd-46b7-8b16-c6c3f885d9ec\",\"name\":\"13d5e793ea51\",\"index\":\".kibana\",\"host\":\"0.0.0.0\",\"port\":18648,\"locale\":\"en\",\"transport_address\":\"0.0.0.0:18648\",\"version\":\"6.5.0\",\"snapshot\":false,\"status\":\"green\"}}}")
-                                .withStatusCode(200)
-                );
+        context.tempDir = tempDir.getPath();
+        context.perPage = 2;
 
-    	mockServer
-		        .when(
-		                request()
-		                        .withMethod("GET")
-		                        .withPath("/api/stats")
-		        )
-		        .respond(
-		                response()
-		                        .withBody("{\"process\":{\"memory\":{\"heap\":{\"total_bytes\":470466560,\"used_bytes\":343398224,\"size_limit\":1740165498},\"resident_set_size_bytes\":587878400},\"pid\":32,\"event_loop_delay\":0.280181884765625,\"uptime_ms\":97230924},\"os\":{\"platform\":\"linux\",\"platform_release\":\"linux-4.15.0-1032-gcp\",\"load\":{\"1m\":1.37451171875,\"5m\":1.43408203125,\"15m\":1.34375},\"memory\":{\"total_bytes\":147879931904,\"free_bytes\":45620334592,\"used_bytes\":102259597312},\"uptime_ms\":18093713000,\"distro\":\"Centos\",\"distro_release\":\"Centos-7.8.2003\"},\"requests\":{\"disconnects\":0,\"total\":1,\"status_codes\":{\"302\":1}},\"concurrent_connections\":8,\"timestamp\":\"2021-01-06T01:35:11.324Z\",\"kibana\":{\"uuid\":\"a4f369ef-fecd-46b7-8b16-c6c3f885d9ec\",\"name\":\"13d5e793ea51\",\"index\":\".kibana\",\"host\":\"0.0.0.0\",\"locale\":\"en\",\"transport_address\":\"0.0.0.0:18648\",\"version\":\"7.9.0\",\"snapshot\":false,\"status\":\"green\"},\"last_updated\":\"2021-01-06T01:35:15.911Z\",\"collection_interval_ms\":5000,\"cluster_uuid\":\"RfBRUssssadN4WZssnnog\"}")
-		        );
-		mockServer
-		        .when(
-		                request()
-		                        .withMethod("GET")
-		                        .withPath("/api/actions")
-		        )
-		        .respond(
-		                response()
-		                        .withBody("[{\"id\":\"10c09567-fa28-4059-9484-aae83fa9c5ce\",\"actionTypeId\":\".webhook\",\"name\":\"rerere\",\"config\":{\"method\":\"post\",\"url\":\"https://mail.google.com/mail/u/0/#inbox\"}},{\"id\":\"eec7ee50-7129-11eb-9b41-17a1879ebc72\",\"actionTypeId\":\".webhook\",\"name\":\"webhook-auto-create-case\",\"config\":{\"method\":\"post\",\"hasAuth\":true,\"url\":\"https://7067a1cd7a8142a79ab8dec9304a5436.europe-west1.gcp.cloud.es.io/api/cases\",\"headers\":{\"kbn-xsrf\":\"kibana\",\"Content-Type\":\"application/json\"}},\"isPreconfigured\":false,\"referencedByCount\":8}]")
-		        );
-		mockServer
-		        .when(
-		                request()
-		                        .withMethod("GET")
-		                        .withPath("/api/detection_engine/privileges")
-		        )
-		        .respond(
-		                response()
-		                        .withBody("{\"username\":\"elastic\",\"has_all_requested\":false,\"is_authenticated\":true,\"has_encryption_key\":true}")
-		        );
-		mockServer
-		        .when(
-		                request()
-		                        .withMethod("GET")
-		                        .withPath("/api/detection_engine/prepackaged")
-		        )
-		        .respond(
-		                response()
-		                        .withBody("{\"username\":\"elastic\"}")
-		        );
+        configMockServerRoute(
+          "/api/settings",
+          "{\"cluster_uuid\":\"RLtzkhfBRUadN4WZ8fnnog\",\"settings\":{\"xpack\":{\"default_admin_email\":null},\"kibana\":{\"uuid\":\"a4f369ef-fecd-46b7-8b16-c6c3f885d9ec\",\"name\":\"13d5e793ea51\",\"index\":\".kibana\",\"host\":\"0.0.0.0\",\"port\":18648,\"locale\":\"en\",\"transport_address\":\"0.0.0.0:18648\",\"version\":\"6.5.0\",\"snapshot\":false,\"status\":\"green\"}}}"
+        );
+        configMockServerRoute(
+          "/api/stats",
+          "{\"process\":{\"memory\":{\"heap\":{\"total_bytes\":470466560,\"used_bytes\":343398224,\"size_limit\":1740165498},\"resident_set_size_bytes\":587878400},\"pid\":32,\"event_loop_delay\":0.280181884765625,\"uptime_ms\":97230924},\"os\":{\"platform\":\"linux\",\"platform_release\":\"linux-4.15.0-1032-gcp\",\"load\":{\"1m\":1.37451171875,\"5m\":1.43408203125,\"15m\":1.34375},\"memory\":{\"total_bytes\":147879931904,\"free_bytes\":45620334592,\"used_bytes\":102259597312},\"uptime_ms\":18093713000,\"distro\":\"Centos\",\"distro_release\":\"Centos-7.8.2003\"},\"requests\":{\"disconnects\":0,\"total\":1,\"status_codes\":{\"302\":1}},\"concurrent_connections\":8,\"timestamp\":\"2021-01-06T01:35:11.324Z\",\"kibana\":{\"uuid\":\"a4f369ef-fecd-46b7-8b16-c6c3f885d9ec\",\"name\":\"13d5e793ea51\",\"index\":\".kibana\",\"host\":\"0.0.0.0\",\"locale\":\"en\",\"transport_address\":\"0.0.0.0:18648\",\"version\":\"7.9.0\",\"snapshot\":false,\"status\":\"green\"},\"last_updated\":\"2021-01-06T01:35:15.911Z\",\"collection_interval_ms\":5000,\"cluster_uuid\":\"RfBRUssssadN4WZssnnog\"}"
+        );
+        configMockServerRoute(
+          "/api/actions",
+          "[{\"id\":\"10c09567-fa28-4059-9484-aae83fa9c5ce\",\"actionTypeId\":\".webhook\",\"name\":\"rerere\",\"config\":{\"method\":\"post\",\"url\":\"https://mail.google.com/mail/u/0/#inbox\"}},{\"id\":\"eec7ee50-7129-11eb-9b41-17a1879ebc72\",\"actionTypeId\":\".webhook\",\"name\":\"webhook-auto-create-case\",\"config\":{\"method\":\"post\",\"hasAuth\":true,\"url\":\"https://7067a1cd7a8142a79ab8dec9304a5436.europe-west1.gcp.cloud.es.io/api/cases\",\"headers\":{\"kbn-xsrf\":\"kibana\",\"Content-Type\":\"application/json\"}},\"isPreconfigured\":false,\"referencedByCount\":8}]"
+        );
+        configMockServerRoute(
+          "/api/detection_engine/privileges",
+          "{\"username\":\"elastic\",\"has_all_requested\":false,\"is_authenticated\":true,\"has_encryption_key\":true}"
+        );
+        configMockServerRoute(
+          "/api/detection_engine/prepackaged",
+          "{\"username\":\"elastic\"}"
+        );
+        configMockServerRoute(
+          "/api/task_manager/_health",
+          "{\"username\":\"elastic\"}"
+        );
+        configMockServerRoute(
+          "/api/alerts/_find",
+          "{\"page\":1,\"perPage\":2,\"total\":4,\"data\":{\"xpack\":{\"default_admin_email\":null},\"kibana\":{\"uuid\":\"a4f369ef-fecd-46b7-8b16-c6c3f885d9ec\",\"name\":\"13d5e793ea51\",\"index\":\".kibana\",\"host\":\"0.0.0.0\",\"port\":18648,\"locale\":\"en\",\"transport_address\":\"0.0.0.0:18648\",\"version\":\"6.5.0\",\"snapshot\":false,\"status\":\"green\"}}}",
+          new Parameter("per_page", "1")
+        );
+        configMockServerRoute(
+          "/api/alerts/_find",
+          "{\"page\":1,\"perPage\":2,\"total\":4,\"data\":{\"xpack\":{\"default_admin_email\":null},\"kibana\":{\"uuid\":\"a4f369ef-fecd-46b7-8b16-c6c3f885d9ec\",\"name\":\"13d5e793ea51\",\"index\":\".kibana\",\"host\":\"0.0.0.0\",\"port\":18648,\"locale\":\"en\",\"transport_address\":\"0.0.0.0:18648\",\"version\":\"6.5.0\",\"snapshot\":false,\"status\":\"green\"}}}",
+          new Parameter("page", "1"),
+          new Parameter("per_page", "2")
+        );
+        configMockServerRoute(
+          "/api/alerts/_find",
+          "{\"page\":2,\"perPage\":2,\"total\":4,\"data\":{\"xpack\":{\"default_admin_email\":null},\"kibana\":{\"uuid\":\"a4f369ef-fecd-46b7-8b16-c6c3f885d9ec\",\"name\":\"13d5e793ea51\",\"index\":\".kibana\",\"host\":\"0.0.0.0\",\"port\":18648,\"locale\":\"en\",\"transport_address\":\"0.0.0.0:18648\",\"version\":\"6.5.0\",\"snapshot\":false,\"status\":\"green\"}}}",
+          new Parameter("page", "2"),
+          new Parameter("per_page", "2")
+        );
+        configMockServerRoute(
+          "/api/detection_engine/rules/_find",
+          "{\"page\":1,\"perPage\":2,\"total\":4,\"data\":{\"xpack\":{\"default_admin_email\":null},\"kibana\":{\"uuid\":\"a4f369ef-fecd-46b7-8b16-c6c3f885d9ec\",\"name\":\"13d5e793ea51\",\"index\":\".kibana\",\"host\":\"0.0.0.0\",\"port\":18648,\"locale\":\"en\",\"transport_address\":\"0.0.0.0:18648\",\"version\":\"6.5.0\",\"snapshot\":false,\"status\":\"green\"}}}",
+          new Parameter("per_page", "1")
+        );
+        configMockServerRoute(
+          "/api/detection_engine/rules/_find",
+          "{\"page\":1,\"perPage\":2,\"total\":4,\"data\":{\"xpack\":{\"default_admin_email\":null},\"kibana\":{\"uuid\":\"a4f369ef-fecd-46b7-8b16-c6c3f885d9ec\",\"name\":\"13d5e793ea51\",\"index\":\".kibana\",\"host\":\"0.0.0.0\",\"port\":18648,\"locale\":\"en\",\"transport_address\":\"0.0.0.0:18648\",\"version\":\"6.5.0\",\"snapshot\":false,\"status\":\"green\"}}}",
+          new Parameter("page", "1"),
+          new Parameter("per_page", "2")
+        );
+        configMockServerRoute(
+          "/api/detection_engine/rules/_find",
+          "{\"page\":2,\"perPage\":2,\"total\":4,\"data\":{\"xpack\":{\"default_admin_email\":null},\"kibana\":{\"uuid\":\"a4f369ef-fecd-46b7-8b16-c6c3f885d9ec\",\"name\":\"13d5e793ea51\",\"index\":\".kibana\",\"host\":\"0.0.0.0\",\"port\":18648,\"locale\":\"en\",\"transport_address\":\"0.0.0.0:18648\",\"version\":\"6.5.0\",\"snapshot\":false,\"status\":\"green\"}}}",
+          new Parameter("page", "2"),
+          new Parameter("per_page", "2")
+        );
 
-		mockServer
-		        .when(
-		                request()
-		                        .withMethod("GET")
-		                        .withPath("/api/task_manager/_health")
-		        )
-		        .respond(
-		                response()
-		                        .withBody("{\"username\":\"elastic\"}")
-		        ); 
-		mockServer
-                .when(
-                        request()
-                                .withMethod("GET")
-                                .withPath("/api/alerts/_find")
-                                .withQueryStringParameters(
-		                                new Parameter("per_page", "1")
-		                        )
-                )
-                .respond(
-                        response()
-                                .withBody("{\"page\":1,\"perPage\":2,\"total\":4,\"data\":{\"xpack\":{\"default_admin_email\":null},\"kibana\":{\"uuid\":\"a4f369ef-fecd-46b7-8b16-c6c3f885d9ec\",\"name\":\"13d5e793ea51\",\"index\":\".kibana\",\"host\":\"0.0.0.0\",\"port\":18648,\"locale\":\"en\",\"transport_address\":\"0.0.0.0:18648\",\"version\":\"6.5.0\",\"snapshot\":false,\"status\":\"green\"}}}")
-                                .withStatusCode(200)
-                );
-		mockServer
-                .when(
-                        request()
-                                .withMethod("GET")
-                                .withPath("/api/alerts/_find")
-                                .withQueryStringParameters(
-		                                new Parameter("page", "1"),
-		                                new Parameter("per_page", "2")
-		                        )
-                )
-                .respond(
-                        response()
-                                .withBody("{\"page\":1,\"perPage\":2,\"total\":4,\"data\":{\"xpack\":{\"default_admin_email\":null},\"kibana\":{\"uuid\":\"a4f369ef-fecd-46b7-8b16-c6c3f885d9ec\",\"name\":\"13d5e793ea51\",\"index\":\".kibana\",\"host\":\"0.0.0.0\",\"port\":18648,\"locale\":\"en\",\"transport_address\":\"0.0.0.0:18648\",\"version\":\"6.5.0\",\"snapshot\":false,\"status\":\"green\"}}}")
-                                .withStatusCode(200)
-                );
-        mockServer
-                .when(
-                        request()
-                                .withMethod("GET")
-                                .withPath("/api/alerts/_find")
-                                .withQueryStringParameters(
-		                                new Parameter("page", "2"),
-		                                new Parameter("per_page", "2")
-		                        )
-                )
-                .respond(
-                        response()
-                                .withBody("{\"page\":2,\"perPage\":2,\"total\":4,\"data\":{\"xpack\":{\"default_admin_email\":null},\"kibana\":{\"uuid\":\"a4f369ef-fecd-46b7-8b16-c6c3f885d9ec\",\"name\":\"13d5e793ea51\",\"index\":\".kibana\",\"host\":\"0.0.0.0\",\"port\":18648,\"locale\":\"en\",\"transport_address\":\"0.0.0.0:18648\",\"version\":\"6.5.0\",\"snapshot\":false,\"status\":\"green\"}}}")
-                                .withStatusCode(200)
-                );
-
-        mockServer
-                .when(
-                        request()
-                                .withMethod("GET")
-                                .withPath("/api/detection_engine/rules/_find")
-                                .withQueryStringParameters(
-		                                new Parameter("per_page", "1")
-		                        )
-                )
-                .respond(
-                        response()
-                                .withBody("{\"page\":1,\"perPage\":2,\"total\":4,\"data\":{\"xpack\":{\"default_admin_email\":null},\"kibana\":{\"uuid\":\"a4f369ef-fecd-46b7-8b16-c6c3f885d9ec\",\"name\":\"13d5e793ea51\",\"index\":\".kibana\",\"host\":\"0.0.0.0\",\"port\":18648,\"locale\":\"en\",\"transport_address\":\"0.0.0.0:18648\",\"version\":\"6.5.0\",\"snapshot\":false,\"status\":\"green\"}}}")
-                                .withStatusCode(200)
-                );
-		mockServer
-                .when(
-                        request()
-                                .withMethod("GET")
-                                .withPath("/api/detection_engine/rules/_find")
-                                .withQueryStringParameters(
-		                                new Parameter("page", "1"),
-		                                new Parameter("per_page", "2")
-		                        )
-                )
-                .respond(
-                        response()
-                                .withBody("{\"page\":1,\"perPage\":2,\"total\":4,\"data\":{\"xpack\":{\"default_admin_email\":null},\"kibana\":{\"uuid\":\"a4f369ef-fecd-46b7-8b16-c6c3f885d9ec\",\"name\":\"13d5e793ea51\",\"index\":\".kibana\",\"host\":\"0.0.0.0\",\"port\":18648,\"locale\":\"en\",\"transport_address\":\"0.0.0.0:18648\",\"version\":\"6.5.0\",\"snapshot\":false,\"status\":\"green\"}}}")
-                                .withStatusCode(200)
-                );
-        mockServer
-                .when(
-                        request()
-                                .withMethod("GET")
-                                .withPath("/api/detection_engine/rules/_find")
-                                .withQueryStringParameters(
-		                                new Parameter("page", "2"),
-		                                new Parameter("per_page", "2")
-		                        )
-                )
-                .respond(
-                        response()
-                                .withBody("{\"page\":2,\"perPage\":2,\"total\":4,\"data\":{\"xpack\":{\"default_admin_email\":null},\"kibana\":{\"uuid\":\"a4f369ef-fecd-46b7-8b16-c6c3f885d9ec\",\"name\":\"13d5e793ea51\",\"index\":\".kibana\",\"host\":\"0.0.0.0\",\"port\":18648,\"locale\":\"en\",\"transport_address\":\"0.0.0.0:18648\",\"version\":\"6.5.0\",\"snapshot\":false,\"status\":\"green\"}}}")
-                                .withStatusCode(200)
-                );
-		return context;
+        return context;
     }
-
-    @Test
-    public void testQueriesForKibana() throws DiagnosticException {
-
-		DiagnosticContext context = initializeKibana("6.5.0");
-    	int totalRetries = new RunKibanaQueries().runBasicQueries(httpRestClient, context);
-
-    	String[] pathnames;
-    	pathnames = tempDir.list();
-    	String[] kList = new String[]{"kibana_stats.json", "kibana_settings.json"};
-    	List<String> list = Arrays.asList(kList);
-
-        for (String pathname : pathnames) {
-        	// if this Unit test fail, you can use this two logger to see the error file name
-            // logger.info(Constants.CONSOLE, "pathnames.");
-            // logger.info(Constants.CONSOLE, pathname);
-        	assertTrue(list.contains(pathname));
-        }
-        assertEquals(list.size(), 2);
-
-        JsonNode nodeData = JsonYamlUtils.createJsonNodeFromFileName(context.tempDir, "kibana_stats.json");
-        String pid = nodeData.path("process").path("pid").asText();
-        String os = nodeData.path("os").path("platform").asText();
-        String osParsed = SystemUtils.parseOperatingSystemName(nodeData.path("os").path("platform").asText());
-   		assertEquals(pid, "32");
-   		assertEquals(os, "linux");
-   		assertEquals(osParsed, "linuxOS");
-
-   		JsonNode nodeDataSettings = JsonYamlUtils.createJsonNodeFromFileName(context.tempDir, "kibana_settings.json");
-   		String uuid = nodeDataSettings.path("cluster_uuid").asText();
-   		String version = nodeDataSettings.path("settings").path("kibana").path("version").asText();
-   		assertEquals(uuid, "RLtzkhfBRUadN4WZ8fnnog");
-   		assertEquals(version, "6.5.0");
-    }
-
-    @Test
-	public void testSixversion() throws DiagnosticException {
-
-		DiagnosticContext context = initializeKibana("6.5.0");
-    	int totalRetries = new RunKibanaQueries().runBasicQueries(httpRestClient, context);
-
-    	String[] pathnames;
-    	pathnames = tempDir.list();
-    	String[] kList = new String[]{"kibana_stats.json", "kibana_settings.json"};
-    	List<String> list = Arrays.asList(kList);
-
-        // For each pathname in the pathnames array
-        for (String pathname : pathnames) {
-        	assertTrue(list.contains(pathname));
-        }
-        assertEquals(list.size(), 2);
-
-	}
-
-	@Test
-    public void testQueriesForKibana711() throws DiagnosticException {
-
-		DiagnosticContext context = initializeKibana("7.11.0");
-    	int totalRetries = new RunKibanaQueries().runBasicQueries(httpRestClient, context);
-
-    	String[] pathnames;
-    	pathnames = tempDir.list();
-    	String[] kList = new String[]{"kibana_stats.json", 
-    									"kibana_settings.json", 
-    									"kibana_detection_engine_signals.json", 
-    									"kibana_actions.json",  
-    									"kibana_detection_engine_privileges.json", 
-    									"kibana_task_manager_help.json", 
-    									"kibana_detection_engine_find_1.json", 
-    									"kibana_detection_engine_find_2.json", 
-    									"kibana_alerts_1.json", 
-    									"kibana_alerts_2.json"};
-    	List<String> list = Arrays.asList(kList);
-
-        for (String pathname : pathnames) {
-        	// if this Unit test fail, you can use this two logger to see the error file name
-            logger.info(Constants.CONSOLE, "pathnames.");
-            logger.info(Constants.CONSOLE, pathname);
-        	assertTrue(list.contains(pathname));
-        }
-        assertEquals(list.size(), 10);
-
-        JsonNode nodeData = JsonYamlUtils.createJsonNodeFromFileName(context.tempDir, "kibana_alerts_1.json");
-        String page1 = nodeData.path("page").asText();
-        String total1 = nodeData.path("total").asText();
-        assertEquals(page1, "1");
-   		assertEquals(total1, "4");
-
-   		JsonNode nodeData1 = JsonYamlUtils.createJsonNodeFromFileName(context.tempDir, "kibana_alerts_2.json");
-        String page2 = nodeData1.path("page").asText();
-        String total2 = nodeData1.path("total").asText();
-        assertEquals(page2, "2");
-   		assertEquals(total2, "4");
-
-   		JsonNode nodeData2 = JsonYamlUtils.createJsonNodeFromFileName(context.tempDir, "kibana_detection_engine_find_1.json");
-        String page3 = nodeData2.path("page").asText();
-        String total3 = nodeData2.path("total").asText();
-        assertEquals(page3, "1");
-   		assertEquals(total3, "4");
-
-   		JsonNode nodeData3 = JsonYamlUtils.createJsonNodeFromFileName(context.tempDir, "kibana_detection_engine_find_2.json");
-        String page4 = nodeData3.path("page").asText();
-        String total4 = nodeData3.path("total").asText();
-        assertEquals(page4, "2");
-   		assertEquals(total4, "4");
-
-   		JsonNode nodeData5 = JsonYamlUtils.createJsonNodeFromFileName(context.tempDir, "kibana_stats.json");
-        String pid = nodeData5.path("process").path("pid").asText();
-        String os = nodeData5.path("os").path("platform").asText();
-        String osParsed = SystemUtils.parseOperatingSystemName(nodeData5.path("os").path("platform").asText());
-   		assertEquals(pid, "32");
-   		assertEquals(os, "linux");
-   		assertEquals(osParsed, "linuxOS");
-
-   		JsonNode nodeData6 = JsonYamlUtils.createJsonNodeFromFileName(context.tempDir, "kibana_settings.json");
-        String clusterUuid = nodeData6.path("cluster_uuid").asText();
-        assertEquals(clusterUuid, "RLtzkhfBRUadN4WZ8fnnog");
-
-   		JsonNode nodeData7 = JsonYamlUtils.createJsonNodeFromFileName(context.tempDir, "kibana_task_manager_help.json");
-        String username = nodeData7.path("username").asText();
-        assertEquals(username, "elastic");
-    }
-
 
     @Test
     public void testQueriesForKibanaWithHeaders() throws DiagnosticException {
-
         DiagnosticContext context = initializeKibana("7.10.0");
         int totalRetries = new RunKibanaQueries().runBasicQueries(httpRestClient, context);
         new RunKibanaQueries().filterActionsHeaders(context);
@@ -403,16 +199,11 @@ public class TestRunKibanaQueries {
 
     @Test
     public void testQueriesRemovingHeaders() throws DiagnosticException {
-      mockServer
-            .when(
-                    request()
-                            .withMethod("GET")
-                            .withPath("/api/actions")
-            )
-            .respond(
-                    response()
-                            .withBody("[{\"id\":\"eec7ee50-7129-1111-9b41-17a1879ebc72\",\"actionTypeId\":\".webhook\",\"name\":\"webhook-auto-create-case\",\"config\":{\"method\":\"post\",\"hasAuth\":true,\"url\":\"https://7067a1cd7a8142a79ab8dec9304a5436.europe-west1.gcp.cloud.es.io/api/cases\",\"headers\":{\"Authorization\":\"Basic 1111\",\"customHeader\":\"CustomValue\",\"kbn-xsrf\":\"kibana\",\"Content-Type\":\"application/json\"}},\"isPreconfigured\":false,\"referencedByCount\":9}]")
-            );
+        configMockServerRoute(
+          "/api/actions",
+          "[{\"id\":\"eec7ee50-7129-1111-9b41-17a1879ebc72\",\"actionTypeId\":\".webhook\",\"name\":\"webhook-auto-create-case\",\"config\":{\"method\":\"post\",\"hasAuth\":true,\"url\":\"https://7067a1cd7a8142a79ab8dec9304a5436.europe-west1.gcp.cloud.es.io/api/cases\",\"headers\":{\"Authorization\":\"Basic 1111\",\"customHeader\":\"CustomValue\",\"kbn-xsrf\":\"kibana\",\"Content-Type\":\"application/json\"}},\"isPreconfigured\":false,\"referencedByCount\":9}]"
+        );
+
         DiagnosticContext context = initializeKibana("7.10.0");
         int totalRetries = new RunKibanaQueries().runBasicQueries(httpRestClient, context);
         new RunKibanaQueries().filterActionsHeaders(context);
@@ -430,23 +221,17 @@ public class TestRunKibanaQueries {
     */
     @Test
     public void testQueriesWithoutHeaders() throws DiagnosticException {
-      mockServer
-            .when(
-                    request()
-                            .withMethod("GET")
-                            .withPath("/api/actions")
-            )
-            .respond(
-                    response()
-                            .withBody("[{\"id\":\"eec7ee50-7129-3333-9b41-17a1879ebc72\",\"actionTypeId\":\".webhook\",\"name\":\"webhook-auto-create-case\",\"test\":{\"method\":\"post\",\"hasAuth\":true,\"url\":\"https://7067a1cd7a8142a79ab8dec9304a5436.europe-west1.gcp.cloud.es.io/api/cases\",\"headers\":{\"Authorization\":\"Basic 1111\",\"customHeader\":\"CustomValue\",\"kbn-xsrf\":\"kibana\",\"Content-Type\":\"application/json\"}},\"isPreconfigured\":false,\"referencedByCount\":9}]")
+        configMockServerRoute(
+          "/api/actions",
+          "[{\"id\":\"eec7ee50-7129-3333-9b41-17a1879ebc72\",\"actionTypeId\":\".webhook\",\"name\":\"webhook-auto-create-case\",\"test\":{\"method\":\"post\",\"hasAuth\":true,\"url\":\"https://7067a1cd7a8142a79ab8dec9304a5436.europe-west1.gcp.cloud.es.io/api/cases\",\"headers\":{\"Authorization\":\"Basic 1111\",\"customHeader\":\"CustomValue\",\"kbn-xsrf\":\"kibana\",\"Content-Type\":\"application/json\"}},\"isPreconfigured\":false,\"referencedByCount\":9}]"
         );
+
         DiagnosticContext context = initializeKibana("7.10.0");
         int totalRetries = new RunKibanaQueries().runBasicQueries(httpRestClient, context);
-        try {
-            new RunKibanaQueries().filterActionsHeaders(context);
-        } catch (RuntimeException e) {
-            assertTrue(false);
-        }
+
+        // mutates `context` and throws an error uppon failure
+        new RunKibanaQueries().filterActionsHeaders(context);
+
         JsonNode nodeData = JsonYamlUtils.createJsonNodeFromFileName(context.tempDir, "kibana_actions.json");
         JsonNode config = nodeData.get(0).get("config");
         assertEquals(nodeData.get(0).path("id").asText(), "eec7ee50-7129-3333-9b41-17a1879ebc72");

--- a/src/test/java/co/elastic/support/rest/TestRestConfigFileValidity.java
+++ b/src/test/java/co/elastic/support/rest/TestRestConfigFileValidity.java
@@ -29,12 +29,12 @@ public class TestRestConfigFileValidity {
         // validates each set of version entries.
         for (String yamlfile : Arrays.asList("elastic-rest.yml", "logstash-rest.yml", "kibana-rest.yml", "monitoring-rest.yml")) {
             Map<String, Object> restEntriesConfig = JsonYamlUtils.readYamlFromClasspath(yamlfile, true);
-            validateEntries(restEntriesConfig);
+            validateEntries(yamlfile, restEntriesConfig);
         }
     }
 
 
-    private void validateEntries(Map<String, Object> config) {
+    private void validateEntries(String file, Map<String, Object> config) {
         for (Map.Entry<String, Object> entry : config.entrySet()) {
 
             Map<String, Object> values = (Map) entry.getValue();
@@ -53,7 +53,7 @@ public class TestRestConfigFileValidity {
             }
 
             // should be at most 1 valid URL (0 if it's not available anymore)
-            assertTrue(entry.getKey(), nbrValid <= 1);
+            assertTrue("[" + file +  "][" + entry.getKey() + "] matches " + nbrValid, nbrValid <= 1);
 
         }
 


### PR DESCRIPTION
This adds the concept of a `runner` to indicate who or what ran the diagnostic, and adds it to the `manifest.json` file.

It also fixes a few things, such as forcing the UTC date functions to actually force UTC, as well as printing the ISO-8601 formatted timezone instead of the RFC 822 ones.

Finally, it fixes a malformed ES action (because it should match one and only one API per action) and removes some Kibana tests that did not reflect the current state of output.