### PR TITLE
[Kibana] Remove Fleet Package Policies

### DIFF
--- a/src/main/java/co/elastic/support/diagnostics/commands/RunKibanaQueries.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/RunKibanaQueries.java
@@ -55,7 +55,6 @@ public class RunKibanaQueries extends BaseQuery {
             "kibana_detection_engine_find",
             "kibana_fleet_agent_policies",
             "kibana_fleet_agents",
-            "kibana_fleet_package_policies",
             "kibana_security_endpoint_event_filters",
             "kibana_security_endpoint_exception_items",
             "kibana_security_endpoint_host_isolation",
@@ -117,8 +116,7 @@ public class RunKibanaQueries extends BaseQuery {
 
         if (
             action.getName().equals("kibana_fleet_agents") ||
-            action.getName().equals("kibana_fleet_agent_policies") ||
-            action.getName().equals("kibana_fleet_package_policies")
+            action.getName().equals("kibana_fleet_agent_policies")
         ) {
             perPageField = "perPage";
         } else if (

--- a/src/main/resources/kibana-rest.yml
+++ b/src/main/resources/kibana-rest.yml
@@ -48,10 +48,6 @@ kibana_fleet_agent_policies:
   versions:
     ">= 7.10.0": "/api/fleet/agent_policies"
 
-kibana_fleet_package_policies:
-  versions:
-    ">=7.10.0": "/api/fleet/package_policies"
-
 kibana_fleet_packages:
   versions:
     ">=7.11.0": "/api/fleet/epm/packages?experimental=true"


### PR DESCRIPTION
This removes the Fleet Package Policy API usage from the Kibana diagnostic.