### PR TITLE
[Kibana api] add stack monitoring health api

### DIFF
--- a/src/main/resources/kibana-rest.yml
+++ b/src/main/resources/kibana-rest.yml
@@ -62,3 +62,7 @@ kibana_user:
   versions:
     ">= 7.6.0": "/internal/security/me"
     ">= 5.0.0 < 7.6.0": "/api/security/v1/me"
+
+kibana_stack_monitoring_health:
+  versions:
+    ">= 8.3.1": "/api/monitoring/v1/_health"


### PR DESCRIPTION
### Summary
Add a rest call to the [stack monitoring Health endpoint](https://github.com/elastic/kibana/tree/main/x-pack/plugins/monitoring/server/routes/api/v1/_health)

### Testing
- `mvn package`
- `unzip target/diagnostics-8.4.1-SNAPSHOT-dist.zip`
- `./target/diagnostics-8.4.1-SNAPSHOT-dist/diagnostics.sh --type kibana-api --host localhost --port 5601 --output ~/OUTPUT_PATH -u elastic -p`
- navigate to OUTPUT_PATH and verify `kibana_stack_monitoring_health.json` is populated