### PR TITLE
Revive --indexName option to import-monitoring as --targetsuffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,6 +736,12 @@ Once the data is imported you should be able to view the new data via monitoring
    <td width="30%" align="left" valign="top">--clustername testCluster</td>
  </tr>
 
+ <tr>
+   <td width="20%" align="left" valign="top">--targetsuffix</td>
+   <td width="50%" align="left" valign="top">An alternative suffix to be used when ingesting documents to target such as `.monitoring-es-7-diag-import-`. Default is `yyyy-MM-dd`. Must be lowercase.</td>
+   <td width="30%" align="left" valign="top">--targetsuffix test-cluster-20200106</td>
+ </tr>
+
  </table>
 
 ### Monitoring Import Examples
@@ -755,7 +761,7 @@ Uses the generated index name but gives the cluster a different name:
 Uses a custom index and cluster name:
 
 ```$xslt
-   ./import-monitoring.sh --host 10.0.0.20 -u elastic -p --ssl -i /Users/joe_user/temp/export-20190801-150615.zip  --clustername big_cluster --indexName big_cluster_2019_10_01
+   ./import-monitoring.sh --host 10.0.0.20 -u elastic -p --ssl -i /Users/joe_user/temp/export-20190801-150615.zip  --clustername big_cluster --targetsuffix big_cluster_2019_10_01
 ```
 
 ## Standard Diagnostic Troubleshooting

