### PR TITLE
Include ML trained model info in support diag

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -417,6 +417,16 @@ ml_stats:
     ">= 5.0.0 < 7.0.0": "/_xpack/ml/anomaly_detectors/_stats?pretty"
     ">= 7.0.0": "/_ml/anomaly_detectors/_stats?pretty"
 
+ml_trained_models:
+  subdir: "commercial"
+  versions:
+    ">= 7.10.0": "/_ml/trained_models?pretty"
+
+ml_trained_models_stats:
+  subdir: "commercial"
+  versions:
+    ">= 7.10.0": "/_ml/trained_models/_stats?pretty"
+
 nodes_shutdown_status:
   subdir: "commercial"
   versions:


### PR DESCRIPTION
Adds /ml/trained_models and /ml/trained_models/_stats to the
support diag from 7.10 onwards.

These provide details of Java models in 7.x but are particularly
important in 8.0 and above as they provide us with information
about the native PyTorch NLP models that a customer might be
requesting support for.