### PR TITLE
[Kibana] Fix Broken Endpoints

### DIFF
--- a/src/main/java/co/elastic/support/diagnostics/commands/RunKibanaQueries.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/RunKibanaQueries.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Iterator;
@@ -43,13 +44,34 @@ public class RunKibanaQueries extends BaseQuery {
 
     private static final Logger logger = LogManager.getLogger(RunKibanaQueries.class);
 
-   /**
-    * Create a new ProcessProfile object and extract the information from fileName to get PID and OS.
-    * @param  tempDir where is the temporary data stored
-    * @param  fileName of the API content required, for more information check the kibana-rest.ymal
-    * @param  context The current diagnostic context as set in the DiagnosticService class
-    * @return the object that consolidate the process information
-    */
+    /**
+     * Paged actions are explicitally called out because they behave differently
+     * than normal diagnostic behaviors because they need to be called
+     * repeatedly in order to fetch all of the data.
+     */
+    private static final List<String> pagedActions = Arrays.asList(
+        new String[] {
+            "kibana_alerts",
+            "kibana_detection_engine_find",
+            "kibana_fleet_agent_policies",
+            "kibana_fleet_agents",
+            "kibana_fleet_package_policies",
+            "kibana_security_endpoint_event_filters",
+            "kibana_security_endpoint_exception_items",
+            "kibana_security_endpoint_host_isolation",
+            "kibana_security_endpoint_metadata",
+            "kibana_security_endpoint_trusted_apps",
+            "kibana_security_exception_list",
+        }
+    );
+
+    /**
+     * Create a new ProcessProfile object and extract the information from fileName to get PID and OS.
+     * @param  tempDir where is the temporary data stored
+     * @param  fileName of the API content required, for more information check the kibana-rest.ymal
+     * @param  context The current diagnostic context as set in the DiagnosticService class
+     * @return the object that consolidate the process information
+     */
     private ProcessProfile getProfile(String tempDir, String fileName, DiagnosticContext context) {
         ProcessProfile profile = new ProcessProfile();
         context.targetNode = profile;
@@ -61,25 +83,24 @@ public class RunKibanaQueries extends BaseQuery {
     }
 
 
-   /**
-    * CheckKibanaVersion (executed before) defined/set the context.elasticRestCalls.
-    * here we will loop and create a List of RestEntry with the queries/APIs that need to be executed
-    * You have two APIs that work differently and and may have or not many pages, so we use the getAllPages function
-    * runQueries called in this function create a json file for each RestEntry set on the 'queries' variable.
-    *
-    * @param  client the configured client to connect to Kibana.
-    * @param  context  The current diagnostic context as set in the DiagnosticService class
-    * @return Number of HTTP request that will be executed.
-    */
+    /**
+     * CheckKibanaVersion (executed before) defined/set the context.elasticRestCalls.
+     * here we will loop and create a List of RestEntry with the queries/APIs that need to be executed
+     * You have two APIs that work differently and and may have or not many pages, so we use the getAllPages function
+     * runQueries called in this function create a json file for each RestEntry set on the 'queries' variable.
+     *
+     * @param  client the configured client to connect to Kibana.
+     * @param  context  The current diagnostic context as set in the DiagnosticService class
+     * @return Number of HTTP request that will be executed.
+     */
     public int runBasicQueries(RestClient client, DiagnosticContext context) throws DiagnosticException {
-
         int totalRetries = 0;
         List<RestEntry> queries = new ArrayList<>();
-        
-        for (Map.Entry<String, RestEntry> entry : context.elasticRestCalls.entrySet()) {
 
+        for (Map.Entry<String, RestEntry> entry : context.elasticRestCalls.entrySet()) {
             String actionName = entry.getValue().getName().toString();
-            if (actionName.equals("kibana_alerts") || actionName.equals("kibana_detection_engine_find") || actionName.equals("kibana_fleet_agent_policies") || actionName.equals("kibana_fleet_agents") || actionName.equals("kibana_fleet_package_policies") || actionName.equals("kibana_security_endpoint_event_filters") || actionName.equals("kibana_security_endpoint_host_isolation") || actionName.equals("kibana_security_endpoint_list") || actionName.equals("kibana_security_endpoint_metadata") || actionName.equals("kibana_security_endpoint_trusted_apps") || actionName.equals("kibana_security_exception_list")) {
+
+            if (pagedActions.contains(actionName)) {
                 getAllPages(client, queries, context.perPage, entry.getValue());
             } else {
                 queries.add(entry.getValue());
@@ -119,19 +140,24 @@ public class RunKibanaQueries extends BaseQuery {
     * then we call getNewEntryPage to create a new RestEntry for each page.
     *
     * @param  client the configured client to connect to Kibana.
-    * @param  queries we will store the list of queries that need to be executed 
+    * @param  queries we will store the list of queries that need to be executed
     * @param  perPage  Number of docusment we reques to the API
     * @param  action Kibana API name we are running
     */
     public void getAllPages(RestClient client, List<RestEntry> queries, int perPage, RestEntry action) throws DiagnosticException {
+        String url = getPageUrl(action, 1, 100);
+
         // get the values needed to the pagination.
-        RestResult res = client.execQuery(getPageUrl(action, 1, 100));
+        RestResult res = client.execQuery(url);
         if (! res.isValid()) {
-            throw new DiagnosticException( res.formatStatusMessage("Could not retrieve Kibana API pagination - unable to continue." + action.getUrl()));
+            logger.info(Constants.CONSOLE, "{}   {}  failed. Bypassing", action.getName(), url);
+            logger.info(Constants.CONSOLE, res.formatStatusMessage("See archived diagnostics.log for more detail."));
         }
+
         String result   = res.toString();
         JsonNode root   = JsonYamlUtils.createJsonNodeFromString(result);
         int total       = (int) (Math.ceil(root.path("total").intValue() / 100.0)) * 100;
+
         if (total > 0 && perPage > 0) {
             // Get the first actions page
             queries.add(getNewEntryPage(perPage, 1, action));
@@ -173,7 +199,7 @@ public class RunKibanaQueries extends BaseQuery {
    /**
     * This function is executed **after** runBasicQueries
     * Extract the information on the kibana_stats.json with getProfile function.
-    * set the ResourceCache.addSystemCommand according tp the OS 
+    * set the ResourceCache.addSystemCommand according tp the OS
     *
     * @param  context The current diagnostic context as set in the DiagnosticService class
     * @return according with the type of diagnostic return the system command
@@ -197,7 +223,7 @@ public class RunKibanaQueries extends BaseQuery {
                 else{
                     targetOS = profile.os;
                 }
-                
+
                 syscmd = context.resourceCache.getSystemCommand(Constants.systemCommands);
                 break;
 

--- a/src/main/resources/kibana-rest.yml
+++ b/src/main/resources/kibana-rest.yml
@@ -37,7 +37,8 @@ kibana_detection_engine_privileges:
 
 kibana_detection_engine_signals:
   versions:
-    "> 7.10.0": "/api/detection_engine/rules/prepackaged/_status"
+    ">= 7.10.0 < 7.15.0": "/api/detection_engine/prepackaged"
+    ">= 7.15.0": "/api/detection_engine/rules/prepackaged/_status"
 
 kibana_fleet_agents:
   versions:
@@ -67,6 +68,7 @@ kibana_security_endpoint_trusted_apps:
   versions:
     ">= 7.10.0": "/api/endpoint/trusted_apps"
 
+# These endpoints will return 404 if there are no exceptions
 kibana_security_endpoint_host_isolation:
   versions:
     ">= 7.14.0": "/api/exception_lists/items/_find?list_id=endpoint_host_isolation_exceptions&namespace_type=agnostic"


### PR DESCRIPTION
When Kibana receives a request for the exception lists, it will return a `404` response if there are no exceptions (even though the API call is valid).

This updates the handling to log the error and move on in that scenario.