### PR TITLE
Fix bugs in import monitoring

### DIFF
--- a/src/main/java/co/elastic/support/monitoring/MonitoringImportConfig.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringImportConfig.java
@@ -35,7 +35,7 @@ public class MonitoringImportConfig extends BaseConfig {
         bulkSize = (Integer) configuration.get("bulk-import-size");
         monitoringExtractIndexPattern = (String)configuration.get("monitoring-extract-pattern");
         logstashExtractIndexPattern = (String)configuration.get("logstash-extract-pattern");
-        metricbeatExtractIndexPattern = (String)configuration.get("metricbeatExtractIndexPattern");
+        metricbeatExtractIndexPattern = (String)configuration.get("metricbeat-extract-pattern");
         templateList = (List<String>)configuration.get("import-templates");
 
     }

--- a/src/main/java/co/elastic/support/monitoring/MonitoringImportProcessor.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringImportProcessor.java
@@ -148,7 +148,7 @@ public class MonitoringImportProcessor {
     }
 
     private long writeBatch(String query, int size) {
-        RestResult res = new RestResult(client.execPost("_bulk", query), "_bulk");
+        RestResult res = new RestResult(client.execPost("/_bulk", query), "/_bulk");
         if (res.getStatus() != 200) {
             logger.error(Constants.CONSOLE, "Batch update had errors: {}  {}", res.getStatus(), res.getReason());
             logger.error(Constants.CONSOLE, Constants.CHECK_LOG);
@@ -169,7 +169,7 @@ public class MonitoringImportProcessor {
                 String path = Constants.TEMPLATE_CONFIG_PACKAGE + template + ".json";
                 File file = new File(classLoader.getResource(path).getFile());
                 String data = FileUtils.readFileToString(file, "UTF-8");
-                client.execPost("_template/" + template, data);
+                client.execPost("/_template/" + template, data);
             } catch (Exception e) {
                 logger.error("Issue checking template {}", template, e);
             }

--- a/src/main/resources/monitoring-extract/templates/monitoring-es-diag.json
+++ b/src/main/resources/monitoring-extract/templates/monitoring-es-diag.json
@@ -2,7 +2,7 @@
   "order" : 0,
   "version" : 7000199,
   "index_patterns" : [
-    ".monitoring-es-7-diag-import"
+    ".monitoring-es-7-diag-import-*"
   ],
   "settings" : {
     "index" : {


### PR DESCRIPTION
## [Prepend slash to path of HTTP request](https://github.com/elastic/support-diagnostics/commit/9382501062a7f3f665586b390c8632db1a4fea24)

With this fix, `import-monitoring` is now able to import data to ESS as follows.

<details>
<summary>import.log</summary>

```shell
C:\Users\YouheiSakurai\git\support-diagnostics\target\diagnostcs\diagnostics-8.4.2-SNAPSHOT>import-monitoring.bat --user elastic -p --port 443 --host 18c**********************dae5d6e.ap-northeast-1.aws.found.io --ssl -i monitoring-export-20221203-060640.zip
No Java Home was found. Using current path. If execution fails please install Java and make sure it is in the search path or exposed via the JAVA_HOME environment variable.
2022-12-03 15:41:43,539 main ERROR Unable to locate appender "diag" for logger config "root"
Processing diagnosticInputs...
Elasticsearch user password: ************************
Deleted directory: C:\Users\YouheiSakurai\git\support-diagnostics\target\diagnostcs\diagnostics-8.4.2-SNAPSHOT\monitoring-export.
Creating temporary directory C:\Users\YouheiSakurai\git\support-diagnostics\target\diagnostcs\diagnostics-8.4.2-SNAPSHOT\monitoring-export
Configuring log file.
Diagnostic logger reconfigured for inclusion into archive
Extract completed successfully!
Processing: ccr_auto_follow_stats.json
Indexing document batch 0 to 500
Indexing document batch 500 to 1000
Indexing document batch 1000 to 1500
Indexing document batch 1500 to 2000
Indexing document batch 2000 to 2156
2156 events written from ccr_auto_follow_stats.json
Processing: cluster_stats.json
Indexing document batch 0 to 500
Indexing document batch 500 to 1000
Indexing document batch 1000 to 1500
Indexing document batch 1500 to 2000
Indexing document batch 2000 to 2156
2156 events written from cluster_stats.json
Processing: index_stats.json
Indexing document batch 0 to 500
Indexing document batch 500 to 1000
Indexing document batch 1000 to 1500
Indexing document batch 1500 to 2000
Indexing document batch 2000 to 2500
Indexing document batch 2500 to 3000
Indexing document batch 3000 to 3500
Indexing document batch 3500 to 4000
Indexing document batch 4000 to 4500
Indexing document batch 4500 to 5000
Indexing document batch 5000 to 5500
Indexing document batch 5500 to 6000
Indexing document batch 6000 to 6500
Indexing document batch 6500 to 7000
Indexing document batch 7000 to 7500
Indexing document batch 7500 to 8000
Indexing document batch 8000 to 8500
Indexing document batch 8500 to 9000
Indexing document batch 9000 to 9500
Indexing document batch 9500 to 10000
Indexing document batch 10000 to 10500
Indexing document batch 10500 to 11000
Indexing document batch 11000 to 11500
Indexing document batch 11500 to 12000
Indexing document batch 12000 to 12500
Indexing document batch 12500 to 12935
12935 events written from index_stats.json
Processing: indices_stats.json
Indexing document batch 0 to 500
Indexing document batch 500 to 1000
Indexing document batch 1000 to 1500
Indexing document batch 1500 to 2000
Indexing document batch 2000 to 2156
2156 events written from indices_stats.json
Processing: node_stats.json
Indexing document batch 0 to 500
Indexing document batch 500 to 1000
Indexing document batch 1000 to 1500
Indexing document batch 1500 to 2000
Indexing document batch 2000 to 2500
Indexing document batch 2500 to 3000
Indexing document batch 3000 to 3500
Indexing document batch 3500 to 4000
Indexing document batch 4000 to 4312
4312 events written from node_stats.json
Processing: shards.json
Indexing document batch 0 to 500
Indexing document batch 500 to 1000
Indexing document batch 1000 to 1006
1006 events written from shards.json
Closing loggers.
```

</details>

Closes #615

## [Fix typo of config property](https://github.com/elastic/support-diagnostics/commit/8f9580e77daf8a5b510c7093a5210ba8a29cb879)

[diags.yml](https://github.com/elastic/support-diagnostics/blob/v8.4.1/src/main/resources/diags.yml#L130-L132) doesn't have such a property, so `metricbeatExtractIndexPattern` was typo.

## [Append wildcard to index pattern](https://github.com/elastic/support-diagnostics/commit/7787b5bd8fa7fb6c6cf7028d96c722698f23e653)

With this fix, the following index patterns are set to index templates.

![image](https://user-images.githubusercontent.com/721858/205430259-dc829a24-f105-49fd-a10a-f441229b8789.png)
