### PR TITLE
Add Detection Engine health API

### DIFF
--- a/src/main/java/co/elastic/support/diagnostics/commands/RunKibanaQueries.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/RunKibanaQueries.java
@@ -52,7 +52,7 @@ public class RunKibanaQueries extends BaseQuery {
     private static final List<String> pagedActions = Arrays.asList(
         new String[] {
             "kibana_alerts",
-            "kibana_detection_engine_find",
+            "kibana_detection_engine_rules_installed",
             "kibana_fleet_agent_policies",
             "kibana_fleet_agents",
             "kibana_security_endpoint_event_filters",

--- a/src/main/resources/kibana-rest.yml
+++ b/src/main/resources/kibana-rest.yml
@@ -27,18 +27,37 @@ kibana_alerts_health:
     ">= 7.11.0 < 7.13.0": "/api/alerts/_health"
     ">= 7.13.0": "/api/alerting/_health"
 
-kibana_detection_engine_find:
+# Calculates health of Detection Engine and returns a health snapshot.
+# Scope: the whole cluster = all detection rules in all Kibana spaces.
+# https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/common/detection_engine/rule_monitoring/api/detection_engine_health/README.md
+kibana_detection_engine_health_cluster:
   versions:
-    ">= 7.6.0": "/api/detection_engine/rules/_find?sort_field=enabled&sort_order=asc"
+    ">= 8.8.2": "/internal/detection_engine/health/_cluster"
+
+# Calculates health of Detection Engine and returns a health snapshot.
+# Scope: all detection rules in the current/default Kibana space.
+# https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/common/detection_engine/rule_monitoring/api/detection_engine_health/README.md
+kibana_detection_engine_health_space:
+  versions:
+    ">= 8.8.2": "/internal/detection_engine/health/_space"
 
 kibana_detection_engine_privileges:
   versions:
     ">= 7.6.0": "/api/detection_engine/privileges"
 
-kibana_detection_engine_signals:
+# Returns installed detection rules, both prebuilt and custom. This endpoint requires pagination.
+# Scope: current/default Kibana space.
+kibana_detection_engine_rules_installed:
+  versions:
+    ">= 7.6.0": "/api/detection_engine/rules/_find?sort_field=enabled&sort_order=asc"
+
+# Returns status of prebuilt detection rules: how many of them are installed, can be installed, can be upgraded, etc.
+# Scope: current/default Kibana space.
+kibana_detection_engine_rules_prebuilt_status:
   versions:
     ">= 7.10.0 < 7.15.0": "/api/detection_engine/prepackaged"
-    ">= 7.15.0": "/api/detection_engine/rules/prepackaged/_status"
+    ">= 7.15.0 < 8.9.0": "/api/detection_engine/rules/prepackaged/_status"
+    ">= 8.9.0": "/internal/detection_engine/prebuilt_rules/status"
 
 kibana_fleet_agents:
   versions:


### PR DESCRIPTION
**Epic:** https://github.com/elastic/kibana/issues/125642

## Summary

This PR adds the Detection Engine health API implemented in https://github.com/elastic/kibana/pull/157155, to the list of supported endpoints. There was also some cleanup done.

- `/internal/detection_engine/health/_cluster` endpoint is added as `kibana_detection_engine_health_cluster`
- `/internal/detection_engine/health/_space` endpoint is added as `kibana_detection_engine_health_space`
- `kibana_detection_engine_find` renamed to `kibana_detection_engine_rules_installed`
- `kibana_detection_engine_signals` renamed to `kibana_detection_engine_rules_prebuilt_status`
- Added comments, sorted the entries

### Checklist

- [x] I have verified that the APIs in this pull request do not return sensitive data
