### PR TITLE
Polish scripts

### DIFF
--- a/scripts/diagnostics.bat
+++ b/scripts/diagnostics.bat
@@ -6,10 +6,15 @@ SET diagpath=%scriptpath:~0,-1%
 SET libpath=%diagpath%\lib\NUL
 
 IF NOT EXIST %libpath% (
-    ECHO "Runtimes library does not exist - make sure you are running the "
-    ECHO "archive with 'dist' in the name, not the one labeled: 'source'."
-    EXIT
+    ECHO Diagnostic executable not found:
+    ECHO.
+    ECHO Please make sure that you are running with the archive ending with
+    ECHO '-dist.zip' in the name and not the one labeled 'Source code'.
+    ECHO.
+    ECHO Download at https://github.com/elastic/support-diagnostics/releases/latest
+    EXIT /b 400
 )
+
 set JAVA_EXEC=java
 if not defined JAVA_HOME (
   set JAVA_EXEC=java
@@ -19,10 +24,15 @@ if not defined JAVA_HOME (
   set JAVA_EXEC=!JAVA_HOME!\bin\java
 )
 
-if not defined DIAG_JAVA_OPTIONS (
-  set DIAG_JAVA_OPTIONS=-Xmx512m
+if defined DIAG_DEBUG (
+  set DIAG_DEBUG_OPTS=-Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=y
 )
 
-"%JAVA_EXEC%" %DIAG_JAVA_OPTIONS% -cp %diagpath%\config;%diagpath%\lib\* co.elastic.support.diagnostics.DiagnosticApp %*
+if not defined DIAG_JAVA_OPTS (
+  set DIAG_JAVA_OPTS=-Xms256m -Xmx2000m
+)
+
+echo Using %DIAG_JAVA_OPTS% %DIAG_DEBUG_OPTS% for options.
+"%JAVA_EXEC%" %DIAG_JAVA_OPTS% %DIAG_DEBUG_OPTS% -cp %diagpath%\config;%diagpath%\lib\* co.elastic.support.diagnostics.DiagnosticApp %*
 
 endlocal

--- a/scripts/diagnostics.sh
+++ b/scripts/diagnostics.sh
@@ -27,7 +27,7 @@ if [ ! -x "$JAVA" ]; then
     exit 1
 fi
 
-[[ "${DIAG_DEBUG}" != "" ]] && export DIAG_DEBUG_OPTS=" -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=y"
+[[ "${DIAG_DEBUG}" != "" ]] && export DIAG_DEBUG_OPTS="-Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=y"
 
 [[ "${DIAG_JAVA_OPTS}" == "" ]] && export DIAG_JAVA_OPTS="-Xms256m -Xmx2000m"
 

--- a/scripts/export-monitoring.bat
+++ b/scripts/export-monitoring.bat
@@ -6,9 +6,13 @@ SET diagpath=%scriptpath:~0,-1%
 SET libpath=%diagpath%\lib\NUL
 
 IF NOT EXIST %libpath% (
-    ECHO "Runtimes library does not exist - make sure you are running the "
-    ECHO "archive with 'dist' in the name, not the one labeled: 'source'."
-    EXIT
+    ECHO Diagnostic executable not found:
+    ECHO.
+    ECHO Please make sure that you are running with the archive ending with
+    ECHO '-dist.zip' in the name and not the one labeled 'Source code'.
+    ECHO.
+    ECHO Download at https://github.com/elastic/support-diagnostics/releases/latest
+    EXIT /b 400
 )
 
 set JAVA_EXEC=java
@@ -20,10 +24,15 @@ if not defined JAVA_HOME (
   set JAVA_EXEC=!JAVA_HOME!\bin\java
 )
 
-if not defined DIAG_JAVA_OPTIONS (
-  set DIAG_JAVA_OPTIONS=-Xmx2000m
+if defined DIAG_DEBUG (
+  set DIAG_DEBUG_OPTS=-Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=y
 )
 
-"%JAVA_EXEC%" %DIAG_JAVA_OPTIONS% -cp %diagpath%\config;%diagpath%\lib\* co.elastic.support.monitoring.MonitoringExportApp %*
+if not defined DIAG_JAVA_OPTS (
+  set DIAG_JAVA_OPTS=-Xms256m -Xmx2000m
+)
+
+echo Using %DIAG_JAVA_OPTS% %DIAG_DEBUG_OPTS% for options.
+"%JAVA_EXEC%" %DIAG_JAVA_OPTS% %DIAG_DEBUG_OPTS% -cp %diagpath%\config;%diagpath%\lib\* co.elastic.support.monitoring.MonitoringExportApp %*
 
 endlocal

--- a/scripts/export-monitoring.sh
+++ b/scripts/export-monitoring.sh
@@ -1,17 +1,21 @@
 #!/usr/bin/env bash
 
-scriptDir=$0
-scriptDir=${scriptDir/\/export-monitoring.sh/$''}
-libDir=$scriptDir'/lib'
+scriptDir="$0"
+scriptDir="${scriptDir/\/export-monitoring.sh/$''}"
+libDir="$scriptDir"'/lib'
 
-if [  -d "libDir" ]; then
-    echo "Runtimes library does not exist - make sure you are running the "
-    echo "archive with 'dist' in the name, not the one labeled: 'source'."
-    exit
+if [ ! -d "$libDir" ]; then
+    echo "Diagnostic executable not found:"
+    echo ""
+    echo "Please make sure that you are running with the archive ending with"
+    echo "'-dist.zip' in the name and not the one labeled 'Source code'."
+    echo ""
+    echo "Download at https://github.com/elastic/support-diagnostics/releases/latest"
+    exit 400
 fi
 
-if [ -x "$JAVA_HOME/bin/java" ]; then
-    JAVA="$JAVA_HOME/bin/java"
+if [ -x "${JAVA_HOME}/bin/java" ]; then
+    JAVA="${JAVA_HOME}/bin/java"
 else
     JAVA=`which java`
 fi
@@ -23,9 +27,9 @@ if [ ! -x "$JAVA" ]; then
     exit 1
 fi
 
-[[ ${DIAG_DEBUG} != "" ]] && export DIAG_DEBUG_OPTS=" -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=y"
+[[ "${DIAG_DEBUG}" != "" ]] && export DIAG_DEBUG_OPTS="-Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=y"
 
-[[ ${DIAG_JAVA_OPTS} == "" ]] && export DIAG_JAVA_OPTS="-Xms256m -Xmx2000m"
+[[ "${DIAG_JAVA_OPTS}" == "" ]] && export DIAG_JAVA_OPTS="-Xms256m -Xmx2000m"
 
 echo "Using ${DIAG_JAVA_OPTS} ${DIAG_DEBUG_OPTS} for options."
-"$JAVA" $DIAG_JAVA_OPTS ${DIAG_DEBUG_OPTS} -cp ${scriptDir}/config:${scriptDir}/lib/* co.elastic.support.monitoring.MonitoringExportApp "$@"
+"$JAVA" $DIAG_JAVA_OPTS ${DIAG_DEBUG_OPTS} -cp "${scriptDir}/config:${scriptDir}/lib/*" co.elastic.support.monitoring.MonitoringExportApp "$@"

--- a/scripts/import-monitoring.bat
+++ b/scripts/import-monitoring.bat
@@ -6,9 +6,13 @@ SET diagpath=%scriptpath:~0,-1%
 SET libpath=%diagpath%\lib\NUL
 
 IF NOT EXIST %libpath% (
-    ECHO "Runtimes library does not exist - make sure you are running the "
-    ECHO "archive with 'dist' in the name, not the one labeled: 'source'."
-    EXIT
+    ECHO Diagnostic executable not found:
+    ECHO.
+    ECHO Please make sure that you are running with the archive ending with
+    ECHO '-dist.zip' in the name and not the one labeled 'Source code'.
+    ECHO.
+    ECHO Download at https://github.com/elastic/support-diagnostics/releases/latest
+    EXIT /b 400
 )
 
 set JAVA_EXEC=java
@@ -20,10 +24,15 @@ if not defined JAVA_HOME (
   set JAVA_EXEC=!JAVA_HOME!\bin\java
 )
 
-if not defined DIAG_JAVA_OPTIONS (
-  set DIAG_JAVA_OPTIONS=-Xmx2000m
+if defined DIAG_DEBUG (
+  set DIAG_DEBUG_OPTS=-Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=y
 )
 
-"%JAVA_EXEC%" %DIAG_JAVA_OPTIONS% -cp %diagpath%\config;%diagpath%\lib\* co.elastic.support.monitoring.MonitoringImportApp %*
+if not defined DIAG_JAVA_OPTS (
+  set DIAG_JAVA_OPTS=-Xms256m -Xmx2000m
+)
+
+echo Using %DIAG_JAVA_OPTS% %DIAG_DEBUG_OPTS% for options.
+"%JAVA_EXEC%" %DIAG_JAVA_OPTS% %DIAG_DEBUG_OPTS% -cp %diagpath%\config;%diagpath%\lib\* co.elastic.support.monitoring.MonitoringImportApp %*
 
 endlocal

--- a/scripts/import-monitoring.sh
+++ b/scripts/import-monitoring.sh
@@ -1,17 +1,21 @@
 #!/usr/bin/env bash
 
-scriptDir=$0
-scriptDir=${scriptDir/\/import-monitoring.sh/$''}
-libDir=$scriptDir'/lib'
+scriptDir="$0"
+scriptDir="${scriptDir/\/import-monitoring.sh/$''}"
+libDir="$scriptDir"'/lib'
 
-if [  -d "libDir" ]; then
-    echo "Runtimes library does not exist - make sure you are running the "
-    echo "archive with 'dist' in the name, not the one labeled: 'source'."
-    exit
+if [ ! -d "$libDir" ]; then
+    echo "Diagnostic executable not found:"
+    echo ""
+    echo "Please make sure that you are running with the archive ending with"
+    echo "'-dist.zip' in the name and not the one labeled 'Source code'."
+    echo ""
+    echo "Download at https://github.com/elastic/support-diagnostics/releases/latest"
+    exit 400
 fi
 
-if [ -x "$JAVA_HOME/bin/java" ]; then
-    JAVA="$JAVA_HOME/bin/java"
+if [ -x "${JAVA_HOME}/bin/java" ]; then
+    JAVA="${JAVA_HOME}/bin/java"
 else
     JAVA=`which java`
 fi
@@ -23,9 +27,9 @@ if [ ! -x "$JAVA" ]; then
     exit 1
 fi
 
-[[ ${DIAG_DEBUG} != "" ]] && export DIAG_DEBUG_OPTS=" -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=y"
+[[ "${DIAG_DEBUG}" != "" ]] && export DIAG_DEBUG_OPTS="-Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=y"
 
-[[ ${DIAG_JAVA_OPTS} == "" ]] && export DIAG_JAVA_OPTS="-Xms256m -Xmx2000m"
+[[ "${DIAG_JAVA_OPTS}" == "" ]] && export DIAG_JAVA_OPTS="-Xms256m -Xmx2000m"
 
 echo "Using ${DIAG_JAVA_OPTS} ${DIAG_DEBUG_OPTS} for options."
-"$JAVA" $DIAG_JAVA_OPTS ${DIAG_DEBUG_OPTS} -cp ${scriptDir}/config:${scriptDir}/lib/* co.elastic.support.monitoring.MonitoringImportApp "$@"
+"$JAVA" $DIAG_JAVA_OPTS ${DIAG_DEBUG_OPTS} -cp "${scriptDir}/config:${scriptDir}/lib/*" co.elastic.support.monitoring.MonitoringImportApp "$@"

--- a/scripts/scrub.bat
+++ b/scripts/scrub.bat
@@ -6,9 +6,13 @@ SET diagpath=%scriptpath:~0,-1%
 SET libpath=%diagpath%\lib\NUL
 
 IF NOT EXIST %libpath% (
-    ECHO "Runtimes library does not exist - make sure you are running the "
-    ECHO "archive with 'dist' in the name, not the one labeled: 'source'."
-    EXIT
+    ECHO Diagnostic executable not found:
+    ECHO.
+    ECHO Please make sure that you are running with the archive ending with
+    ECHO '-dist.zip' in the name and not the one labeled 'Source code'.
+    ECHO.
+    ECHO Download at https://github.com/elastic/support-diagnostics/releases/latest
+    EXIT /b 400
 )
 
 set JAVA_EXEC=java
@@ -20,10 +24,15 @@ if not defined JAVA_HOME (
   set JAVA_EXEC=!JAVA_HOME!\bin\java
 )
 
-if not defined DIAG_JAVA_OPTIONS (
-  set DIAG_JAVA_OPTIONS=-Xmx2000m
+if defined DIAG_DEBUG (
+  set DIAG_DEBUG_OPTS=-Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=y
 )
 
-"%JAVA_EXEC%" %DIAG_JAVA_OPTIONS% -cp %diagpath%\config;%diagpath%\lib\* co.elastic.support.scrub.ScrubApp %*
+if not defined DIAG_JAVA_OPTS (
+  set DIAG_JAVA_OPTS=-Xms8g -Xmx8g
+)
+
+echo Using %DIAG_JAVA_OPTS% %DIAG_DEBUG_OPTS% for options.
+"%JAVA_EXEC%" %DIAG_JAVA_OPTS% %DIAG_DEBUG_OPTS% -cp %diagpath%\config;%diagpath%\lib\* co.elastic.support.scrub.ScrubApp %*
 
 endlocal

--- a/scripts/scrub.sh
+++ b/scripts/scrub.sh
@@ -1,17 +1,21 @@
 #!/usr/bin/env bash
 
-scriptDir=$0
-scriptDir=${scriptDir/\/scrub.sh/$''}
-libDir=$scriptDir'/lib'
+scriptDir="$0"
+scriptDir="${scriptDir/\/scrub.sh/$''}"
+libDir="$scriptDir"'/lib'
 
-if [  -d "libDir" ]; then
-    echo "Runtimes library does not exist - make sure you are running the "
-    echo "archive with 'dist-' in the name, not the one labeled: 'source'."
-    exit
+if [ ! -d "$libDir" ]; then
+    echo "Diagnostic executable not found:"
+    echo ""
+    echo "Please make sure that you are running with the archive ending with"
+    echo "'-dist.zip' in the name and not the one labeled 'Source code'."
+    echo ""
+    echo "Download at https://github.com/elastic/support-diagnostics/releases/latest"
+    exit 400
 fi
 
-if [ -x "$JAVA_HOME/bin/java" ]; then
-    JAVA="$JAVA_HOME/bin/java"
+if [ -x "${JAVA_HOME}/bin/java" ]; then
+    JAVA="${JAVA_HOME}/bin/java"
 else
     JAVA=`which java`
 fi
@@ -23,9 +27,9 @@ if [ ! -x "$JAVA" ]; then
     exit 1
 fi
 
-[[ ${DIAG_DEBUG} != "" ]] && export DIAG_DEBUG_OPTS=" -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=y"
+[[ "${DIAG_DEBUG}" != "" ]] && export DIAG_DEBUG_OPTS="-Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=y"
 
-[[ ${DIAG_JAVA_OPTS} == "" ]] && export DIAG_JAVA_OPTS="-Xms8g -Xmx8g"
+[[ "${DIAG_JAVA_OPTS}" == "" ]] && export DIAG_JAVA_OPTS="-Xms8g -Xmx8g"
 
 echo "Using ${DIAG_JAVA_OPTS} ${DIAG_DEBUG_OPTS} for options."
-"$JAVA" $DIAG_JAVA_OPTS ${DIAG_DEBUG_OPTS} -cp ${scriptDir}/config:${scriptDir}/lib/* co.elastic.support.scrub.ScrubApp "$@"
+"$JAVA" $DIAG_JAVA_OPTS ${DIAG_DEBUG_OPTS} -cp "${scriptDir}/config:${scriptDir}/lib/*" co.elastic.support.scrub.ScrubApp "$@"


### PR DESCRIPTION
- Unify error message on missing libDir among all scripts
- Unify DIAG_JAVA_OPTS between bat and sh files
- Unify details such as quotation among each type of files
- Port DIAG_DEBUG and related message from sh to bat files
- Change DIAG_JAVA_OPTIONS to DIAG_JAVA_OPTS in bat files
- Add /b option to exit in bat files

<details>
<summary>Test: Run bat files in source</summary>

```console
C:\Users\YouheiSakurai\git\support-diagnostics>scripts\diagnostics.bat --help
Diagnostic executable not found:

Please make sure that you are running with the archive ending with
'-dist.zip' in the name and not the one labeled 'Source code'.

Download at https://github.com/elastic/support-diagnostics/releases/latest

C:\Users\YouheiSakurai\git\support-diagnostics>scripts\import-monitoring.bat --help
Diagnostic executable not found:

Please make sure that you are running with the archive ending with
'-dist.zip' in the name and not the one labeled 'Source code'.

Download at https://github.com/elastic/support-diagnostics/releases/latest

C:\Users\YouheiSakurai\git\support-diagnostics>scripts\export-monitoring.bat --help
Diagnostic executable not found:

Please make sure that you are running with the archive ending with
'-dist.zip' in the name and not the one labeled 'Source code'.

Download at https://github.com/elastic/support-diagnostics/releases/latest

C:\Users\YouheiSakurai\git\support-diagnostics>scripts\scrub.bat --help
Diagnostic executable not found:

Please make sure that you are running with the archive ending with
'-dist.zip' in the name and not the one labeled 'Source code'.

Download at https://github.com/elastic/support-diagnostics/releases/latest
```
</details>

<details>
<summary>Test: Run bat files in dist</summary>

```console
C:\Users\YouheiSakurai\git\support-diagnostics>diagnostics-8.4.4-SNAPSHOT\diagnostics.bat --help
No Java Home was found. Using current path. If execution fails please install Java and make sure it is in the search path or exposed via the JAVA_HOME environment variable.
Using -Xms256m -Xmx2000m  for options.
2023-05-27 04:24:45,370 main ERROR Unable to locate appender "diag" for logger config "root"
SLF4J: Class path contains multiple SLF4J bindings.
...
C:\Users\YouheiSakurai\git\support-diagnostics>diagnostics-8.4.4-SNAPSHOT\import-monitoring.bat --help
No Java Home was found. Using current path. If execution fails please install Java and make sure it is in the search path or exposed via the JAVA_HOME environment variable.
Using -Xms256m -Xmx2000m  for options.
2023-05-27 04:25:30,285 main ERROR Unable to locate appender "diag" for logger config "root"
SLF4J: Class path contains multiple SLF4J bindings.
...
C:\Users\YouheiSakurai\git\support-diagnostics>diagnostics-8.4.4-SNAPSHOT\export-monitoring.bat --help
No Java Home was found. Using current path. If execution fails please install Java and make sure it is in the search path or exposed via the JAVA_HOME environment variable.
Using -Xms256m -Xmx2000m  for options.
2023-05-27 04:25:56,400 main ERROR Unable to locate appender "diag" for logger config "root"
SLF4J: Class path contains multiple SLF4J bindings.
...
C:\Users\YouheiSakurai\git\support-diagnostics>diagnostics-8.4.4-SNAPSHOT\scrub.bat --help
No Java Home was found. Using current path. If execution fails please install Java and make sure it is in the search path or exposed via the JAVA_HOME environment variable.
Using -Xms8g -Xmx8g  for options.
2023-05-27 04:26:15,047 main ERROR Unable to locate appender "diag" for logger config "root"
SLF4J: Class path contains multiple SLF4J bindings.
...
```
</details>

<details>
<summary>Test: Run sh files in source</summary>

```console
root@wsl:/mnt/c/Users/YouheiSakurai/git/support-diagnostics# scripts/diagnostics.sh --help
Diagnostic executable not found:

Please make sure that you are running with the archive ending with
'-dist.zip' in the name and not the one labeled 'Source code'.

Download at https://github.com/elastic/support-diagnostics/releases/latest
root@wsl:/mnt/c/Users/YouheiSakurai/git/support-diagnostics# scripts/import-monitoring.sh --help
Diagnostic executable not found:

Please make sure that you are running with the archive ending with
'-dist.zip' in the name and not the one labeled 'Source code'.

Download at https://github.com/elastic/support-diagnostics/releases/latest
root@wsl:/mnt/c/Users/YouheiSakurai/git/support-diagnostics# scripts/export-monitoring.sh --help
Diagnostic executable not found:

Please make sure that you are running with the archive ending with
'-dist.zip' in the name and not the one labeled 'Source code'.

Download at https://github.com/elastic/support-diagnostics/releases/latest
root@wsl:/mnt/c/Users/YouheiSakurai/git/support-diagnostics# scripts/scrub.sh --help
Diagnostic executable not found:

Please make sure that you are running with the archive ending with
'-dist.zip' in the name and not the one labeled 'Source code'.

Download at https://github.com/elastic/support-diagnostics/releases/latest
```
</details>

<details>
<summary>Test: Run bat files in dist</summary>

```console
bash-4.4# diagnostics-8.4.4-SNAPSHOT/diagnostics.sh --help
Using /usr/java/openjdk-18/bin/java as Java Runtime
Using -Xms256m -Xmx2000m  for options.
2023-05-26 19:30:17,966 main ERROR Unable to locate appender "diag" for logger config "root"
SLF4J: Class path contains multiple SLF4J bindings.
...

bash-4.4# diagnostics-8.4.4-SNAPSHOT/import-monitoring.sh --help
Using /usr/java/openjdk-18/bin/java as Java Runtime
Using -Xms256m -Xmx2000m  for options.
2023-05-26 19:30:48,120 main ERROR Unable to locate appender "diag" for logger config "root"
SLF4J: Class path contains multiple SLF4J bindings.
...
bash-4.4# diagnostics-8.4.4-SNAPSHOT/export-monitoring.sh --help
Using /usr/java/openjdk-18/bin/java as Java Runtime
Using -Xms256m -Xmx2000m  for options.
2023-05-26 19:31:07,463 main ERROR Unable to locate appender "diag" for logger config "root"
SLF4J: Class path contains multiple SLF4J bindings.
...
bash-4.4# diagnostics-8.4.4-SNAPSHOT/scrub.sh --help
Using /usr/java/openjdk-18/bin/java as Java Runtime
Using -Xms8g -Xmx8g  for options.
2023-05-26 19:31:29,387 main ERROR Unable to locate appender "diag" for logger config "root"
SLF4J: Class path contains multiple SLF4J bindings.
...
```
</details>