--- a/src/main/java/co/elastic/support/monitoring/MonitoringImportInputs.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringImportInputs.java
@@ -15,6 +15,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.beryx.textio.StringInputReader;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 
@@ -26,6 +29,9 @@ public class MonitoringImportInputs extends ElasticRestClientInputs {
 
     @Parameter(names = {"--clustername"}, description = "Overrides the name of the imported cluster.")
     protected String clusterName;
+
+    @Parameter(names = {"--targetsuffix"}, description = "Overrides the suffix of the import target from the date, appending it to e.g. .monitoring-es-7-diag-import-.")
+    protected String targetSuffix;
 
     @Parameter(names = {"-i", "--input"}, description = "Required: The archive that you wish to import into Elastic Monitoring. This must be in the format produced by the diagnostic export utility.")
     protected String input;
@@ -48,6 +54,11 @@ public class MonitoringImportInputs extends ElasticRestClientInputs {
                 .withMinLength(0)
                 .read("Specify an alternate name for the imported cluster or hit enter to use original cluster name:");
 
+        targetSuffix = textIOManager.textIO.newStringInputReader()
+                .withInputTrimming(true)
+                .withDefaultValue((DateTimeFormatter.ofPattern("yyyy-MM-dd").format(ZonedDateTime.now(ZoneId.of("+0")))))
+                .read("Specify an alternate suffix for the import target or hit enter for the default generated name:");
+
         input = textIOManager.textIO.newStringInputReader()
                 .withInputTrimming(true)
                 .withValueChecker((String val, String propname) -> validateRequiredFile(val))
@@ -63,6 +74,7 @@ public class MonitoringImportInputs extends ElasticRestClientInputs {
         List<String> errors = super.parseInputs(textIOManager, args);
 
         errors.addAll(ObjectUtils.defaultIfNull(validateId(clusterName), emptyList));
+        errors.addAll(ObjectUtils.defaultIfNull(validateId(targetSuffix), emptyList));
         errors.addAll(ObjectUtils.defaultIfNull(validateRequiredFile(input), emptyList));
 
         return errors;
@@ -82,6 +94,7 @@ public class MonitoringImportInputs extends ElasticRestClientInputs {
     public String toString() {
         return "MonitoringImportInputs{" +
                 "clusterName='" + clusterName + '\'' +
+                ", targetSuffix='" + targetSuffix + '\'' +
                 ", input='" + input + '\'' +
                 ", proxyHostReader=" + proxyHostReader +
                 '}';

--- a/src/main/java/co/elastic/support/monitoring/MonitoringImportProcessor.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringImportProcessor.java
@@ -18,9 +18,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.*;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Vector;
@@ -68,17 +65,16 @@ public class MonitoringImportProcessor {
 
         logger.info(Constants.CONSOLE, "Processing: {}", file.getName());
         long eventsWritten = 0;
-        String indexDate = (DateTimeFormatter.ofPattern("yyyy-MM-dd").format(ZonedDateTime.now(ZoneId.of("+0"))));
         String indexName;
 
         try (InputStream instream = new FileInputStream(file)) {
 
             if (file.getName().contains("logstash")) {
-                indexName = config.logstashExtractIndexPattern + "-" + indexDate;
+                indexName = config.logstashExtractIndexPattern + "-" + inputs.targetSuffix;
             } else if (file.getName().contains("metricbeat")) {
-                indexName = config.metricbeatExtractIndexPattern + "-" + indexDate;
+                indexName = config.metricbeatExtractIndexPattern + "-" + inputs.targetSuffix;
             } else {
-                indexName = config.monitoringExtractIndexPattern + "-" + indexDate;
+                indexName = config.monitoringExtractIndexPattern + "-" + inputs.targetSuffix;
             }
 
             BufferedReader br = new BufferedReader(new InputStreamReader(instream));


### PR DESCRIPTION
**Issue**:

`--indexName` was removed as a part of https://github.com/elastic/support-diagnostics/pull/425, but it's still nice-to-have.

**Solution**:

Revive the option with small alignments.

Closes #537

The option was originally `--indexName`. However, because the target is no longer index but data stream in 8.x as reported in https://github.com/elastic/support-diagnostics/issues/585, I decided to change the option to `--targetsuffix`.

The below console log shows my testing of this change with `diagnostics-8.4.2-SNAPSHOT`. If any further tests are needed, please let me know.

<details>
 <summary>Console log running import-monitoring</summary>

```shell
C:\Users\YouheiSakurai\Desktop\diagnostics-8.4.2-SNAPSHOT>import-monitoring.bat -i monitoring-export-20221114-113114.zip --targetsuffix docker-desktop-copied --clustername docker-desktop-copied
No Java Home was found. Using current path. If execution fails please install Java and make sure it is in the search path or exposed via the JAVA_HOME environment variable.
2022-11-14 20:47:11,662 main ERROR Unable to locate appender "diag" for logger config "root"
Processing diagnosticInputs...
Deleted directory: C:\Users\YouheiSakurai\Desktop\diagnostics-8.4.2-SNAPSHOT\monitoring-export.
Creating temporary directory C:\Users\YouheiSakurai\Desktop\diagnostics-8.4.2-SNAPSHOT\monitoring-export
Configuring log file.
Diagnostic logger reconfigured for inclusion into archive
Extract completed successfully!
Processing: ccr_auto_follow_stats.json
Indexing document batch 0 to 500
Indexing document batch 500 to 1000
Indexing document batch 1000 to 1500
Indexing document batch 1500 to 2000
Indexing document batch 2000 to 2156
2156 events written from ccr_auto_follow_stats.json
Processing: cluster_stats.json
Indexing document batch 0 to 500
Indexing document batch 500 to 1000
Indexing document batch 1000 to 1500
Indexing document batch 1500 to 2000
Indexing document batch 2000 to 2156
2156 events written from cluster_stats.json
Processing: indices_stats.json
Indexing document batch 0 to 500
Indexing document batch 500 to 1000
Indexing document batch 1000 to 1500
Indexing document batch 1500 to 2000
Indexing document batch 2000 to 2156
2156 events written from indices_stats.json
Processing: node_stats.json
Indexing document batch 0 to 500
Indexing document batch 500 to 1000
Indexing document batch 1000 to 1500
Indexing document batch 1500 to 2000
Indexing document batch 2000 to 2156
2156 events written from node_stats.json
Closing loggers.

C:\Users\YouheiSakurai\Desktop\diagnostics-8.4.2-SNAPSHOT>curl localhost:9200/_cat/indices/.monitoring-*
green open .monitoring-es-7-diag-import-docker-desktop-copied LaxCNhS1ReqOoJq1hzojTw 1 0 8640 0 3.2mb 3.2mb

C:\Users\YouheiSakurai\Desktop\diagnostics-8.4.2-SNAPSHOT>import-monitoring.bat --help
No Java Home was found. Using current path. If execution fails please install Java and make sure it is in the search path or exposed via the JAVA_HOME environment variable.
2022-11-14 20:53:27,469 main ERROR Unable to locate appender "diag" for logger config "root"
Processing diagnosticInputs...
Usage: <main class> [options]
  Options:
    --archiveType
      File type that will be used to compress the output directory. Choose
      between: 'zip', 'tar' or 'any'. 'any' will try to zip first and fallback
      to tar if the zip fails. Defaults to any.
      Default: any
    --bypassDiagVerify
      Bypass the diagnostic version check. Use when internet outbound HTTP
      access is blocked by a firewall.
      Default: false
    --clustername
      Overrides the name of the imported cluster.
    -?, --help
      Help contents.
    -h, --host
      Required field.  Hostname, IP Address, or localhost.  HTTP access for
      this node must be enabled:
      Default: localhost
    -i, --input
      Required: The archive that you wish to import into Elastic Monitoring.
      This must be in the format produced by the diagnostic export utility.
    --noVerify
      Bypass hostname verification for certificate? This is unsafe and NOT
      recommended. No value required, only the option.
      Default: false
    -o, --out, --output, --outputDir
      Fully qualified path to an output directory. If it does not exist the
      diagnostic will attempt to create it. If not specified the diagnostic
      directory will be used:
      Default: C:\Users\YouheiSakurai\Desktop\diagnostics-8.4.2-SNAPSHOT
    -p, --password
      Prompt for Elasticsearch password.  Do not enter a value.
      Default: false
    --pkiKeystore
      Path/filename for PKI keystore with client certificate:
      Default: <empty string>
    --pkiPass
      Prompt for keystore password. Do not enter a value.
      Default: false
    --port
      Listening port. Defaults to 9200:
      Default: 9200
    --proxyHost
      Proxy server host name or IP Address:
      Default: <empty string>
    --proxyPort
      Proxy server port number. Defaults to port 80:
      Default: 8080
    --proxyUser
      Proxy server login:
      Default: <empty string>
    -s, --ssl
      Use https to access the cluster? No value required, only the option.
      Default: false
    --targetsuffix
      Overrides the suffix of the import target from the date, appending it to
      e.g. .monitoring-es-7-diag-import-.
    -u, --user
      Elasticsearch user account:
      Default: <empty string>

Exiting...
```

</details>