### PR TITLE
Support export/import of monitoring data from/to 8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,7 +748,7 @@ Once the data is imported you should be able to view the new data via monitoring
 
  <tr>
    <td width="20%" align="left" valign="top">--targetsuffix</td>
-   <td width="50%" align="left" valign="top">An alternative suffix to be used when ingesting documents to target such as `.monitoring-es-7-diag-import-`. Default is `yyyy-MM-dd`. Must be lowercase.</td>
+   <td width="50%" align="left" valign="top">An alternative suffix to be used when ingesting documents to target such as `.monitoring-es-{{version}}-diag-import-{{suffix}}`. Default is `yyyy-MM-dd`. Must be lowercase.</td>
    <td width="30%" align="left" valign="top">--targetsuffix test-cluster-20200106</td>
  </tr>
 

--- a/src/main/java/co/elastic/support/monitoring/MonitoringImportInputs.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringImportInputs.java
@@ -30,8 +30,8 @@ public class MonitoringImportInputs extends ElasticRestClientInputs {
     @Parameter(names = {"--clustername"}, description = "Overrides the name of the imported cluster.")
     protected String clusterName;
 
-    @Parameter(names = {"--targetsuffix"}, description = "Overrides the suffix of the import target from the date, appending it to e.g. .monitoring-es-7-diag-import-.")
-    protected String targetSuffix;
+    @Parameter(names = {"--targetsuffix"}, description = "Overrides the suffix of the import target from yyyy-MM-dd.")
+    protected String targetSuffix = DateTimeFormatter.ofPattern("yyyy-MM-dd").format(ZonedDateTime.now(ZoneId.of("+0")));
 
     @Parameter(names = {"-i", "--input"}, description = "Required: The archive that you wish to import into Elastic Monitoring. This must be in the format produced by the diagnostic export utility.")
     protected String input;
@@ -56,7 +56,7 @@ public class MonitoringImportInputs extends ElasticRestClientInputs {
 
         targetSuffix = textIOManager.textIO.newStringInputReader()
                 .withInputTrimming(true)
-                .withDefaultValue((DateTimeFormatter.ofPattern("yyyy-MM-dd").format(ZonedDateTime.now(ZoneId.of("+0")))))
+                .withDefaultValue(targetSuffix)
                 .read("Specify an alternate suffix for the import target or hit enter for the default generated name:");
 
         input = textIOManager.textIO.newStringInputReader()

--- a/src/main/resources/diags.yml
+++ b/src/main/resources/diags.yml
@@ -127,9 +127,9 @@ import-templates:
   - "monitoring-logstash-diag"
   - "metricbeat-system-diag"
 
-monitoring-extract-pattern: ".monitoring-es-7-diag-import"
-logstash-extract-pattern: ".monitoring-logstash-7-diag-import"
-metricbeat-extract-pattern: "metricbeat-7-diag-import"
+monitoring-extract-pattern: ".monitoring-es-{{version}}-diag-import-{{suffix}}"
+logstash-extract-pattern: ".monitoring-logstash-{{version}}-diag-import-{{suffix}}"
+metricbeat-extract-pattern: "metricbeat-{{version}}-diag-import-{{suffix}}"
 
 query-files:
   - general

--- a/src/main/resources/monitoring-extract/cluster_ids.json
+++ b/src/main/resources/monitoring-extract/cluster_ids.json
@@ -1,7 +1,12 @@
 {
   "query": {
     "bool": {
-      "filter": [ { "term": { "type": "cluster_stats" } } ]
+      "filter": [
+        {"bool": {"should": [
+          {"term": {"type": "cluster_stats"}},
+          {"exists": {"field": "cluster_stats"}}
+        ]}}
+      ]
     }
   },
   "collapse": {
@@ -11,5 +16,5 @@
     "timestamp": "asc"
   },
   "size": 100,
-  "_source": ["cluster_uuid", "cluster_name", "cluster_settings.cluster.metadata.display_name"]
+  "_source": ["cluster_uuid", "cluster_name", "cluster_settings.cluster.metadata.display_name", "elasticsearch.cluster.name"]
 }

--- a/src/main/resources/monitoring-extract/general.json
+++ b/src/main/resources/monitoring-extract/general.json
@@ -3,7 +3,10 @@
     "query":{
       "bool": {
         "filter": [
-          {"term": {"type": "{{type}}"} },
+          {"bool": {"should": [
+            {"term": {"type": "{{type}}"}},
+            {"exists": {"field": "{{field}}"}}
+          ]}},
           {"term": { "cluster_uuid" : "{{clusterId}}"} },
           { "range":
             { "timestamp":

--- a/src/main/resources/monitoring-extract/index_all.json
+++ b/src/main/resources/monitoring-extract/index_all.json
@@ -3,7 +3,10 @@
   "query":{
     "bool": {
       "filter": [
-        {"term": {"type": "index_stats"} },
+        {"bool": {"should": [
+          {"term": {"type": "index_stats"}},
+          {"exists": {"field": "index_stats"}}
+        ]}},
         {"term": { "cluster_uuid" : "{{clusterId}}"} },
         { "range":
           { "timestamp":

--- a/src/main/resources/monitoring-extract/index_stats.json
+++ b/src/main/resources/monitoring-extract/index_stats.json
@@ -10,7 +10,10 @@
         }}
       ],
       "filter": [
-        {"term": {"type": "{{type}}"} },
+        {"bool": {"should": [
+          {"term": {"type": "{{type}}"}},
+          {"exists": {"field": "{{field}}"}}
+        ]}},
         {"term": { "cluster_uuid" : "{{clusterId}}"} },
         { "range":
           { "timestamp":


### PR DESCRIPTION
resolves #585

~~Differences between 7.x and 8.x:~~
~~- type field is omitted in 8.x~~
~~- cluster_name moves to elasticsearch.cluster.name in 8.x~~
~~- cluster_uuid aliases to elasticsearch.cluster.id in 8.x~~
~~- create action must be used for bulk to data streams in 8.x~~

Differences in monitoring by Metricbeat 8:
- type field is omitted
- cluster_uuid aliases to [*.]elasticsearch.cluster.id
- cluster_name moves to elasticsearch.cluster.name
- bulk with create action to data streams