### PR TITLE
[HealthAPI] explain has been renamed to verbose in 8.6 and the API is GA in 8.7

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -225,6 +225,8 @@ internal_health:
   versions:
     ">= 8.2.0 < 8.3.0": "/_internal/_health?pretty"
     ">= 8.3.0": "/_internal/_health?pretty&explain"
+    ">= 8.6.0 < 8.7.0": "/_internal/_health?pretty"
+    ">=8.7.0": "/_health?pretty"
 
 internal_desired_balance:
   retry: true


### PR DESCRIPTION
Update the Health API paths to reflect the latest changes in Elasticsearch 8.6 and 8.7:
1. Starting with 8.6 the `explain` parameter is named `verbose` (I've omitted specifying it as 
   the default is `true`)
2. We will promote the API to generally available in 8.7 so the path changed to `_health`