### PR TITLE
Remove `pretty` from nodes/stats and indices/stats

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -217,8 +217,8 @@ indices:
 indices_stats:
   retry: true
   versions:
-    ">= 0.9.0 < 7.7.0": "/_stats?level=shards&pretty&human"
-    ">= 7.7.0": "/_stats?level=shards&pretty&human&expand_wildcards=all"
+    ">= 0.9.0 < 7.7.0": "/_stats?level=shards&human"
+    ">= 7.7.0": "/_stats?level=shards&human&expand_wildcards=all"
 
 internal_health:
   retry: true
@@ -261,7 +261,7 @@ nodes_short:
 nodes_stats:
   retry: true
   versions:
-    ">= 0.9.0": "/_nodes/stats?pretty&human"
+    ">= 0.9.0": "/_nodes/stats?human"
 
 nodes_usage:
   versions:


### PR DESCRIPTION
Removing `pretty` from the `nodes_stats.json` and `indices_stats.json` we will reduce the frequency of JSON parsing failures in other tools. Anyone working with local files still has the option to use tools like [`jless`](https://github.com/PaulJuliusMartinez/jless), [`fx`](https://github.com/antonmedv/fx) or [`jq`](https://github.com/stedolan/jq) to pretty-print the JSON if needed.

### Checklist

- [x] I have verified that the APIs in this pull request do not return sensitive data
