### PR TITLE
LS Hot Threads should have TXT extension not JSON

### DIFF
--- a/src/main/resources/logstash-rest.yml
+++ b/src/main/resources/logstash-rest.yml
@@ -29,7 +29,7 @@ logstash_node_stats:
 logstash_nodes_hot_threads:
   extension: ".txt"
   versions:
-    "> 0.0.0": "/_node/hot_threads?human=true&threads=10000"
+    "> 0.0.0": "/_node/hot_threads?threads=10000"
 
 logstash_plugins:
   versions:

--- a/src/main/resources/logstash-rest.yml
+++ b/src/main/resources/logstash-rest.yml
@@ -27,6 +27,7 @@ logstash_node_stats:
     "> 0.0.0": "/_node/stats?pretty"
 
 logstash_nodes_hot_threads:
+  extension: ".txt"
   versions:
     "> 0.0.0": "/_node/hot_threads?human=true&threads=10000"
 


### PR DESCRIPTION
👋🏼 howdy, team! Can we fix that `logstash_nodes_hot_threads.json` should pull as `logstash_nodes_hot_threads.txt` since it's not a valid JSON file.

![image](https://user-images.githubusercontent.com/26751266/235720126-ddc52028-d7e5-47ed-9143-7cdb1498cca7.png)
