### PR TITLE
[System settings] Get the ReadAhead value of mounts

### DIFF
--- a/src/main/resources/diags.yml
+++ b/src/main/resources/diags.yml
@@ -56,6 +56,7 @@ linuxOS:
     cpu_governor: "cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor"
     limits: "cat /etc/security/limits.conf"
     proc-limit: "cat /proc/{{PID}}/limits"
+    readahead: "lsblk -o NAME,RA,MOUNTPOINT,TYPE,SIZE"
 
   java:
     elastic-java: "ps -fp {{PID}} | awk '{ if (NR!=1) print $8}'"


### PR DESCRIPTION
According to https://github.com/elastic/elasticsearch/pull/88007/files it is important to get the ReadAhead value of disks used as Elasticsearch data disks.
Having an RA of 128KB is recommended.