### PR TITLE
Retrieve top-level data_stream property from indices

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -337,6 +337,16 @@ ccr_stats:
   versions:
     ">= 6.5.0": "/_ccr/stats?pretty"
 
+data_stream:
+  subdir: "commercial"
+  versions:
+    ">= 7.9.0": "/_data_stream?pretty"
+
+data_stream_index:
+  subdir: "commercial"
+  versions:
+    ">= 7.9.0": "/_all?filter_path=*.data_stream&expand_wildcards=all"
+
 enrich_policies:
   subdir: "commercial"
   versions:
@@ -510,8 +520,3 @@ xpack:
   subdir: "commercial"
   versions:
     ">= 5.0.0": "/_xpack/usage?pretty&human"
-
-data_stream:
-  subdir: "commercial"
-  versions:
-    ">= 7.9.0": "/_data_stream?pretty"


### PR DESCRIPTION
We currently collect `alias`, `settings` and `mappings` but the top-level `data_stream` property isn't in the diagnostic anywhere. This will greatly help automating and visualize data streams in our analyzer.

### Checklist

- [x] I have verified that the APIs in this pull request do not return sensitive data
