### PR TITLE
Update CAT Node Headers

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -73,7 +73,7 @@ cat_nodes:
   subdir: "cat"
   versions:
     ">= 0.9.0 < 6.0.0": "/_cat/nodes?v&h=n,nodeId,m,i,r,d,hp,rp,cpu,load_1m,load_5m,load_15m,"
-    ">= 6.0.0": "/_cat/nodes?v&h=n,nodeId,m,i,r,d,hp,rp,cpu,load_1m,load_5m,load_15m&s=n"
+    ">= 6.0.0": "/_cat/nodes?v&h=n,nodeId,i,v,r,m,dup,hp,cpu,load_1m,load_5m,load_15m,iic,sfc,sqc,scc&s=n"
 
 cat_pending_tasks:
   extension: ".txt"

--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -73,7 +73,7 @@ cat_nodes:
   subdir: "cat"
   versions:
     ">= 0.9.0 < 6.0.0": "/_cat/nodes?v&h=n,nodeId,m,i,r,d,hp,rp,cpu,load_1m,load_5m,load_15m,"
-    ">= 6.0.0": "/_cat/nodes?v&h=n,nodeId,i,v,r,m,dup,hp,cpu,load_1m,load_5m,load_15m,iic,sfc,sqc,scc&s=n"
+    ">= 6.0.0": "/_cat/nodes?v&h=n,nodeId,i,v,r,m,d,dup,hp,cpu,load_1m,load_5m,load_15m,iic,sfc,sqc,scc&s=n"
 
 cat_pending_tasks:
   extension: ".txt"


### PR DESCRIPTION
👋🏼 howdy, team! 👶🏼 PR to optimize the [CAT Nodes](https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-nodes.html) response headers

\+ `v` (alias for `version`) - to speed debugging split versions
\- `d` (alias for `disk.avail`) - the question to answer is "is the disk filling up?". With the addition of node temperatures, this has lost its quick-glance meaning.
\+ `dup` (alias for `disk.used_percent`) - this replaces `d` to answer the "is the disk filling up?" question
\- `rp` (alias for `ram.percent` - this is document to be misleading and needing refactored, see [es#32393](https://github.com/elastic/elasticsearch/issues/32393)
\+ current heavy traffic processes [`iic`,`sfc`,`sqc`,`scc`] (aliases for [`indexing.index_current`,`search.fetch_current`, `search.query_current`, `search.scroll_current`])

From
```
# GET _cat/nodes?v&h=n,nodeId,m,i,r,d,hp,rp,cpu,load_1m,load_5m,load_15m&s=n

n                   nodeId m i           r            d hp rp cpu load_1m load_5m load_15m
instance-0000000005 nxh5   * 10.42.3.113 himrst 179.8gb 39 65   1    0.93    1.19     1.25
```

To
```
# GET _cat/nodes?v&h=n,nodeId,i,v,r,m,dup,hp,cpu,load_1m,load_5m,load_15m,iic,sfc,sqc,scc&s=n

n                   nodeId i           v     r      m  dup hp cpu load_1m load_5m load_15m iic sfc sqc scc
instance-0000000005 nxh5   10.42.3.113 8.1.2 himrst * 0.06 31   2    1.07    1.21     1.31   0   0   0   0
```