### PR TITLE
[ES] Add `GET /_internal/_health`

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -220,6 +220,11 @@ indices_stats:
     ">= 0.9.0 < 7.7.0": "/_stats?level=shards&pretty&human"
     ">= 7.7.0": "/_stats?level=shards&pretty&human&expand_wildcards=all"
 
+internal_health:
+  retry: true
+  versions:
+    ">= 8.2.0": "/_internal/_health?explain"
+
 licenses:
   versions:
     ">= 1.0.0 < 2.0.0": "/_licenses"


### PR DESCRIPTION
This adds the `/_internal/_health` _with_ the `explain` parameter.

Closes https://github.com/elastic/support-diagnostics/issues/592