### PR TITLE
[ES] Add `GET /_internal/desired_balance`

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -226,6 +226,11 @@ internal_health:
     ">= 8.2.0 < 8.3.0": "/_internal/_health?pretty"
     ">= 8.3.0": "/_internal/_health?pretty&explain"
 
+internal_desired_balance:
+  retry: true
+  versions:
+    ">= 8.6.0": "/_internal/desired_balance"
+
 licenses:
   versions:
     ">= 1.0.0 < 2.0.0": "/_licenses"


### PR DESCRIPTION
Adds internal state of the desired balance allocator to the diagnostics bundle

(Should be merged after endpoint is commited in ES)

Related to: https://github.com/elastic/elasticsearch/issues/90583