### PR TITLE
Drop Support for `tar` files and and `light` mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Once the REST calls are complete, system calls such as top, netstat, iostat, etc
 
 The application can be run from any directory on the machine. It does not require installation to a specific location, and the only requirement is that the user has read access to the Elasticsearch artifacts, write access to the chosen output directory, and sufficient disk space for the generated archive.
 
-
 ## License
 
 This software is licensed under [Elastic License v2](https://www.elastic.co/licensing/elastic-license).
@@ -65,7 +64,7 @@ This software is licensed under [Elastic License v2](https://www.elastic.co/lice
 
 - JDK - Oracle or OpenJDK, 1.8-13.
   - The IBM JDK is not supported due to JSSE related issues that can cause TLS errors.
-  - **Important Note For Elasticsearch Version 7:** Elasticsearch now includes a bundled JVM that is used by default. For the diagnostic to retrieve thread dumps via  `Jstack` it must be executed with the same JVM that was used to run Elasticsearch. The diagnostic utility will attempt to find the location of the JVM that was used to run the process it is interrogating. If it is unable to do so, you may need to manually configure the location by setting `JAVA_HOME` to the directory containing the `/bin` directory for the included JDK. For example, `<path to Elasticsearch 7 deployment>/jdk/Contents/Home`.
+  - **Important Note For Elasticsearch Version 7:** Elasticsearch now includes a bundled JVM that is used by default. For the diagnostic to retrieve thread dumps via `Jstack` it must be executed with the same JVM that was used to run Elasticsearch. The diagnostic utility will attempt to find the location of the JVM that was used to run the process it is interrogating. If it is unable to do so, you may need to manually configure the location by setting `JAVA_HOME` to the directory containing the `/bin` directory for the included JDK. For example, `<path to Elasticsearch 7 deployment>/jdk/Contents/Home`.
 - The system user account for that host(not the elasticsearch login) must have sufficient authorization to run these commands and access the logs (usually in `/var/log/elasticsearch`) in order to obtain a full collection of diagnostics.
 - If you are authenticating using the built in Security, the supplied user id must have permission to execute the diagnostic URL's. The superuser role is recommended unless you are familar enough with the calls being made to tailor your own accounts and roles.
 
@@ -101,7 +100,7 @@ If you are in a rush and don't mind going through a Q&A process you can execute 
 
 - Input parameters may be specified in any order.
 - As previously stated, to ensure that all artifacts are collected it is recommended that you run the tool with elevated privileges. This means sudo on Linux type platforms and via an Administor Prompt in Windows. This is not set in stone, and is entirely dependent upon the privileges of the account running the diagnostic. Logs can be especially problematic to collect on Linux systems where Elasticsearch was installed via a package manager. When determining how to run, it is suggested you try copying one or more log files from the configured log directory to the user home of the running account. If that works you probably have sufficient authority to run without sudo or the administrative role.
-- An archive with the format `<diagnostic type>-diagnostics`-`<DateTimeStamp>`.tar.gz will be created in the working directory or an output directory you have specified.
+- An archive with the format `<diagnostic type>-diagnostics`-`<DateTimeStamp>`.zip will be created in the working directory or an output directory you have specified.
 - A truststore does not need to be specified - it's assumed you are running this against a node that you set up and if you didn't trust it you wouldn't be running this.
 - You can specify additional Java options such as a higher `-Xmx` value by setting them via the environment variable: `DIAG_JAVA_OPTS`.
 
@@ -160,13 +159,13 @@ Elasticseach, Kibana, and Logstash each have three distinct execution modes avai
    <td width="70%" align="left" valign="top">Similar to Elasticsearch local mode, this runs against a Kibana process running on the same host as the installed diagnostic utility. Retrieves Kibana REST API dignostic information as well as the output from the same system calls and the logs if stored in the default path `var/log/kibana` or in the `journalctl` for linux and mac.
    </td>
  </tr>
- 
+
  <tr>
    <td width="30%" align="left" valign="top">kibana-remote</td>
    <td width="70%" align="left" valign="top">Queries a Kibana processes running on a different host than the utility. Similar to the Elasticsearch remote option. Collects the same artifacts as the kibana-local option.
    </td>
  </tr>
- 
+
  <tr>
    <td width="30%" align="left" valign="top">kibana-api</td>
    <td width="70%" align="left" valign="top">Collects the REST API information only from a running Kibana process. Similar to the Elasticsearch type (This is the method that need to be used when collecting the data for Kibana in **Elastic cloud**).
@@ -241,12 +240,6 @@ Elasticseach, Kibana, and Logstash each have three distinct execution modes avai
    written to this location. Quotes must be used for paths with spaces. If not supplied, the working directory will be used unless it is running in a container, in which case
    the configured volume name will be used.</td>
    <td width="30%" align="left" valign="top">-o "/User/someuser/diagnostics" <br/> -o "C:\temp\My Diagnostics"</td>
- </tr>
-
-<tr>
-   <td width="20%" align="left" valign="top">--archiveType</td>
-   <td width="50%" align="left" valign="top">File type that will be used to compress the output directory. Choose between: 'zip', 'tar' or 'any'. 'any' will try to zip first and fallback to tar if the zip fails. Defaults to any.</td>
-   <td width="30%" align="left" valign="top">--archiveType zip</td>
  </tr>
 
  <tr>
@@ -418,17 +411,17 @@ sudo ./diagnostics.sh --host 10.0.0.20 --type logstash-local --port 9607
 ```
 
 Executing Kibana diagnostics locally from the same server where Kibana is running
- 
+
 ```$xslt
 sudo ./diagnostics.sh --host localhost --port 5601 --type kibana-local
 ```
 
 Running the `kibana-api` type to suppress system call and log collection and explicitly configuring an output directory (this is also the option that needs to be used when collecting the diagnostic for Kibana in **Elastic Cloud**).
- 
+
 ```$xslt
 sudo ./diagnostics.sh --host 2775abprd8230d55d11e5edc86752260dd.us-east-1.aws.found.io --port 9243 --type kibana-api -u elastic --password --ssl -o /home/user1/diag-out
 ```
- 
+
 Executing against a remote host with full collection, using sudo, and enabling trust where there's no known host entry. Note that the diagnostic is not executed via sudo because all the privileged access is on a different host.
 
 ```$xslt
@@ -451,7 +444,7 @@ Executing against a Cloud, ECE, or ECK cluster. Note that in this case we use 92
 
 ##### The Config Directory
 
-All configuration used by the utility is located on the  `/config` under the folder created when the diagnostic utility was unzipped. These can be modified to change some behaviors in the diagnostic utility.
+All configuration used by the utility is located on the `/config` under the folder created when the diagnostic utility was unzipped. These can be modified to change some behaviors in the diagnostic utility.
 
 The `*-rest.yml` files all contain queries that are executed against the cluster being diagnosed. They are versioned and the Elasticsearch calls have additional modifiers that can be used to further customize the retrievals. The `diags.yml` file has generalized configuration information and `scrub.yml` can be used to drive the sanitization (scrub) function.
 
@@ -541,7 +534,7 @@ After it has checked for IP and MAC addresses it will use any configured tokens.
  </tr>
  </table>
 
- See `./scrub.sh --help` for other options.
+See `./scrub.sh --help` for other options.
 
 #### Sanitization Examples
 
@@ -577,7 +570,7 @@ While the standard diagnostic is often useful in providing the background necess
 
 Time series data will be availalble if Elasticsearch Monitoring is enabled, but in order to view it anywhere other than locally you would need to snapshot the relevant monitoring indices or have the person wishing to view it do so via a screen sharing session. Both of these have issues of scale and utility if there is an urgent issue or multiple individuals need to be involved.
 
-This utility allows you to extract a subset of monitoring data for interval of up to 12 hours at a time. It will package this into a tar.gz file, much like the current diagnostic. After it is uploaded, a support engineer can import that data into their own monitoring cluster so it can be investigated outside of a screen share, and be easily viewed by other engineers and developers. It has the advantage of providing a view of the cluster state prior to when an issue occurred so that a better idea of what led up to the issue can be gained.
+This utility allows you to extract a subset of monitoring data for interval of up to 12 hours at a time. It will package this into a zip file, much like the current diagnostic. After it is uploaded, a support engineer can import that data into their own monitoring cluster so it can be investigated outside of a screen share, and be easily viewed by other engineers and developers. It has the advantage of providing a view of the cluster state prior to when an issue occurred so that a better idea of what led up to the issue can be gained.
 
 Not all the information contained in the standard diagnostic is going to be available in the monitoring extraction. That is because it does not collect the same quantity of data. But what it does have should be sufficient to see a number of important trends, particularly when investigating peformance related issues.
 
@@ -737,7 +730,7 @@ Once the data is imported you should be able to view the new data via monitoring
  <tr>
    <td width="20%" align="left" valign="top">-i <br></br>--input</td>
    <td width="50%" align="left" valign="top">The absolute path the to archive containing extracted monitoring data. Paths with spaces should be contained in quotes.</td>
-   <td width="30%" align="left" valign="top">--input /data/monitoring-export-20200106-161558.tar.gz</td>
+   <td width="30%" align="left" valign="top">--input /data/monitoring-export-20200106-161558.zip</td>
  </tr>
 
  <tr>

--- a/README.md
+++ b/README.md
@@ -229,6 +229,12 @@ Elasticseach, Kibana, and Logstash each have three distinct execution modes avai
  </tr>
 
  <tr>
+   <td width="20%" align="left" valign="top">--mode</td>
+   <td width="50%" align="left" valign="top">Designates whether to collect a minimal or full set of data. Enter light or full. Defaults to full.</td>
+   <td width="30%" align="left" valign="top">--mode light</td>
+ </tr>
+
+ <tr>
    <td width="20%" align="left" valign="top">--noVerify</td>
    <td width="50%" align="left" valign="top">Bypass hostname verification for the certificate when using the --ssl option.  This can be unsafe in some cases, but can be used to bypass issues with an incorrect or missing hostname in the certificate. Default value is false.</td>
    <td width="30%" align="left" valign="top">Option only - no value.</td>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.33</version>
+            <version>2.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>co.elastic.support</groupId>
     <artifactId>diagnostics</artifactId>
-    <version>8.5.1-SNAPSHOT</version>
+    <version>9.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Support Diagnostics Utilities</name>
     <description>Elastic Support Diagnostics Utilities</description>

--- a/src/main/java/co/elastic/support/BaseInputs.java
+++ b/src/main/java/co/elastic/support/BaseInputs.java
@@ -12,13 +12,11 @@ import co.elastic.support.util.TextIOManager;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import co.elastic.support.diagnostics.ShowHelpException;
-import co.elastic.support.util.ArchiveUtils.ArchiveType;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.beryx.textio.*;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -36,34 +34,31 @@ public abstract class BaseInputs {
 
     // Input Fields
 
-    @Parameter(names = {"-?", "--help"}, description = "Help contents.", help = true)
+    @Parameter(names = { "-?", "--help" }, description = "Help contents.", help = true)
     public boolean help;
 
     // If no output directory was specified default to the working directory
-    @Parameter(names = {"-o", "--out", "--output", "--outputDir"}, description = outputDirDescription)
+    @Parameter(names = { "-o", "--out", "--output", "--outputDir" }, description = outputDirDescription)
     public String outputDir = SystemProperties.userDir;
     public boolean interactive = false;
 
     // Stop the diag from checking itself for latest version.
-    @Parameter(names = {"--bypassDiagVerify"}, description = bypassDiagVerifyDescription)
+    @Parameter(names = { "--bypassDiagVerify" }, description = bypassDiagVerifyDescription)
     public boolean bypassDiagVerify = false;
-
-    @Parameter(names = {"--archiveType"}, description = archiveTypeDescription)
-    public String archiveType = "any";
 
     // End Input Fields
 
     public boolean runningInDocker = SystemUtils.isRunningInDocker();
 
-    public BaseInputs(){
-        if(runningInDocker){
+    public BaseInputs() {
+        if (runningInDocker) {
             outputDir = "/diagnostic-output";
         }
     }
 
     public abstract boolean runInteractive(TextIOManager textIOManager);
 
-    public List<String> parseInputs(TextIOManager textIOManager, String[] args){
+    public List<String> parseInputs(TextIOManager textIOManager, String[] args) {
         logger.info(Constants.CONSOLE, "Processing diagnosticInputs...");
         jCommander = new JCommander(this);
         jCommander.setCaseSensitiveOptions(true);
@@ -77,72 +72,55 @@ public abstract class BaseInputs {
         List<String> errors = new ArrayList<>();
 
         errors.addAll(ObjectUtils.defaultIfNull(validateDir(outputDir), emptyList));
-        errors.addAll(ObjectUtils.defaultIfNull(validateArchiveType(archiveType), emptyList));
 
         return errors;
     }
 
-    public void usage(){
-        if(jCommander != null){
+    public void usage() {
+        if (jCommander != null) {
             jCommander.usage();
-        }
-        else{
-            logger.error(Constants.CONSOLE, "Please rerun with the --help option or with no arguments for interactive mode.");
+        } else {
+            logger.error(Constants.CONSOLE,
+                    "Please rerun with the --help option or with no arguments for interactive mode.");
         }
     }
 
-    protected void runOutputDirInteractive(TextIOManager textIOManager){
+    protected void runOutputDirInteractive(TextIOManager textIOManager) {
         String output = textIOManager.textIO.newStringInputReader()
                 .withMinLength(0)
-                .withValueChecker(( String val, String propname) -> validateOutputDirectory(val))
+                .withValueChecker((String val, String propname) -> validateOutputDirectory(val))
                 .read(SystemProperties.lineSeparator + outputDirDescription);
 
-        if (StringUtils.isNotEmpty(output)){
+        if (StringUtils.isNotEmpty(output)) {
             outputDir = output;
         }
-
-        archiveType = textIOManager.textIO.newStringInputReader()
-                .withDefaultValue(archiveType)
-                .withIgnoreCase()
-                .withInputTrimming(true)
-                .withValueChecker(( String val, String propname) -> validateArchiveType(val))
-                .read(SystemProperties.lineSeparator + archiveTypeDescription);
     }
 
-    public List<String> validatePort(int val){
-        if (val < 1 || val > 65535){
+    public List<String> validatePort(int val) {
+        if (val < 1 || val > 65535) {
             return Collections.singletonList("Outside the valid range of port values. 1-65535 ");
         }
         return null;
     }
 
-    public List<String> validateOutputDirectory(String val){
+    public List<String> validateOutputDirectory(String val) {
         try {
             if (StringUtils.isEmpty(val.trim())) {
                 return null;
             }
 
             File file = new File(val);
-            if(!file.exists()){
+            if (!file.exists()) {
                 file.mkdir();
             }
         } catch (Exception e) {
-            logger.error( e);
-            return Collections.singletonList("Output directory did not exist and could not be created. " + Constants.CHECK_LOG);
+            logger.error(e);
+            return Collections
+                    .singletonList("Output directory did not exist and could not be created. " + Constants.CHECK_LOG);
         }
 
         return null;
 
-    }
-
-    public List<String> validateArchiveType(String archiveType) {
-        for (ArchiveType type : ArchiveType.values()) {
-            if (type.name().equalsIgnoreCase(archiveType)) {
-                return null;
-            }
-        }
-
-        return Collections.singletonList("Provided archive type [" + archiveType + "] is not supported.");
     }
 
     public List<String> validateDir(String val) {
@@ -153,7 +131,8 @@ public abstract class BaseInputs {
         File file = new File(val);
 
         if (!file.exists() || !file.isDirectory()) {
-            return Collections.singletonList("Specified directory location could not be located or is not a directory.");
+            return Collections
+                    .singletonList("Specified directory location could not be located or is not a directory.");
         }
 
         return null;
@@ -168,7 +147,8 @@ public abstract class BaseInputs {
         File file = new File(val);
 
         if (!file.exists() || file.isDirectory()) {
-            return Collections.singletonList("Specified required file location could not be located or is a directory.");
+            return Collections
+                    .singletonList("Specified required file location could not be located or is a directory.");
         }
 
         return null;

--- a/src/main/java/co/elastic/support/BaseService.java
+++ b/src/main/java/co/elastic/support/BaseService.java
@@ -29,9 +29,9 @@ public abstract class BaseService {
     protected void closeLogs() {
         logger.info(Constants.CONSOLE, "Closing loggers.");
 
-        Appender appnder = logConfig.getAppender("diag");
-        if (appnder != null && appnder.isStarted()) {
-            appnder.stop();
+        Appender appender = logConfig.getAppender("diag");
+        if (appender != null && appender.isStarted()) {
+            appender.stop();
         }
 
         logConfig.getRootLogger().removeAppender("File");

--- a/src/main/java/co/elastic/support/BaseService.java
+++ b/src/main/java/co/elastic/support/BaseService.java
@@ -22,7 +22,7 @@ import org.apache.logging.log4j.core.layout.PatternLayout;
 
 import java.io.File;
 
-public abstract  class BaseService {
+public abstract class BaseService {
 
     private Logger logger = LogManager.getLogger(BaseService.class);
     protected String logPath;
@@ -34,7 +34,7 @@ public abstract  class BaseService {
         logger.info(Constants.CONSOLE, "Closing loggers.");
 
         Appender appndr = logConfig.getAppender("diag");
-        if(appndr != null && appndr.isStarted()){
+        if (appndr != null && appndr.isStarted()) {
             appndr.stop();
         }
 
@@ -65,7 +65,7 @@ public abstract  class BaseService {
         Appender diagAppender = builder.build();
 
         Appender oldAppender = logConfig.getAppender("packaged");
-        if(oldAppender != null && oldAppender.isStarted()){
+        if (oldAppender != null && oldAppender.isStarted()) {
             oldAppender.stop();
             logConfig.getRootLogger().removeAppender("packaged");
         }
@@ -79,9 +79,9 @@ public abstract  class BaseService {
 
     }
 
-    public File createArchive(String tempDir, ArchiveType archiveType) throws DiagnosticException {
+    public File createArchive(String tempDir) throws DiagnosticException {
         logger.info(Constants.CONSOLE, "Archiving diagnostic results.");
-        return ArchiveUtils.createArchive(tempDir, SystemProperties.getFileDateString(), archiveType);
+        return ArchiveUtils.createZipArchive(tempDir, SystemProperties.getFileDateString());
     }
 
 }

--- a/src/main/java/co/elastic/support/BaseService.java
+++ b/src/main/java/co/elastic/support/BaseService.java
@@ -9,11 +9,9 @@ package co.elastic.support;
 import co.elastic.support.diagnostics.DiagnosticException;
 import co.elastic.support.util.SystemProperties;
 import co.elastic.support.util.ArchiveUtils;
-import co.elastic.support.util.ArchiveUtils.ArchiveType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.Appender;
-import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.FileAppender;
 import org.apache.logging.log4j.core.config.AppenderRef;
@@ -25,44 +23,34 @@ import java.io.File;
 public abstract class BaseService {
 
     private Logger logger = LogManager.getLogger(BaseService.class);
-    protected String logPath;
     protected LoggerContext loggerContext = (LoggerContext) LogManager.getContext(false);
     protected Configuration logConfig = loggerContext.getConfiguration();
 
     protected void closeLogs() {
-
         logger.info(Constants.CONSOLE, "Closing loggers.");
 
-        Appender appndr = logConfig.getAppender("diag");
-        if (appndr != null && appndr.isStarted()) {
-            appndr.stop();
+        Appender appnder = logConfig.getAppender("diag");
+        if (appnder != null && appnder.isStarted()) {
+            appnder.stop();
         }
 
         logConfig.getRootLogger().removeAppender("File");
-
     }
 
     protected void createFileAppender(String logDir, String logFile) {
-
-        logPath = logDir + SystemProperties.fileSeparator + logFile;
-
-        Layout layout = PatternLayout.newBuilder()
-                .withConfiguration(logConfig)
-                .withPattern("%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n")
+        Appender diagAppender = FileAppender.newBuilder()
+                .setConfiguration(logConfig)
+                .withFileName(logDir + SystemProperties.fileSeparator + logFile)
+                .withAppend(false)
+                .withLocking(false)
+                .setName("packaged")
+                .setIgnoreExceptions(false)
+                .setLayout(
+                        PatternLayout.newBuilder()
+                                .withConfiguration(logConfig)
+                                .withPattern("%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n")
+                                .build())
                 .build();
-
-        FileAppender.Builder builder = FileAppender.newBuilder();
-        builder.setConfiguration(logConfig);
-        builder.withFileName(logPath);
-        builder.withAppend(false);
-        builder.withLocking(false);
-        builder.setName("packaged");
-        builder.setIgnoreExceptions(false);
-        builder.withImmediateFlush(true);
-        builder.withBufferedIo(false);
-        builder.withBufferSize(0);
-        builder.setLayout(layout);
-        Appender diagAppender = builder.build();
 
         Appender oldAppender = logConfig.getAppender("packaged");
         if (oldAppender != null && oldAppender.isStarted()) {
@@ -76,7 +64,6 @@ public abstract class BaseService {
         logConfig.getRootLogger().addAppender(diagAppender, null, null);
         loggerContext.updateLoggers();
         logger.info(Constants.CONSOLE, "Diagnostic logger reconfigured for inclusion into archive");
-
     }
 
     public File createArchive(String tempDir) throws DiagnosticException {

--- a/src/main/java/co/elastic/support/diagnostics/DiagnosticInputs.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagnosticInputs.java
@@ -16,14 +16,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class DiagnosticInputs extends ElasticRestClientInputs {
-
-
-    public final static String[]
-            diagnosticTypeValues = {
+    public final static String[] diagnosticTypeValues = {
             Constants.local,
             Constants.remote,
             Constants.api,
@@ -32,7 +30,7 @@ public class DiagnosticInputs extends ElasticRestClientInputs {
             Constants.logstashApi,
             Constants.kibanaApi,
             Constants.kibanaLocal,
-            Constants.kibanaRemote};
+            Constants.kibanaRemote };
 
     public static final String localDesc = "Node on the same host as the diagnostic utility.";
     public static final String remoteDesc = "Node on a different host than the diagnostic utility";
@@ -44,9 +42,7 @@ public class DiagnosticInputs extends ElasticRestClientInputs {
     public static final String kibanaRemoteDesc = "Kibana on a different host than the diagnostic utility.";
     public static final String kibanaApiDesc = "Kibana REST calls. No system calls.";
 
-
-    public static final String[]
-            diagnosticTypeEntries = {
+    public static final String[] diagnosticTypeEntries = {
             Constants.local + " - " + localDesc,
             Constants.remote + " - " + remoteDesc,
             Constants.api + " - " + apiDesc,
@@ -55,87 +51,89 @@ public class DiagnosticInputs extends ElasticRestClientInputs {
             Constants.logstashApi + " - " + logstashApiDesc,
             Constants.kibanaApi + " - " + kibanaApiDesc,
             Constants.kibanaRemote + " - " + kibanaRemoteDesc,
-            Constants.kibanaLocal + " - " + kibanaLocalDesc};
+            Constants.kibanaLocal + " - " + kibanaLocalDesc };
 
-    public static final String[]
-            diagnosticTypeEntriesDocker = {
+    public static final String[] diagnosticTypeEntriesDocker = {
             Constants.remote + " - " + remoteDesc,
             Constants.api + " - " + apiDesc,
             Constants.logstashRemote + " - " + logstashRemoteDesc,
             Constants.logstashApi + " - " + logstashApiDesc,
             Constants.kibanaApi + " - " + kibanaApiDesc,
-            Constants.kibanaRemote + " - " + kibanaRemoteDesc};
+            Constants.kibanaRemote + " - " + kibanaRemoteDesc };
 
-
-    public static final String remoteAccessMessage =
-            SystemProperties.lineSeparator
-                    + "You are running the diagnostic against a remote host."
-                    + SystemProperties.lineSeparator
-                    + "You must authenticate either with a username/password combination"
-                    + SystemProperties.lineSeparator
-                    + "or a public keyfile. Keep in mind that in order to collect the logs"
-                    + SystemProperties.lineSeparator
-                    + "from the remote host one of the following MUST be true:"
-                    + SystemProperties.lineSeparator
-                    + SystemProperties.lineSeparator
-                    + "1. The account you are logging in as has read permissions for"
-                    + SystemProperties.lineSeparator
-                    + "   the log directory(usually /var/log/elasticsearch)."
-                    + SystemProperties.lineSeparator
-                    + SystemProperties.lineSeparator
-                    + "2. You select the sudo option and provide the password for "
-                    + SystemProperties.lineSeparator
-                    + "   the sudo challenge. Note that public key acesss is"
-                    + SystemProperties.lineSeparator
-                    + "    probably unneeded if this is the case."
-                    + SystemProperties.lineSeparator
-                    + SystemProperties.lineSeparator
-                    + "3. You specify sudo, use a keyfile access with an empty password, and have"
-                    + SystemProperties.lineSeparator
-                    + "   sudo configured with NOPASSWD."
-                    + SystemProperties.lineSeparator
-                    + SystemProperties.lineSeparator
-                    + "If you are unsure what situation you fall into, you should consult"
-                    + SystemProperties.lineSeparator
-                    + "someone familiar with the system or consider running with --type api"
-                    + SystemProperties.lineSeparator
-                    + "or locally from a host with a running instance."
-                    + SystemProperties.lineSeparator;
+    public static final String remoteAccessMessage = SystemProperties.lineSeparator
+            + "You are running the diagnostic against a remote host."
+            + SystemProperties.lineSeparator
+            + "You must authenticate either with a username/password combination"
+            + SystemProperties.lineSeparator
+            + "or a public keyfile. Keep in mind that in order to collect the logs"
+            + SystemProperties.lineSeparator
+            + "from the remote host one of the following MUST be true:"
+            + SystemProperties.lineSeparator
+            + SystemProperties.lineSeparator
+            + "1. The account you are logging in as has read permissions for"
+            + SystemProperties.lineSeparator
+            + "   the log directory(usually /var/log/elasticsearch)."
+            + SystemProperties.lineSeparator
+            + SystemProperties.lineSeparator
+            + "2. You select the sudo option and provide the password for "
+            + SystemProperties.lineSeparator
+            + "   the sudo challenge. Note that public key acesss is"
+            + SystemProperties.lineSeparator
+            + "    probably unneeded if this is the case."
+            + SystemProperties.lineSeparator
+            + SystemProperties.lineSeparator
+            + "3. You specify sudo, use a keyfile access with an empty password, and have"
+            + SystemProperties.lineSeparator
+            + "   sudo configured with NOPASSWD."
+            + SystemProperties.lineSeparator
+            + SystemProperties.lineSeparator
+            + "If you are unsure what situation you fall into, you should consult"
+            + SystemProperties.lineSeparator
+            + "someone familiar with the system or consider running with --type api"
+            + SystemProperties.lineSeparator
+            + "or locally from a host with a running instance."
+            + SystemProperties.lineSeparator;
 
     private static Logger logger = LogManager.getLogger(DiagnosticInputs.class);
 
-    public final static String  typeDescription = "Enter the number of the diagnostic type to run.";
-    public final static String  remoteUserDescription = "User account to be used for running system commands and obtaining logs. This account must have sufficient authority to run the commands and access the logs.";
-    public final static String  remotePasswordDescription = "Password for the remote login:";
-    public final static String  sshKeyFileDescription= "File containing keys for remote host authentication.";
-    public final static String  sshKeyFIlePassphraseDescription= "Passphrase for the keyfile if required.";
-    public final static String  trustRemoteDescription = "Bypass the known hosts file and trust the specified remote server. Defaults to false.";
-    public final static String  knownHostsDescription = "Known hosts file to search for target server. Default is ~/.ssh/known_hosts for Linux/Mac. Windows users should always set this explicitly.";
-    public final static String  sudoDescription = "Use sudo for remote commands? If not used, log retrieval and some system calls may fail.";
-    public final static String  remotePortDescription = "SSH port for the host being queried.";
+    public final static String typeDescription = "Enter the number of the diagnostic type to run.";
+    public final static String remoteUserDescription = "User account to be used for running system commands and obtaining logs. This account must have sufficient authority to run the commands and access the logs.";
+    public final static String remotePasswordDescription = "Password for the remote login:";
+    public final static String sshKeyFileDescription = "File containing keys for remote host authentication.";
+    public final static String sshKeyFIlePassphraseDescription = "Passphrase for the keyfile if required.";
+    public final static String trustRemoteDescription = "Bypass the known hosts file and trust the specified remote server. Defaults to false.";
+    public final static String knownHostsDescription = "Known hosts file to search for target server. Default is ~/.ssh/known_hosts for Linux/Mac. Windows users should always set this explicitly.";
+    public final static String sudoDescription = "Use sudo for remote commands? If not used, log retrieval and some system calls may fail.";
+    public final static String remotePortDescription = "SSH port for the host being queried.";
 
     // Input Fields
-    @Parameter(names = {"--type"}, description = "Designates the type of service to run. Enter local, remote, api, logstash, or logstash-api. Defaults to local.")
+    @Parameter(names = {
+            "--type" }, description = "Designates the type of service to run. Enter local, remote, api, logstash, or logstash-api. Defaults to local.")
     public String diagType = Constants.local;
-    @Parameter(names = {"--remoteUser"}, description = remoteUserDescription)
+    @Parameter(names = {
+            "--mode" }, description = "Designates whether to collect a minimal or full set of data. Enter light or full. Defaults to full.")
+    public String mode = "full";
+    @Parameter(names = { "--remoteUser" }, description = remoteUserDescription)
     public String remoteUser;
-    @Parameter(names = {"--remotePass"}, description = "Show password prompt for the remote user account.")
+    @Parameter(names = { "--remotePass" }, description = "Show password prompt for the remote user account.")
     public boolean isRemotePass = false;
-    @Parameter(names = {"--remotePassText"}, hidden = true)
+    @Parameter(names = { "--remotePassText" }, hidden = true)
     public String remotePassword = "";
-    @Parameter(names = {"--keyFile"}, description = sshKeyFileDescription)
+    @Parameter(names = { "--keyFile" }, description = sshKeyFileDescription)
     public String keyfile = "";
-    @Parameter(names = {"--keyFilePass" }, description = "Show prompt for keyfile passphrase for the keyfile if one exists.")
+    @Parameter(names = {
+            "--keyFilePass" }, description = "Show prompt for keyfile passphrase for the keyfile if one exists.")
     public boolean isKeyFilePass = false;
-    @Parameter(names = {"--keyFilePassText"}, hidden = true)
+    @Parameter(names = { "--keyFilePassText" }, hidden = true)
     public String keyfilePassword = "";
-    @Parameter(names = {"--trustRemote"}, description = trustRemoteDescription)
+    @Parameter(names = { "--trustRemote" }, description = trustRemoteDescription)
     public boolean trustRemote = false;
-    @Parameter(names = {"--knownHostsFile"}, description = knownHostsDescription)
+    @Parameter(names = { "--knownHostsFile" }, description = knownHostsDescription)
     public String knownHostsFile = "";
-    @Parameter(names = {"--sudo"}, description = sudoDescription)
+    @Parameter(names = { "--sudo" }, description = sudoDescription)
     public boolean isSudo = false;
-    @Parameter(names = {"--remotePort"}, description = remotePortDescription)
+    @Parameter(names = { "--remotePort" }, description = remotePortDescription)
     public int remotePort = 22;
     // End Input Fields
 
@@ -148,10 +146,7 @@ public class DiagnosticInputs extends ElasticRestClientInputs {
     String[] typeEntries;
 
     public DiagnosticInputs() {
-        this.typeEntries =
-          runningInDocker ?
-            diagnosticTypeEntriesDocker :
-            diagnosticTypeEntries;
+        this.typeEntries = runningInDocker ? diagnosticTypeEntriesDocker : diagnosticTypeEntries;
     }
 
     public DiagnosticInputs(String runner) {
@@ -177,10 +172,10 @@ public class DiagnosticInputs extends ElasticRestClientInputs {
         // We'll do this for any Elastic or Logstash submit
         runHttpInteractive(textIOManager);
 
-        if(diagType.contains("remote")) {
+        if (diagType.contains("remote")) {
             logger.info(Constants.CONSOLE, remoteAccessMessage);
 
-            String  remoteUserTxt = "User account to be used for running system commands and obtaining logs." +
+            String remoteUserTxt = "User account to be used for running system commands and obtaining logs." +
                     SystemProperties.lineSeparator
                     + "This account must have sufficient authority to run the commands and access the logs.";
 
@@ -198,22 +193,21 @@ public class DiagnosticInputs extends ElasticRestClientInputs {
                     .read(SystemProperties.lineSeparator + "Use a keyfile for authentication?");
 
             if (useKeyfile) {
-                keyfile = textIOManager
-                        .standardFileReader
+                keyfile = textIOManager.standardFileReader
                         .read(SystemProperties.lineSeparator + sshKeyFileDescription);
 
                 boolean checkMe = textIOManager.standardBooleanReader
                         .read("Is the keyfile password protected?");
 
-                if(checkMe){
+                if (checkMe) {
                     keyfilePassword = textIOManager.standardPasswordReader
                             .read(SystemProperties.lineSeparator + sshKeyFIlePassphraseDescription);
                 }
-                if(isSudo){
+                if (isSudo) {
                     checkMe = textIOManager.standardBooleanReader
                             .read("Password required for sudo challenge?");
 
-                    if(checkMe){
+                    if (checkMe) {
                         remotePassword = textIOManager.standardPasswordReader
                                 .read(SystemProperties.lineSeparator + "Enter the password for remote sudo.");
                     }
@@ -232,7 +226,7 @@ public class DiagnosticInputs extends ElasticRestClientInputs {
                     .withDefaultValue(trustRemote)
                     .read(SystemProperties.lineSeparator + trustRemoteDescription);
 
-            if (!trustRemote){
+            if (!trustRemote) {
                 knownHostsFile = textIOManager.standardFileReader
                         .read(SystemProperties.lineSeparator + knownHostsDescription);
             }
@@ -244,22 +238,23 @@ public class DiagnosticInputs extends ElasticRestClientInputs {
     }
 
     @Override
-    public List<String> parseInputs(TextIOManager textIOManager, String[] args){
+    public List<String> parseInputs(TextIOManager textIOManager, String[] args) {
         List<String> errors = super.parseInputs(textIOManager, args);
 
         errors.addAll(ObjectUtils.defaultIfNull(validateDiagType(diagType), emptyList));
+        errors.addAll(ObjectUtils.defaultIfNull(validateMode(mode), emptyList));
         errors.addAll(ObjectUtils.defaultIfNull(setDefaultPortForDiagType(diagType), emptyList));
         errors.addAll(ObjectUtils.defaultIfNull(validateRemoteUser(remoteUser), emptyList));
         errors.addAll(ObjectUtils.defaultIfNull(validatePort(remotePort), emptyList));
-        errors.addAll(ObjectUtils.defaultIfNull(textIOManager.validateFile(keyfile), emptyList));
-        errors.addAll(ObjectUtils.defaultIfNull(textIOManager.validateFile(knownHostsFile), emptyList));
+        errors.addAll(ObjectUtils.defaultIfNull(TextIOManager.validateFile(keyfile), emptyList));
+        errors.addAll(ObjectUtils.defaultIfNull(TextIOManager.validateFile(knownHostsFile), emptyList));
 
-        if(isRemotePass){
+        if (isRemotePass) {
             remotePassword = textIOManager.standardPasswordReader
                     .read(remotePasswordDescription);
         }
 
-        if(isKeyFilePass){
+        if (isKeyFilePass) {
             keyfilePassword = textIOManager.standardPasswordReader
                     .read(sshKeyFIlePassphraseDescription);
         }
@@ -268,19 +263,22 @@ public class DiagnosticInputs extends ElasticRestClientInputs {
 
     }
 
-   /**
-    * Elasticsearch, Kibana and Logstash have default port, on this function we set the default for Kibana or Logstash in case the port is not defined during the execution
-    * port variable, is a public int defined in the parent class to 9200 if not defined during the execution
-    *
-    * @param type type of diagnostic
-    *
-    */
+    /**
+     * Elasticsearch, Kibana and Logstash have default port, on this function we set
+     * the default for Kibana or Logstash in case the port is not defined during the
+     * execution
+     * port variable, is a public int defined in the parent class to 9200 if not
+     * defined during the execution
+     *
+     * @param type type of diagnostic
+     *
+     */
     public List<String> setDefaultPortForDiagType(String type) {
         if (port == 9200) {
             final String value = type.toLowerCase();
-            if (value.contains("logstash")) {
+            if (value.startsWith("logstash")) {
                 port = Constants.LOGSTASH_PORT;
-            } else if (value.contains("kibana")) {
+            } else if (value.startsWith("kibana")) {
                 port = Constants.KIBANA_PORT;
             }
         }
@@ -290,22 +288,33 @@ public class DiagnosticInputs extends ElasticRestClientInputs {
     public List<String> validateDiagType(String val) {
         List<String> types = Arrays.asList(diagnosticTypeValues);
         if (!types.contains(val)) {
-            return Collections.singletonList(val + " was not a valid diagnostic type. Enter --help to see valid choices");
+            return Collections
+                    .singletonList(val + " was not a valid diagnostic type. Enter --help to see valid choices");
         }
 
-        if(runningInDocker &&val.contains("local") ){
-            return Collections.singletonList(val + " cannot be run from within a Docker container. Please use api or remote options.");
+        if (runningInDocker && val.contains("local")) {
+            return Collections.singletonList(
+                    val + " cannot be run from within a Docker container. Please use api or remote options.");
         }
-
 
         return null;
+    }
+
+    public List<String> validateMode(String mode) {
+        switch (mode) {
+            case "light":
+            case "full":
+                return null;
+        }
+
+        return Collections.singletonList("Invalid mode [" + mode + "] must be either [light] or [full]");
     }
 
     public List<String> validateRemoteUser(String val) {
         // Check the diag type and reset the default port value if
         // it is a Logstash diag.
-        if(diagType.contains("remote")){
-            if(StringUtils.isEmpty(val)){
+        if (diagType.contains("remote")) {
+            if (StringUtils.isEmpty(val)) {
                 return Collections.singletonList("For remote execution a user account must be specified");
             }
         }
@@ -318,9 +327,10 @@ public class DiagnosticInputs extends ElasticRestClientInputs {
 
         return superString + "," + "DiagnosticInputs: {" +
                 ", diagType='" + diagType + '\'' +
+                ", mode='" + mode + '\'' +
                 ", remoteUser='" + remoteUser + '\'' +
                 ", keyfile='" + keyfile + '\'' +
-                ", isKeyFilePass=" +  isKeyFilePass + '\'' +
+                ", isKeyFilePass=" + isKeyFilePass + '\'' +
                 ", trustRemote=" + trustRemote + '\'' +
                 ", knownHostsFile='" + knownHostsFile + '\'' +
                 ", sudo=" + isSudo + '\'' +

--- a/src/main/java/co/elastic/support/diagnostics/DiagnosticService.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagnosticService.java
@@ -13,7 +13,6 @@ import co.elastic.support.Constants;
 import co.elastic.support.diagnostics.chain.DiagnosticChainExec;
 import co.elastic.support.diagnostics.chain.DiagnosticContext;
 import co.elastic.support.rest.RestClient;
-import co.elastic.support.util.ArchiveUtils.ArchiveType;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -32,52 +31,59 @@ public class DiagnosticService extends ElasticRestClientService {
         DiagnosticInputs inputs = context.diagnosticInputs;
         File file;
 
-        try(
+        try (
                 RestClient esRestClient = RestClient.getClient(
-                    inputs.host,
-                    inputs.port,
-                    inputs.scheme,
-                    inputs.user,
-                    inputs.password,
-                    inputs.proxyHost,
-                    inputs.proxyPort,
-                    inputs.proxyUser,
-                    inputs.proxyPassword,
-                    inputs.pkiKeystore,
-                    inputs.pkiKeystorePass,
-                    inputs.skipVerification,
-                    config.extraHeaders,
-                    config.connectionTimeout,
-                    config.connectionRequestTimeout,
-                    config.socketTimeout
-            )){
+                        inputs.host,
+                        inputs.port,
+                        inputs.scheme,
+                        inputs.user,
+                        inputs.password,
+                        inputs.proxyHost,
+                        inputs.proxyPort,
+                        inputs.proxyUser,
+                        inputs.proxyPassword,
+                        inputs.pkiKeystore,
+                        inputs.pkiKeystorePass,
+                        inputs.skipVerification,
+                        config.extraHeaders,
+                        config.connectionTimeout,
+                        config.connectionRequestTimeout,
+                        config.socketTimeout)) {
 
             context.resourceCache.addRestClient(Constants.restInputHost, esRestClient);
 
             // Create the temp directory - delete if first if it exists from a previous run
             String outputDir = inputs.outputDir;
             context.tempDir = outputDir + SystemProperties.fileSeparator + inputs.diagType + "-" + Constants.ES_DIAG;
-            logger.info(Constants.CONSOLE, "{}Creating temp directory: {}", SystemProperties.lineSeparator, context.tempDir);
+            logger.info(Constants.CONSOLE, "{}Creating temp directory: {}", SystemProperties.lineSeparator,
+                    context.tempDir);
 
             try {
                 FileUtils.deleteDirectory(new File(context.tempDir));
                 Files.createDirectories(Paths.get(context.tempDir));
-            }
-            catch (IOException ioe) {
+            } catch (IOException ioe) {
                 logger.error("Temp directory error", ioe);
-                logger.info(Constants.CONSOLE, String.format("Issue with creating temp directory. %s", Constants.CHECK_LOG));
+                logger.info(Constants.CONSOLE,
+                        String.format("Issue with creating temp directory. %s", Constants.CHECK_LOG));
                 throw new DiagnosticException("Could not create temporary directory", ioe);
             }
 
-            // Modify the log file setup since we're going to package it with the diagnostic.
-            // The log4 configuration file sets up 2 loggers, one strictly for the console and a file log in the working directory to handle
-            // any errors we get at the library level that occur before we can get it initiailized.  When we have a target directory to
-            // redirect output to we can reconfigure the appender to go to the diagnostic output temp directory for packaging with the archive.
-            // This lets you configure and create loggers via the file if you want to up the level on one of the library dependencies as well
+            // Modify the log file setup since we're going to package it with the
+            // diagnostic.
+            // The log4 configuration file sets up 2 loggers, one strictly for the console
+            // and a file log in the working directory to handle
+            // any errors we get at the library level that occur before we can get it
+            // initiailized. When we have a target directory to
+            // redirect output to we can reconfigure the appender to go to the diagnostic
+            // output temp directory for packaging with the archive.
+            // This lets you configure and create loggers via the file if you want to up the
+            // level on one of the library dependencies as well
             // as internal classes.
-            // If you want the output to also be shown on the console use: logger.info/error/warn/debug(Constants.CONSOLE, "Some log message");
+            // If you want the output to also be shown on the console use:
+            // logger.info/error/warn/debug(Constants.CONSOLE, "Some log message");
             // This will also log that same output to the diagnostic log file.
-            // To just log to the file log as normal: logger.info/error/warn/debug("Log mewssage");
+            // To just log to the file log as normal: logger.info/error/warn/debug("Log
+            // mewssage");
 
             if (context.includeLogs) {
                 logger.info(Constants.CONSOLE, "Configuring log file.");
@@ -86,7 +92,8 @@ public class DiagnosticService extends ElasticRestClientService {
             DiagnosticChainExec.runDiagnostic(context, inputs.diagType);
 
             if (context.dockerPresent) {
-                logger.info(Constants.CONSOLE, "Identified Docker installations - bypassed log collection and some system calls.");
+                logger.info(Constants.CONSOLE,
+                        "Identified Docker installations - bypassed log collection and some system calls.");
             }
 
             checkAuthLevel(context.diagnosticInputs.user, context.isAuthorized);
@@ -94,7 +101,7 @@ public class DiagnosticService extends ElasticRestClientService {
             if (context.includeLogs) {
                 closeLogs();
             }
-            file = createArchive(context.tempDir, ArchiveType.fromString(inputs.archiveType));
+            file = createArchive(context.tempDir);
             SystemUtils.nukeDirectory(context.tempDir);
         }
 

--- a/src/main/java/co/elastic/support/diagnostics/chain/DiagnosticChainExec.java
+++ b/src/main/java/co/elastic/support/diagnostics/chain/DiagnosticChainExec.java
@@ -16,6 +16,7 @@ import co.elastic.support.diagnostics.commands.CollectDockerInfo;
 import co.elastic.support.diagnostics.commands.CollectKibanaLogs;
 import co.elastic.support.diagnostics.commands.CollectLogs;
 import co.elastic.support.diagnostics.commands.CollectSystemCalls;
+import co.elastic.support.diagnostics.commands.GenerateDiagnosticManifest;
 import co.elastic.support.diagnostics.commands.GenerateLogstashDiagnostics;
 import co.elastic.support.diagnostics.commands.GenerateManifest;
 import co.elastic.support.diagnostics.commands.KibanaGetDetails;
@@ -30,105 +31,106 @@ public class DiagnosticChainExec {
     public static void runDiagnostic(DiagnosticContext context, String type) throws DiagnosticException {
         new CheckDiagnosticVersion().execute(context);
 
-        switch (type){
-            case Constants.api :
+        switch (type) {
+            case Constants.api:
                 new CheckElasticsearchVersion().execute(context);
                 new CheckUserAuthLevel().execute(context);
                 // Removed temporarily due to issues with finding and accessing cloud master
-                //new CheckPlatformDetails().execute(context);
+                // new CheckPlatformDetails().execute(context);
                 new RunClusterQueries().execute(context);
                 break;
 
-            case Constants.local :
+            case Constants.local:
                 new CheckElasticsearchVersion().execute(context);
                 new CheckUserAuthLevel().execute(context);
                 new CheckPlatformDetails().execute(context);
                 new RunClusterQueries().execute(context);
-                if(context.runSystemCalls){
+                if (context.runSystemCalls) {
                     new CollectSystemCalls().execute(context);
                     new CollectLogs().execute(context);
                     new RetrieveSystemDigest().execute(context);
                 }
-                if(context.dockerPresent){
+                if (context.dockerPresent) {
                     new CollectDockerInfo().execute(context);
                 }
                 break;
 
-            case Constants.remote :
+            case Constants.remote:
                 new CheckElasticsearchVersion().execute(context);
                 new CheckUserAuthLevel().execute(context);
                 new CheckPlatformDetails().execute(context);
                 new RunClusterQueries().execute(context);
-                if(context.runSystemCalls){
+                if (context.runSystemCalls) {
                     new CollectSystemCalls().execute(context);
                     new CollectLogs().execute(context);
                 }
-                if(context.dockerPresent){
+                if (context.dockerPresent) {
                     new CollectDockerInfo().execute(context);
                 }
                 break;
 
-            case Constants.logstashLocal :
+            case Constants.logstashLocal:
                 new RunLogstashQueries().execute(context);
                 new GenerateLogstashDiagnostics().execute(context);
-                if(context.runSystemCalls){
+                if (context.runSystemCalls) {
                     new CollectSystemCalls().execute(context);
                     new RetrieveSystemDigest().execute(context);
                 }
-                if(context.dockerPresent){
+                if (context.dockerPresent) {
                     new CollectDockerInfo().execute(context);
                 }
                 break;
 
-            case Constants.logstashRemote :
+            case Constants.logstashRemote:
                 new RunLogstashQueries().execute(context);
                 new GenerateLogstashDiagnostics().execute(context);
-                if(context.runSystemCalls){
+                if (context.runSystemCalls) {
                     new CollectSystemCalls().execute(context);
                 }
-                if(context.dockerPresent){
+                if (context.dockerPresent) {
                     new CollectDockerInfo().execute(context);
                 }
                 break;
 
-            case Constants.logstashApi :
+            case Constants.logstashApi:
                 new RunLogstashQueries().execute(context);
                 break;
 
-            case Constants.kibanaLocal :
+            case Constants.kibanaLocal:
                 new CheckKibanaVersion().execute(context);
                 new KibanaGetDetails().execute(context);
                 new RunKibanaQueries().execute(context);
-                if(context.runSystemCalls){
+                if (context.runSystemCalls) {
                     new CollectSystemCalls().execute(context);
                     new CollectKibanaLogs().execute(context);
                     new RetrieveSystemDigest().execute(context);
                 }
-                if(context.dockerPresent){
+                if (context.dockerPresent) {
                     new CollectDockerInfo().execute(context);
                 }
                 break;
 
-            case Constants.kibanaRemote :
+            case Constants.kibanaRemote:
                 new CheckKibanaVersion().execute(context);
                 new KibanaGetDetails().execute(context);
                 new RunKibanaQueries().execute(context);
-                if(context.runSystemCalls){
+                if (context.runSystemCalls) {
                     new CollectSystemCalls().execute(context);
                     new CollectKibanaLogs().execute(context);
                 }
-                if(context.dockerPresent){
+                if (context.dockerPresent) {
                     new CollectDockerInfo().execute(context);
                 }
                 break;
 
-             case Constants.kibanaApi :
+            case Constants.kibanaApi:
                 new CheckKibanaVersion().execute(context);
                 new RunKibanaQueries().execute(context);
                 break;
-            }
+        }
 
         new GenerateManifest().execute(context);
+        new GenerateDiagnosticManifest().execute(context);
     }
 
 }

--- a/src/main/java/co/elastic/support/diagnostics/chain/DiagnosticContext.java
+++ b/src/main/java/co/elastic/support/diagnostics/chain/DiagnosticContext.java
@@ -30,7 +30,7 @@ public class DiagnosticContext {
    public String tempDir = "";
    public String diagVersion;
 
-   //public RestClient esRestClient;
+   // public RestClient esRestClient;
    public DiagConfig diagsConfig;
    public DiagnosticInputs diagnosticInputs;
    public ProcessProfile targetNode;
@@ -38,10 +38,12 @@ public class DiagnosticContext {
 
    public List<String> dockerContainers = new ArrayList<String>();
    public Map<String, RestEntry> elasticRestCalls;
+   public Map<String, RestEntry> fullElasticRestCalls;
 
    public ResourceCache resourceCache;
 
-   public DiagnosticContext(DiagConfig diagConfig, DiagnosticInputs diagnosticInputs, ResourceCache resourceCache, boolean includeLogs) {
+   public DiagnosticContext(DiagConfig diagConfig, DiagnosticInputs diagnosticInputs, ResourceCache resourceCache,
+         boolean includeLogs) {
       this.diagsConfig = diagConfig;
       this.diagnosticInputs = diagnosticInputs;
       this.resourceCache = resourceCache;

--- a/src/main/java/co/elastic/support/diagnostics/commands/CheckElasticsearchVersion.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CheckElasticsearchVersion.java
@@ -7,6 +7,7 @@
 package co.elastic.support.diagnostics.commands;
 
 import co.elastic.support.Constants;
+import co.elastic.support.diagnostics.DiagConfig;
 import co.elastic.support.diagnostics.DiagnosticException;
 import co.elastic.support.diagnostics.DiagnosticInputs;
 import co.elastic.support.diagnostics.chain.Command;
@@ -15,7 +16,6 @@ import co.elastic.support.rest.RestClient;
 import co.elastic.support.rest.RestEntryConfig;
 import co.elastic.support.rest.RestResult;
 import co.elastic.support.util.JsonYamlUtils;
-import co.elastic.support.util.ResourceCache;
 import co.elastic.support.util.SystemProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.vdurmont.semver4j.Semver;
@@ -23,7 +23,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Map;
-
 
 public class CheckElasticsearchVersion implements Command {
 
@@ -42,48 +41,54 @@ public class CheckElasticsearchVersion implements Command {
         // by just submitting the host/port combo
         logger.info(Constants.CONSOLE, "Getting Elasticsearch Version.");
         DiagnosticInputs inputs = context.diagnosticInputs;
+        DiagConfig config = context.diagsConfig;
 
         try {
-           RestClient restClient = RestClient.getClient(
-                    context.diagnosticInputs.host,
-                    context.diagnosticInputs.port,
-                    context.diagnosticInputs.scheme,
-                    context.diagnosticInputs.user,
-                    context.diagnosticInputs.password,
-                    context.diagnosticInputs.proxyHost,
-                    context.diagnosticInputs.proxyPort,
-                    context.diagnosticInputs.proxyUser,
-                    context.diagnosticInputs.proxyPassword,
-                    context.diagnosticInputs.pkiKeystore,
-                    context.diagnosticInputs.pkiKeystorePass,
-                    context.diagnosticInputs.skipVerification,
-                    context.diagsConfig.extraHeaders,
-                    context.diagsConfig.connectionTimeout,
-                    context.diagsConfig.connectionRequestTimeout,
-                    context.diagsConfig.socketTimeout);
+            RestClient restClient = RestClient.getClient(
+                    inputs.host,
+                    inputs.port,
+                    inputs.scheme,
+                    inputs.user,
+                    inputs.password,
+                    inputs.proxyHost,
+                    inputs.proxyPort,
+                    inputs.proxyUser,
+                    inputs.proxyPassword,
+                    inputs.pkiKeystore,
+                    inputs.pkiKeystorePass,
+                    inputs.skipVerification,
+                    config.extraHeaders,
+                    config.connectionTimeout,
+                    config.connectionRequestTimeout,
+                    config.socketTimeout);
 
-           // Add it to the global cache - automatically closed on exit.
+            // Add it to the global cache - automatically closed on exit.
             context.resourceCache.addRestClient(Constants.restInputHost, restClient);
             context.version = getElasticsearchVersion(restClient);
             String version = context.version.getValue();
-            RestEntryConfig builder = new RestEntryConfig(version);
+            RestEntryConfig builder = new RestEntryConfig(version, inputs.mode);
             Map restCalls = JsonYamlUtils.readYamlFromClasspath(Constants.ES_REST, true);
 
             context.elasticRestCalls = builder.buildEntryMap(restCalls);
+            // For Elasticsearch, we use some API calls based
+            context.fullElasticRestCalls = new RestEntryConfig(version).buildEntryMap(restCalls);
         } catch (Exception e) {
-            logger.error( "Unanticipated error:", e);
-            throw new DiagnosticException(String.format("Could not retrieve the Elasticsearch version due to a system or network error - unable to continue. %s%s%s", e.getMessage(), SystemProperties.lineSeparator, Constants.CHECK_LOG));
+            logger.error("Unanticipated error:", e);
+            throw new DiagnosticException(String.format(
+                    "Could not retrieve the Elasticsearch version due to a system or network error - unable to continue. %s%s%s",
+                    e.getMessage(), SystemProperties.lineSeparator, Constants.CHECK_LOG));
         }
     }
 
     public static Semver getElasticsearchVersion(RestClient client) throws DiagnosticException {
-            RestResult res = client.execQuery("/");
-            if (! res.isValid()) {
-                throw new DiagnosticException( res.formatStatusMessage( "Could not retrieve the Elasticsearch version - unable to continue."));
-            }
-            String result = res.toString();
-            JsonNode root = JsonYamlUtils.createJsonNodeFromString(result);
-            String version = root.path("version").path("number").asText();
-            return new Semver(version, Semver.SemverType.NPM);
+        RestResult res = client.execQuery("/");
+        if (!res.isValid()) {
+            throw new DiagnosticException(
+                    res.formatStatusMessage("Could not retrieve the Elasticsearch version - unable to continue."));
+        }
+        String result = res.toString();
+        JsonNode root = JsonYamlUtils.createJsonNodeFromString(result);
+        String version = root.path("version").path("number").asText();
+        return new Semver(version, Semver.SemverType.NPM);
     }
 }

--- a/src/main/java/co/elastic/support/diagnostics/commands/CollectDockerInfo.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CollectDockerInfo.java
@@ -10,7 +10,6 @@ import co.elastic.support.Constants;
 import co.elastic.support.diagnostics.chain.Command;
 import co.elastic.support.diagnostics.chain.DiagnosticContext;
 import co.elastic.support.util.LocalSystem;
-import co.elastic.support.util.ResourceCache;
 import co.elastic.support.util.SystemCommand;
 import co.elastic.support.util.SystemProperties;
 import co.elastic.support.util.SystemUtils;
@@ -48,11 +47,12 @@ public class CollectDockerInfo implements Command {
 
         // Determine where Docker is located
         String dockerPath = getDockerPath(systemCommand, platform);
-        //String kubePath = getKubectlPath(dockerPath);
+        // String kubePath = getKubectlPath(dockerPath);
 
         // Run the global calls. It's a single pass
         runDockerCalls(targetDir, context.diagsConfig.dockerGlobal, systemCommand, "", dockerPath);
-        //runDockerCalls(targetDir, context.diagsConfig.kubernates, systemCommand, "", kubePath);
+        // runDockerCalls(targetDir, context.diagsConfig.kubernates, systemCommand, "",
+        // kubePath);
 
         String idsCmd = context.diagsConfig.dockerContainerIds;
 
@@ -75,12 +75,12 @@ public class CollectDockerInfo implements Command {
                     return lines;
 
                 } catch (Exception e) {
-                    logger.error( "Error getting directory listing.", e);
+                    logger.error("Error getting directory listing.", e);
                 }
             }
 
         } catch (Exception e) {
-            logger.error( "Error obtaining Docker Container Id's");
+            logger.error("Error obtaining Docker Container Id's");
         }
 
         // If anything happened just bypass processing and continue with the rest.
@@ -88,7 +88,8 @@ public class CollectDockerInfo implements Command {
 
     }
 
-    private void runDockerCalls(String targetDir, Map<String, String> commandMap, SystemCommand sysCmd, String token, String dockerPath) {
+    private void runDockerCalls(String targetDir, Map<String, String> commandMap, SystemCommand sysCmd, String token,
+            String dockerPath) {
         String suffix = "";
         if (StringUtils.isNotEmpty(token)) {
             suffix = "-" + token;
@@ -100,7 +101,8 @@ public class CollectDockerInfo implements Command {
                 cmd = cmd.replace("{{dockerPath}}", dockerPath);
 
                 String output = sysCmd.runCommand(cmd);
-                SystemUtils.writeToFile(output, targetDir + SystemProperties.fileSeparator + entry.getKey() + suffix + ".txt");
+                SystemUtils.writeToFile(output,
+                        targetDir + SystemProperties.fileSeparator + entry.getKey() + suffix + ".txt");
             } catch (Exception e) {
                 logger.error(Constants.CONSOLE, e.getMessage());
             }
@@ -114,11 +116,11 @@ public class CollectDockerInfo implements Command {
             return "docker";
         }
 
-        for(String path: Constants.exePaths){
+        for (String path : Constants.exePaths) {
             String expectedPath = path + "docker";
             String dockerPath = systemCommand.runCommand("ls " + expectedPath);
             dockerPath = dockerPath.trim();
-            if(expectedPath.equalsIgnoreCase(dockerPath)){
+            if (expectedPath.equalsIgnoreCase(dockerPath)) {
                 return dockerPath;
             }
         }
@@ -126,7 +128,7 @@ public class CollectDockerInfo implements Command {
         return "docker";
     }
 
-    private String getKubectlPath(String dockerPath){
+    private String getKubectlPath(String dockerPath) {
 
         return dockerPath.replace("docker", "kubectl");
 

--- a/src/main/java/co/elastic/support/diagnostics/commands/GenerateDiagnosticManifest.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/GenerateDiagnosticManifest.java
@@ -22,8 +22,6 @@ import java.util.Map;
 /**
  * Generate a manifest containing the basic runtime info for the diagnostic
  * runtime.
- * Some of the values we get, like the Diagnostic version will be used again
- * downstream.
  */
 public class GenerateDiagnosticManifest implements Command {
    private final Logger logger = LogManager.getLogger(GenerateDiagnosticManifest.class);

--- a/src/main/java/co/elastic/support/diagnostics/commands/GenerateManifest.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/GenerateManifest.java
@@ -22,8 +22,6 @@ import java.util.Map;
 /**
  * Generate a manifest containing the basic runtime info for the diagnostic
  * runtime.
- * Some of the values we get, like the Diagnostic version will be used again
- * downstream.
  */
 public class GenerateManifest implements Command {
    private final Logger logger = LogManager.getLogger(GenerateManifest.class);

--- a/src/main/java/co/elastic/support/diagnostics/commands/RetrieveSystemDigest.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/RetrieveSystemDigest.java
@@ -35,24 +35,24 @@ public class RetrieveSystemDigest implements Command {
     public void execute(DiagnosticContext context) {
         try {
             SystemInfo si = new SystemInfo();
-            HardwareAbstractionLayer hal = si.getHardware();
-            OperatingSystem os = si.getOperatingSystem();
             File sysFileJson = new File(context.tempDir + SystemProperties.fileSeparator + "system-digest.json");
 
             try (
-                OutputStream outputStreamJson = new FileOutputStream(sysFileJson);
-                BufferedWriter jsonWriter = new BufferedWriter(new OutputStreamWriter(outputStreamJson));
-            ) {
-                String jsonInfo = si.toPrettyJSON();
-                jsonWriter.write(jsonInfo);
+                    OutputStream outputStreamJson = new FileOutputStream(sysFileJson);
+                    BufferedWriter jsonWriter = new BufferedWriter(new OutputStreamWriter(outputStreamJson));) {
+                jsonWriter.write(si.toPrettyJSON());
+            } catch (Exception | Error e) {
+                logger.info("Failed saving [system-digest.json] file.", e);
             }
 
             File sysFile = new File(context.tempDir + SystemProperties.fileSeparator + "system-digest.txt");
 
             try (
-                OutputStream outputStream = new FileOutputStream(sysFile);
-                BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(outputStream));
-            ) {
+                    OutputStream outputStream = new FileOutputStream(sysFile);
+                    BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(outputStream));) {
+                HardwareAbstractionLayer hal = si.getHardware();
+                OperatingSystem os = si.getOperatingSystem();
+
                 printComputerSystem(writer, hal.getComputerSystem());
                 writer.newLine();
 
@@ -82,13 +82,14 @@ public class RetrieveSystemDigest implements Command {
             }
 
             logger.info("Finished querying SysInfo.");
-        } catch (final Exception e) {
+        } catch (final Exception | Error e) {
             logger.info("Failed saving system-digest.txt file.", e);
         }
 
     }
 
-    private static void printComputerSystem(BufferedWriter writer, final ComputerSystem computerSystem) throws Exception {
+    private static void printComputerSystem(BufferedWriter writer, final ComputerSystem computerSystem)
+            throws Exception {
 
         writer.write("Computer System");
         writer.newLine();
@@ -164,7 +165,8 @@ public class RetrieveSystemDigest implements Command {
 
     }
 
-    private static void printProcesses(BufferedWriter writer, OperatingSystem os, GlobalMemory memory) throws Exception {
+    private static void printProcesses(BufferedWriter writer, OperatingSystem os, GlobalMemory memory)
+            throws Exception {
         writer.write("Processes");
         writer.newLine();
         writer.write("----------");
@@ -213,7 +215,6 @@ public class RetrieveSystemDigest implements Command {
                 "Context Switches/Interrupts: " + processor.getContextSwitches() + " / " + processor.getInterrupts());
         writer.newLine();
 
-
         long[] prevTicks = processor.getSystemCpuLoadTicks();
 
         writer.write("CPU, IOWait, and IRQ ticks @ 0 sec:" + Arrays.toString(prevTicks));
@@ -242,7 +243,8 @@ public class RetrieveSystemDigest implements Command {
                 100d * iowait / totalCpu, 100d * irq / totalCpu, 100d * softirq / totalCpu, 100d * steal / totalCpu));
         writer.newLine();
 
-        writer.write(String.format("CPU load: %.1f%% (counting ticks)%n", processor.getSystemCpuLoadBetweenTicks() * 100));
+        writer.write(
+                String.format("CPU load: %.1f%% (counting ticks)%n", processor.getSystemCpuLoadBetweenTicks() * 100));
         writer.write(String.format("CPU load: %.1f%% (OS MXBean)%n", processor.getSystemCpuLoad() * 100));
         double[] loadAverage = processor.getSystemLoadAverage(3);
         writer.write("CPU load averages:" + (loadAverage[0] < 0 ? " N/A" : String.format(" %.2f", loadAverage[0]))
@@ -267,7 +269,8 @@ public class RetrieveSystemDigest implements Command {
 
         for (HWDiskStore disk : diskStores) {
             boolean readwrite = disk.getReads() > 0 || disk.getWrites() > 0;
-            writer.write(String.format(" %s: (model: %s - S/N: %s) size: %s, reads: %s (%s), writes: %s (%s), xfer: %s ms%n",
+            writer.write(String.format(
+                    " %s: (model: %s - S/N: %s) size: %s, reads: %s (%s), writes: %s (%s), xfer: %s ms%n",
                     disk.getName(), disk.getModel(), disk.getSerial(),
                     disk.getSize() > 0 ? FormatUtil.formatBytesDecimal(disk.getSize()) : "?",
                     readwrite ? disk.getReads() : "?", readwrite ? FormatUtil.formatBytes(disk.getReadBytes()) : "?",
@@ -298,7 +301,8 @@ public class RetrieveSystemDigest implements Command {
         for (OSFileStore fs : fsArray) {
             long usable = fs.getUsableSpace();
             long total = fs.getTotalSpace();
-            writer.write(String.format(" %s (%s) [%s] %s of %s free (%.1f%%) is %s and is mounted at %s%n", fs.getName(),
+            writer.write(String.format(" %s (%s) [%s] %s of %s free (%.1f%%) is %s and is mounted at %s%n",
+                    fs.getName(),
                     fs.getDescription().isEmpty() ? "file system" : fs.getDescription(), fs.getType(),
                     FormatUtil.formatBytes(usable), FormatUtil.formatBytes(fs.getTotalSpace()), 100d * usable / total,
                     fs.getVolume(), fs.getMount()));
@@ -327,7 +331,8 @@ public class RetrieveSystemDigest implements Command {
         for (NetworkIF net : networkIFs) {
             writer.write(String.format(" Name: %s (%s)%n", net.getName(), net.getDisplayName()));
             writer.write(String.format("   MAC Address: %s %n", net.getMacaddr()));
-            writer.write(String.format("   MTU: %s, Speed: %s %n", net.getMTU(), FormatUtil.formatValue(net.getSpeed(), "bps")));
+            writer.write(String.format("   MTU: %s, Speed: %s %n", net.getMTU(),
+                    FormatUtil.formatValue(net.getSpeed(), "bps")));
             writer.write(String.format("   IPv4: %s %n", Arrays.toString(net.getIPv4addr())));
             writer.write(String.format("   IPv6: %s %n", Arrays.toString(net.getIPv6addr())));
             boolean hasData = net.getBytesRecv() > 0 || net.getBytesSent() > 0 || net.getPacketsRecv() > 0
@@ -344,5 +349,3 @@ public class RetrieveSystemDigest implements Command {
     }
 
 }
-
-

--- a/src/main/java/co/elastic/support/diagnostics/commands/RunLogstashQueries.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/RunLogstashQueries.java
@@ -51,7 +51,8 @@ public class RunLogstashQueries extends BaseQuery {
             queries.addAll(entries.values());
             runQueries(client, queries, context.tempDir, 0, 0);
 
-            // Get the information we need to run system calls. It's easier to just get it off disk after all the REST calls run.
+            // Get the information we need to run system calls. It's easier to just get it
+            // off disk after all the REST calls run.
             ProcessProfile nodeProfile = new ProcessProfile();
             context.targetNode = nodeProfile;
 
@@ -69,10 +70,9 @@ public class RunLogstashQueries extends BaseQuery {
             switch (context.diagnosticInputs.diagType) {
                 case Constants.logstashRemote:
                     String targetOS;
-                    if(context.dockerPresent){
+                    if (context.dockerPresent) {
                         targetOS = Constants.linuxPlatform;
-                    }
-                    else{
+                    } else {
                         targetOS = nodeProfile.os;
                     }
                     syscmd = new RemoteSystem(
@@ -85,8 +85,7 @@ public class RunLogstashQueries extends BaseQuery {
                             context.diagnosticInputs.pkiKeystorePass,
                             context.diagnosticInputs.knownHostsFile,
                             context.diagnosticInputs.trustRemote,
-                            context.diagnosticInputs.isSudo
-                    );
+                            context.diagnosticInputs.isSudo);
                     context.resourceCache.addSystemCommand(Constants.systemCommands, syscmd);
                     break;
 
@@ -101,15 +100,16 @@ public class RunLogstashQueries extends BaseQuery {
                     break;
 
                 default:
-                    // If it's not one of the above types it shouldn't be here but try to keep going...
+                    // If it's not one of the above types it shouldn't be here but try to keep
+                    // going...
                     context.runSystemCalls = false;
-                    throw new RuntimeException("Host/Platform check error.");
             }
 
-
         } catch (Throwable t) {
-            logger.error( "Logstash Query error:", t);
-            throw new DiagnosticException(String.format("Error obtaining logstash output and/or process id - will bypass the rest of processing.. %s", Constants.CHECK_LOG));
+            logger.error("Logstash Query error:", t);
+            throw new DiagnosticException(String.format(
+                    "Error obtaining logstash output and/or process id - will bypass the rest of processing.. %s",
+                    Constants.CHECK_LOG));
         }
     }
 }

--- a/src/main/java/co/elastic/support/rest/RestClient.java
+++ b/src/main/java/co/elastic/support/rest/RestClient.java
@@ -42,8 +42,6 @@ import java.io.FileInputStream;
 import java.io.UnsupportedEncodingException;
 import java.security.KeyStore;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 public class RestClient implements Closeable {
 
@@ -56,7 +54,8 @@ public class RestClient implements Closeable {
 
     private Map<String, String> extraHeaders;
 
-    public RestClient(CloseableHttpClient client, HttpHost httpHost, HttpClientContext context, Map<String, String> extraHeaders) {
+    public RestClient(CloseableHttpClient client, HttpHost httpHost, HttpClientContext context,
+            Map<String, String> extraHeaders) {
         this.client = client;
         this.httpHost = httpHost;
         this.httpContext = context;
@@ -86,10 +85,10 @@ public class RestClient implements Closeable {
         try {
             return client.execute(httpHost, httpRequest, httpContext);
         } catch (HttpHostConnectException e) {
-            logger.error( "Host connection error.", e);
+            logger.error("Host connection error.", e);
             throw new RuntimeException("Host connection");
         } catch (Exception e) {
-            logger.error( "Unexpected Execution Error", e);
+            logger.error("Unexpected Execution Error", e);
             throw new RuntimeException(e.getMessage());
         }
     }
@@ -104,13 +103,13 @@ public class RestClient implements Closeable {
             logger.debug(uri + SystemProperties.fileSeparator + payload);
             return execRequest(httpPost);
         } catch (UnsupportedEncodingException e) {
-            logger.error(Constants.CONSOLE,  "Error with json body.", e);
+            logger.error(Constants.CONSOLE, "Error with json body.", e);
             throw new RuntimeException("Could not complete post request.");
         }
     }
 
     public HttpResponse execDelete(String uri) {
-        HttpDelete httpDelete = new HttpDelete( uri);
+        HttpDelete httpDelete = new HttpDelete(uri);
         logger.debug(uri);
 
         return execRequest(httpDelete);
@@ -122,7 +121,7 @@ public class RestClient implements Closeable {
                 client.close();
             }
         } catch (Exception e) {
-            logger.error( "Error occurred closing client connection.");
+            logger.error("Error occurred closing client connection.");
         }
     }
 
@@ -142,9 +141,9 @@ public class RestClient implements Closeable {
             Map<String, String> extraHeaders,
             int connectionTimeout,
             int connectionRequestTimeout,
-            int socketTimeout){
+            int socketTimeout) {
 
-        try{
+        try {
             HttpClientBuilder clientBuilder = HttpClients.custom();
             HttpHost httpHost = new HttpHost(host, port, scheme);
             HttpHost httpProxyHost = null;
@@ -162,14 +161,13 @@ public class RestClient implements Closeable {
                     .setConnectionRequestTimeout(connectionRequestTimeout).build());
 
             // If there's a proxy server, set it now.
-            if(StringUtils.isNotEmpty(proxyHost)){
+            if (StringUtils.isNotEmpty(proxyHost)) {
                 httpProxyHost = new HttpHost(proxyHost, proxyPort);
                 clientBuilder.setProxy(httpProxyHost);
                 basicAuth.processChallenge(new BasicHeader(AUTH.PROXY_AUTH, "BASIC realm=default"));
                 authCache.put(httpProxyHost, basicAuth);
 
-            }
-            else{
+            } else {
                 authCache.put(httpHost, basicAuth);
             }
 
@@ -177,18 +175,16 @@ public class RestClient implements Closeable {
             clientBuilder.setDefaultCredentialsProvider(credentialsProvider);
 
             // If authentication was supplied
-            if(StringUtils.isNotEmpty(user) && StringUtils.isEmpty(proxyUser)){
+            if (StringUtils.isNotEmpty(user) && StringUtils.isEmpty(proxyUser)) {
                 context.setAuthCache(authCache);
                 credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(user, password));
-            }
-            else if(StringUtils.isNotEmpty(user) && StringUtils.isNotEmpty(proxyUser)){
+            } else if (StringUtils.isNotEmpty(user) && StringUtils.isNotEmpty(proxyUser)) {
                 context.setAuthCache(authCache);
                 credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(user, password));
                 credentialsProvider.setCredentials(
                         AuthScope.ANY,
                         new UsernamePasswordCredentials(proxyUser, proxyPassword));
-            }
-            else if (StringUtils.isNotEmpty(proxyUser)){
+            } else if (StringUtils.isNotEmpty(proxyUser)) {
                 context.setAuthCache(authCache);
                 credentialsProvider.setCredentials(
                         AuthScope.ANY,
@@ -197,7 +193,7 @@ public class RestClient implements Closeable {
 
             SSLContextBuilder sslContextBuilder = new SSLContextBuilder();
             sslContextBuilder.loadTrustMaterial(new TrustAllStrategy());
-            if(StringUtils.isNotEmpty(pkiKeystore) ) {
+            if (StringUtils.isNotEmpty(pkiKeystore)) {
                 // If they are using a PKI auth set it up now
                 KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
                 ks.load(new FileInputStream(pkiKeystore), pkiKeystorePass.toCharArray());
@@ -209,8 +205,7 @@ public class RestClient implements Closeable {
             SSLConnectionSocketFactory factory = null;
             if (bypassVerify) {
                 factory = new SSLConnectionSocketFactory(sslCtx, NoopHostnameVerifier.INSTANCE);
-            }
-            else{
+            } else {
                 factory = new SSLConnectionSocketFactory(sslCtx);
             }
             clientBuilder.setSSLSocketFactory(factory);
@@ -229,9 +224,8 @@ public class RestClient implements Closeable {
             RestClient restClient = new RestClient(httpClient, httpHost, context, extraHeaders);
 
             return restClient;
-        }
-        catch (Exception e){
-            logger.error( "Connection setup failed", e);
+        } catch (Exception e) {
+            logger.error("Connection setup failed", e);
             throw new RuntimeException("Error establishing http connection for: " + host, e);
         }
     }

--- a/src/main/java/co/elastic/support/rest/RestResult.java
+++ b/src/main/java/co/elastic/support/rest/RestResult.java
@@ -36,15 +36,13 @@ public class RestResult implements Cloneable {
     // to disk or the body is stored as a string and the status retained as well.
     public RestResult(HttpResponse response, String url) {
         this.url = url;
-        try{
+        try {
             processCodes(response);
             responseString = EntityUtils.toString(response.getEntity());
-        }
-        catch (Exception e){
-            logger.error( "Error Processing Response", e);
+        } catch (Exception e) {
+            logger.error("Error Processing Response", e);
             throw new RuntimeException();
-        }
-        finally {
+        } finally {
             HttpClientUtils.closeQuietly(response);
         }
     }
@@ -53,35 +51,31 @@ public class RestResult implements Cloneable {
 
         this.url = url;
 
-        // If the query got a success status stream the result immediately to the target file.
-        // If not, the result should be small and contain diagnostic info so stgre it in the response string.
+        // If the query got a success status stream the result immediately to the target
+        // file.
+        // If not, the result should be small and contain diagnostic info so stgre it in
+        // the response string.
         File output = new File(fileName);
-        if(output.exists()){
+        if (output.exists()) {
             FileUtils.deleteQuietly(output);
         }
 
-        try(OutputStream out = new FileOutputStream(fileName)){
+        try (OutputStream out = new FileOutputStream(fileName)) {
             processCodes(response);
-            if (status == 200) {
-                response.getEntity().writeTo(out);
-            } else {
-                responseString = EntityUtils.toString(response.getEntity());
-                IOUtils.write(reason + SystemProperties.lineSeparator + responseString, out, Constants.UTF_8);
-            }
+            response.getEntity().writeTo(out);
         } catch (Exception e) {
-            logger.error( "Error Streaming Response To OutputStream", e);
+            logger.error("Error Streaming Response To OutputStream", e);
             throw new RuntimeException();
-        }
-        finally {
+        } finally {
             HttpClientUtils.closeQuietly(response);
         }
     }
 
-    private void processCodes(HttpResponse response){
+    private void processCodes(HttpResponse response) {
         status = response.getStatusLine().getStatusCode();
         if (status == 400) {
             reason = "Bad Request. Rejected";
-           isRetryable = true;
+            isRetryable = true;
         } else if (status == 401) {
             reason = "Authentication failure. Invalid login credentials.";
             isRetryable = false;
@@ -97,9 +91,9 @@ public class RestResult implements Cloneable {
         }
     }
 
-    public String formatStatusMessage(String msg){
+    public String formatStatusMessage(String msg) {
 
-        if(StringUtils.isNotEmpty(msg)){
+        if (StringUtils.isNotEmpty(msg)) {
             msg = msg + " ";
         }
 
@@ -109,11 +103,11 @@ public class RestResult implements Cloneable {
                 reason);
     }
 
-    public int getStatus(){
+    public int getStatus() {
         return status;
     }
 
-    public String getReason(){
+    public String getReason() {
         return reason;
     }
 
@@ -121,17 +115,16 @@ public class RestResult implements Cloneable {
         return responseString;
     }
 
-    public void toFile(String fileName){
+    public void toFile(String fileName) {
         File output = new File(fileName);
-        if(output.exists()){
+        if (output.exists()) {
             FileUtils.deleteQuietly(output);
         }
 
-        try(FileOutputStream fs = new FileOutputStream(output)){
+        try (FileOutputStream fs = new FileOutputStream(output)) {
             IOUtils.write(reason + SystemProperties.lineSeparator + responseString, fs, Constants.UTF_8);
-        }
-        catch (Exception e){
-            logger.error( "Error writing Response To OutputStream", e);
+        } catch (Exception e) {
+            logger.error("Error writing Response To OutputStream", e);
         }
     }
 
@@ -139,8 +132,8 @@ public class RestResult implements Cloneable {
         return isRetryable;
     }
 
-    public boolean isValid(){
-        if(status == 200){
+    public boolean isValid() {
+        if (status == 200) {
             return true;
         }
         return false;

--- a/src/main/java/co/elastic/support/util/ArchiveUtils.java
+++ b/src/main/java/co/elastic/support/util/ArchiveUtils.java
@@ -10,15 +10,9 @@ import co.elastic.support.Constants;
 import co.elastic.support.diagnostics.DiagnosticException;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
-import org.apache.commons.compress.compressors.CompressorOutputStream;
-import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
-import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.apache.commons.io.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -26,89 +20,26 @@ import java.io.*;
 
 public class ArchiveUtils {
 
-   public enum ArchiveType {
-      ZIP, TAR, ANY;
-
-      public static ArchiveType fromString(String name) {
-         for (ArchiveType type : ArchiveType.values()) {
-            if (type.name().equalsIgnoreCase(name)) {
-               return type;
-            }
-         }
-
-         return ANY;
-      }
-   }
-
    private static final Logger logger = LogManager.getLogger(ArchiveUtils.class);
 
-   public static File createArchive(String dir, String archiveFileName, ArchiveType type) throws DiagnosticException {
-      switch (type) {
-         case ZIP:
-            try {
-               return createZipArchive(dir, archiveFileName);
-            } catch (IOException ioe) {
-               throw new DiagnosticException("Couldn't create zip archive.", ioe);
-            }
-         case TAR:
-            try {
-               return createTarArchive(dir, archiveFileName);
-            } catch (IOException ioe) {
-               throw new DiagnosticException("Couldn't create tar.gz archive.", ioe);
-            }
-         default:
-            try {
-               return createZipArchive(dir, archiveFileName);
-            } catch (IOException zipException) {
-               logger.info(Constants.CONSOLE, "Couldn't create zip archive. Trying tar.gz");
-
-               try {
-                  return createTarArchive(dir, archiveFileName);
-               } catch (Exception tarException) {
-                  logger.info(Constants.CONSOLE, "Couldn't create tar.gz archive.");
-                  tarException.addSuppressed(zipException);
-                  throw new DiagnosticException("Couldn't create zip and tar.gz archives.", tarException);
-               }
-            }
-      }
-   }
-
-   private static File createZipArchive(String dir, String archiveFileName) throws IOException {
+   public static File createZipArchive(String dir, String archiveFileName) throws DiagnosticException {
       File srcDir = new File(dir);
       String filename = dir + "-" + archiveFileName + ".zip";
       File file = new File(filename);
 
       try (
-         FileOutputStream fout = new FileOutputStream(filename);
-         ZipArchiveOutputStream taos = new ZipArchiveOutputStream(fout)
-      ) {
+            FileOutputStream fout = new FileOutputStream(filename);
+            ZipArchiveOutputStream taos = new ZipArchiveOutputStream(fout)) {
          archiveResultsZip(archiveFileName, taos, srcDir, "", true);
          logger.info(Constants.CONSOLE, "Archive: " + filename + " was created");
          return file;
+      } catch (IOException ioe) {
+         throw new DiagnosticException("Couldn't create zip archive.", ioe);
       }
    }
 
-   private static File createTarArchive(String dir, String archiveFileName) throws IOException {
-      File srcDir = new File(dir);
-      String filename = dir + "-" + archiveFileName + ".tar.gz";
-      File file = new File(filename);
-
-      try (
-         FileOutputStream fout = new FileOutputStream(filename);
-         CompressorOutputStream cout = new GzipCompressorOutputStream(fout);
-         TarArchiveOutputStream taos = new TarArchiveOutputStream(cout)
-      ) {
-         taos.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_STAR);
-         taos.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
-         archiveResultsTar(archiveFileName, taos, srcDir, "", true);
-
-         logger.info(Constants.CONSOLE,  "Archive: " + filename + " was created");
-
-         return file;
-      }
-   }
-
-   private static void archiveResultsZip(String archiveFilename, ZipArchiveOutputStream taos, File file, String path, boolean append) {
+   private static void archiveResultsZip(String archiveFilename, ZipArchiveOutputStream taos, File file, String path,
+         boolean append) {
       String relPath = "";
 
       try {
@@ -132,100 +63,65 @@ public class ArchiveUtils {
             }
          }
       } catch (IOException e) {
-         logger.error(Constants.CONSOLE,"Archive Error", e);
-      }
-   }
-
-   private static void archiveResultsTar(String archiveFilename, TarArchiveOutputStream taos, File file, String path, boolean append) {
-      String relPath = "";
-
-      try {
-         if (append) {
-            relPath = path + "/" + file.getName() + "-" + archiveFilename;
-         } else {
-            relPath = path + "/" + file.getName();
-         }
-         TarArchiveEntry tae = new TarArchiveEntry(file, relPath);
-         taos.putArchiveEntry(tae);
-
-         if (file.isFile()) {
-            try (BufferedInputStream bis = new BufferedInputStream(new FileInputStream(file))) {
-               IOUtils.copy(bis, taos);
-               taos.closeArchiveEntry();
-            }
-         } else if (file.isDirectory()) {
-            taos.closeArchiveEntry();
-
-            for (File childFile : file.listFiles()) {
-               archiveResultsTar(archiveFilename, taos, childFile, relPath, false);
-            }
-         }
-      } catch (IOException e) {
-         logger.error(Constants.CONSOLE,"Archive Error", e);
+         logger.error(Constants.CONSOLE, "Archive Error", e);
       }
    }
 
    public static void extractArchive(String filename, String targetDir) throws IOException {
       final int bufferSize = 1024;
       ArchiveInputStream ais = null;
-      try  {
-         InputStream inputStream  = new FileInputStream(new File(filename));
-         if(filename.endsWith(".zip")){
+      try {
+         InputStream inputStream = new FileInputStream(new File(filename));
+         if (filename.endsWith(".zip")) {
             ais = new ZipArchiveInputStream(inputStream);
-         }
-         else if (filename.endsWith(".tar")){
-            ais = new TarArchiveInputStream(inputStream);
-         }
-         else if (filename.endsWith(".tar.gz")){
-            ais = new TarArchiveInputStream(new GzipCompressorInputStream(inputStream));
-         }
-         else{
+         } else {
             logger.error(Constants.CONSOLE, "Unsupported archive type");
             return;
          }
 
          ArchiveEntry entry = ais.getNextEntry();
          String archiveDir = entry.getName();
-         while (( entry = ais.getNextEntry()) != null) {
+         while ((entry = ais.getNextEntry()) != null) {
             String newPath = entry.getName().replace(archiveDir, "");
-            if(newPath.endsWith(".zip") || newPath.endsWith(".tar") | newPath.endsWith("tar.gz")){
+            if (newPath.endsWith(".zip") || newPath.endsWith(".tar") | newPath.endsWith("tar.gz")) {
                String nestedArch = entryToDisk(ais, targetDir, newPath);
                String nestedTargetDir = nestedArch.substring(nestedArch.lastIndexOf(SystemProperties.fileSeparator));
                extractArchive(nestedArch, nestedTargetDir);
                new File(nestedArch).delete();
-            }
-            else if (entry.isDirectory()) {
+            } else if (entry.isDirectory()) {
                File f = new File(targetDir + SystemProperties.fileSeparator + newPath);
                boolean created = f.mkdir();
                if (!created) {
                   System.out.printf("Unable to create directory '%s', during extraction of archive contents.\n",
-                          f.getAbsolutePath());
+                        f.getAbsolutePath());
                }
             } else {
                entryToDisk(ais, targetDir, newPath);
-               /*int count;
-               byte data[] = new byte[bufferSize];
-               FileOutputStream fos = new FileOutputStream(new File(targetDir + SystemProperties.fileSeparator + newPath), false);
-               try (BufferedOutputStream dest = new BufferedOutputStream(fos, bufferSize)) {
-                  while ((count = ais.read(data, 0, bufferSize)) != -1) {
-                     dest.write(data, 0, count);
-                  }
-               }*/
+               /*
+                * int count;
+                * byte data[] = new byte[bufferSize];
+                * FileOutputStream fos = new FileOutputStream(new File(targetDir +
+                * SystemProperties.fileSeparator + newPath), false);
+                * try (BufferedOutputStream dest = new BufferedOutputStream(fos, bufferSize)) {
+                * while ((count = ais.read(data, 0, bufferSize)) != -1) {
+                * dest.write(data, 0, count);
+                * }
+                * }
+                */
             }
          }
 
          System.out.println("Extract completed successfully!");
       } catch (IOException e) {
          logger.error(e);
-      }
-      finally {
+      } finally {
          if (ais != null) {
             ais.close();
          }
       }
    }
 
-   private static String entryToDisk(ArchiveInputStream ais, String targetDir, String newPath) throws IOException{
+   private static String entryToDisk(ArchiveInputStream ais, String targetDir, String newPath) throws IOException {
       int bufferSize = 1024;
       int count;
       byte data[] = new byte[bufferSize];
@@ -240,5 +136,3 @@ public class ArchiveUtils {
    }
 
 }
-
-

--- a/src/main/java/co/elastic/support/util/ResourceCache.java
+++ b/src/main/java/co/elastic/support/util/ResourceCache.java
@@ -13,45 +13,44 @@ import org.apache.logging.log4j.Logger;
 import java.io.Closeable;
 import java.util.concurrent.ConcurrentHashMap;
 
-
 public class ResourceCache implements AutoCloseable {
 
     private final Logger logger = LogManager.getLogger(ResourceCache.class);
-    private ConcurrentHashMap<String, Closeable> resources = new ConcurrentHashMap();
+    private ConcurrentHashMap<String, Closeable> resources = new ConcurrentHashMap<>();
 
-    public void addSystemCommand(String name, SystemCommand systemCommand){
-        // Log the error if they tried to overlay with a dupe but don't throw an exception.
-        resources.putIfAbsent(name, systemCommand );
+    public void addSystemCommand(String name, SystemCommand systemCommand) {
+        // Log the error if they tried to overlay with a dupe but don't throw an
+        // exception.
+        resources.putIfAbsent(name, systemCommand);
     }
 
-    public SystemCommand getSystemCommand(String name){
-        if(resources.containsKey(name)){
-            return (SystemCommand)resources.get(name);
+    public SystemCommand getSystemCommand(String name) {
+        if (resources.containsKey(name)) {
+            return (SystemCommand) resources.get(name);
         }
 
         throw new IllegalStateException("SystemCommand instance requested does not exist");
     }
 
-    public void addRestClient(String name, RestClient client){
+    public void addRestClient(String name, RestClient client) {
         resources.putIfAbsent(name, client);
     }
 
-    public RestClient getRestClient(String name){
-        if (resources.containsKey(name)){
-            return (RestClient)resources.get(name);
+    public RestClient getRestClient(String name) {
+        if (resources.containsKey(name)) {
+            return (RestClient) resources.get(name);
         }
         throw new IllegalStateException("RestClient instance does not exist");
     }
 
     @Override
     public void close() {
-        resources.forEach((name, resource)->{
-                try{
-                    resource.close();
-                }
-                catch (Exception e){
-                    logger.error( "Failed to close resource {}", name);
-                }
+        resources.forEach((name, resource) -> {
+            try {
+                resource.close();
+            } catch (Exception e) {
+                logger.error("Failed to close resource {}", name);
+            }
         });
     }
 }

--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -137,7 +137,7 @@ nodes_hot_threads:
 ## Common JSON API's
 alias:
   versions:
-    ">= 0.9.0": "/_alias?pretty&human"
+    ">= 0.9.0": "/_alias?human"
 
 allocation:
   versions:
@@ -145,13 +145,14 @@ allocation:
   showErrors: false
 
 allocation_explain:
+  tags: light
   versions:
-    ">= 5.0.0": "/_cluster/allocation/explain?pretty"
+    ">= 5.0.0": "/_cluster/allocation/explain"
   showErrors: false
 
 allocation_explain_disk:
   versions:
-    ">= 5.0.0": "/_cluster/allocation/explain?include_disk_info=true&pretty"
+    ">= 5.0.0": "/_cluster/allocation/explain?include_disk_info=true"
 
 component_templates:
   retry: true
@@ -164,19 +165,20 @@ count:
 
 cluster_health:
   versions:
-    ">= 0.9.0": "/_cluster/health?pretty"
+    ">= 0.9.0": "/_cluster/health"
 
 cluster_pending_tasks:
   versions:
-    ">= 0.9.0": "/_cluster/pending_tasks?pretty&human"
+    ">= 0.9.0": "/_cluster/pending_tasks?human"
 
 cluster_settings:
   versions:
-    ">= 0.9.0": "/_cluster/settings?pretty&flat_settings"
+    ">= 0.9.0": "/_cluster/settings?flat_settings"
 
 cluster_settings_defaults:
+  tags: light
   versions:
-    ">= 6.4.0": "/_cluster/settings?include_defaults&pretty&flat_settings"
+    ">= 6.4.0": "/_cluster/settings?include_defaults&flat_settings"
 
 cluster_state:
   retry: true
@@ -184,27 +186,29 @@ cluster_state:
     ">= 0.9.0": "/_cluster/state?human"
 
 cluster_stats:
+  tags: light
   versions:
-    ">= 0.9.0": "/_cluster/stats?pretty&human"
+    ">= 0.9.0": "/_cluster/stats?human"
 
 dangling_indices:
   versions:
-    ">= 7.9.0": "/_dangling?pretty&human"
+    ">= 7.9.0": "/_dangling?human"
 
 fielddata:
   versions:
-    ">= 0.9.0": "/_cat/fielddata?format=json&bytes&pretty"
+    ">= 0.9.0": "/_cat/fielddata?format=json&bytes"
 
 fielddata_stats:
   versions:
-    ">= 0.9.0 < 5.0.0": "/_nodes/stats/indices/fielddata?pretty=true&fields=*"
-    ">= 5.0.0": "/_nodes/stats/indices/fielddata?level=shards&pretty=true&fields=*"
+    ">= 0.9.0 < 5.0.0": "/_nodes/stats/indices/fielddata?fields=*"
+    ">= 5.0.0": "/_nodes/stats/indices/fielddata?level=shards&fields=*"
 
 geoip_stats:
   versions:
-    ">= 7.13.0": "/_ingest/geoip/stats?pretty"
+    ">= 7.13.0": "/_ingest/geoip/stats"
 
 index_templates:
+  tags: light
   retry: true
   versions:
     ">= 7.8.0": "/_index_template"
@@ -221,12 +225,13 @@ indices_stats:
     ">= 7.7.0": "/_stats?level=shards&human&expand_wildcards=all"
 
 internal_health:
+  tags: light
   retry: true
   versions:
-    ">= 8.2.0 < 8.3.0": "/_internal/_health?pretty"
-    ">= 8.3.0 < 8.3.0": "/_internal/_health?pretty&explain"
-    ">= 8.6.0 < 8.7.0": "/_internal/_health?pretty"
-    ">=8.7.0": "/_health_report?pretty"
+    ">= 8.2.0 < 8.3.0": "/_internal/_health"
+    ">= 8.3.0 < 8.3.0": "/_internal/_health?explain"
+    ">= 8.6.0 < 8.7.0": "/_internal/_health"
+    ">=8.7.0": "/_health_report"
 
 internal_desired_balance:
   retry: true
@@ -236,11 +241,12 @@ internal_desired_balance:
 licenses:
   versions:
     ">= 1.0.0 < 2.0.0": "/_licenses"
-    ">= 2.0.0 < 7.6.0": "/_license?pretty"
-    ">= 7.6.0 < 8.0.0": "/_license?pretty&accept_enterprise=true"
-    ">= 8.0.0": "/_license?pretty"
+    ">= 2.0.0 < 7.6.0": "/_license"
+    ">= 7.6.0 < 8.0.0": "/_license?accept_enterprise=true"
+    ">= 8.0.0": "/_license"
 
 mapping:
+  tags: light
   versions:
     ">= 0.9.0 < 7.7.0": "/_mapping"
     ">= 7.7.0": "/_mapping?expand_wildcards=all"
@@ -250,26 +256,29 @@ master:
     ">= 0.9.0": "/_cat/master?format=json"
 
 nodes:
+  tags: light
   retry: true
   versions:
-    ">= 0.9.0": "/_nodes?pretty&human"
+    ">= 0.9.0": "/_nodes?human"
 
 nodes_short:
   versions:
     ">= 0.9.0": "/_cat/nodes?format=json&v&full_id&h=name,id,master,ip,role"
 
 nodes_stats:
+  tags: light
   retry: true
   versions:
     ">= 0.9.0": "/_nodes/stats?human"
 
 nodes_usage:
   versions:
-    ">= 6.0.0": "/_nodes/usage?pretty"
+    ">= 6.0.0": "/_nodes/usage"
 
 pipelines:
+  tags: light
   versions:
-    ">= 5.0.0": "/_ingest/pipeline/*?pretty&human"
+    ">= 5.0.0": "/_ingest/pipeline/*?human"
 
 plugins:
   versions:
@@ -277,52 +286,58 @@ plugins:
 
 recovery:
   versions:
-    ">= 0.9.0": "/_recovery?pretty&human&detailed=true"
+    ">= 0.9.0": "/_recovery?human&detailed=true"
 
 remote_cluster_info:
   versions:
     ">= 6.0.0": "/_remote/info"
 
 repositories:
+  tags: light
   versions:
-    ">= 2.0.0": "/_snapshot?pretty"
+    ">= 2.0.0": "/_snapshot"
 
 segments:
   retry: true
   versions:
-    ">= 0.9.0": "/_segments?pretty&human"
+    ">= 0.9.0": "/_segments?human"
 
 settings:
+  tags: light
   retry: true
   versions:
-    ">= 0.9.0 < 7.7.0": "/_settings?pretty&human"
-    ">= 7.7.0": "/_settings?pretty&human&expand_wildcards=all"
+    ">= 0.9.0 < 7.7.0": "/_settings?human"
+    ">= 7.7.0": "/_settings?human&expand_wildcards=all"
 
 shard_stores:
   versions:
-    ">=2.0.0": "/_shard_stores?pretty"
+    ">=2.0.0": "/_shard_stores"
 
 shards:
+  tags: light
   retry: true
   versions:
-    ">=0.9.0": "/_cat/shards?format=json&bytes=b&pretty"
+    ">=0.9.0": "/_cat/shards?format=json&bytes=b"
 
 snapshot:
   versions:
     ">=7.15.0": "/_snapshot/*/*?verbose=false"
 
 ssl_certs:
+  tags: light
   versions:
     ">= 6.2.0 < 7.0.0": "/_xpack/ssl/certificates"
     ">= 7.0.0": "/_ssl/certificates"
 
 tasks:
+  tags: light
   versions:
-    ">=2.0.0": "/_tasks?pretty&human&detailed=true"
+    ">=2.0.0": "/_tasks?human&detailed=true"
 
 templates:
+  tags: light
   versions:
-    ">= 0.9.0": "/_template?pretty"
+    ">= 0.9.0": "/_template"
 
 version:
   retry: true
@@ -333,54 +348,57 @@ version:
 autoscaling_capacity:
   subdir: "commercial"
   versions:
-    ">= 7.11.0": "/_autoscaling/capacity?pretty"
+    ">= 7.11.0": "/_autoscaling/capacity"
 
 ccr_autofollow_patterns:
   subdir: "commercial"
   versions:
-    ">= 6.5.0": "/_ccr/auto_follow?pretty"
+    ">= 6.5.0": "/_ccr/auto_follow"
 
 ccr_follower_info:
   subdir: "commercial"
   versions:
-    ">= 6.7.0": "/_all/_ccr/info?pretty"
+    ">= 6.7.0": "/_all/_ccr/info"
 
 ccr_stats:
   subdir: "commercial"
   versions:
-    ">= 6.5.0": "/_ccr/stats?pretty"
+    ">= 6.5.0": "/_ccr/stats"
 
 enrich_policies:
   subdir: "commercial"
   versions:
-    ">= 7.5.0": "/_enrich/policy?pretty"
+    ">= 7.5.0": "/_enrich/policy"
 
 enrich_stats:
   subdir: "commercial"
   versions:
-    ">= 7.5.0": "/_enrich/_stats?pretty"
+    ">= 7.5.0": "/_enrich/_stats"
 
 ilm_explain:
+  tags: light
   subdir: "commercial"
   versions:
-    ">= 6.6.0 < 7.7.0": "/*/_ilm/explain?human&pretty"
-    ">= 7.7.0": "/*/_ilm/explain?human&pretty&expand_wildcards=all"
+    ">= 6.6.0 < 7.7.0": "/*/_ilm/explain?human"
+    ">= 7.7.0": "/*/_ilm/explain?human&expand_wildcards=all"
 
 ilm_explain_only_errors:
   subdir: "commercial"
   versions:
-    ">= 7.4.0 < 7.7.0": "/*/_ilm/explain?only_errors=true&human&pretty"
-    ">= 7.7.0": "/*/_ilm/explain?only_errors=true&human&pretty&expand_wildcards=all"
+    ">= 7.4.0 < 7.7.0": "/*/_ilm/explain?only_errors=true&human"
+    ">= 7.7.0": "/*/_ilm/explain?only_errors=true&human&expand_wildcards=all"
 
 ilm_policies:
+  tags: light
   subdir: "commercial"
   versions:
-    ">= 6.6.0": "/_ilm/policy?human&pretty"
+    ">= 6.6.0": "/_ilm/policy?human"
 
 ilm_status:
+  tags: light
   subdir: "commercial"
   versions:
-    ">= 6.6.0": "/_ilm/status?pretty"
+    ">= 6.6.0": "/_ilm/status"
 
 logstash_pipeline:
   subdir: "commercial"
@@ -390,56 +408,57 @@ logstash_pipeline:
 ml_anomaly_detectors:
   subdir: "commercial"
   versions:
-    ">= 5.0.0 < 7.0.0": "/_xpack/ml/anomaly_detectors?pretty"
-    ">= 7.0.0": "/_ml/anomaly_detectors?pretty"
+    ">= 5.0.0 < 7.0.0": "/_xpack/ml/anomaly_detectors"
+    ">= 7.0.0": "/_ml/anomaly_detectors"
 
 ml_datafeeds:
   subdir: "commercial"
   versions:
-    ">= 5.0.0 < 7.0.0": "/_xpack/ml/datafeeds?pretty"
-    ">= 7.0.0": "/_ml/datafeeds?pretty"
+    ">= 5.0.0 < 7.0.0": "/_xpack/ml/datafeeds"
+    ">= 7.0.0": "/_ml/datafeeds"
 
 ml_datafeeds_stats:
   subdir: "commercial"
   versions:
-    ">= 7.4.0": "/_ml/datafeeds/_stats?pretty"
+    ">= 7.4.0": "/_ml/datafeeds/_stats"
 
 ml_dataframe:
   subdir: "commercial"
   versions:
-    ">= 7.3.0": "/_ml/data_frame/analytics?pretty"
+    ">= 7.3.0": "/_ml/data_frame/analytics"
 
 ml_dataframe_stats:
   subdir: "commercial"
   versions:
-    ">= 7.3.0": "/_ml/data_frame/analytics/_stats?pretty"
+    ">= 7.3.0": "/_ml/data_frame/analytics/_stats"
 
 ml_info:
   subdir: "commercial"
   versions:
-    ">= 6.3.0 < 7.0.0": "/_xpack/ml/info?pretty"
-    ">= 7.0.0": "/_ml/info?pretty"
+    ">= 6.3.0 < 7.0.0": "/_xpack/ml/info"
+    ">= 7.0.0": "/_ml/info"
 
 ml_stats:
   subdir: "commercial"
   versions:
-    ">= 5.0.0 < 7.0.0": "/_xpack/ml/anomaly_detectors/_stats?pretty"
-    ">= 7.0.0": "/_ml/anomaly_detectors/_stats?pretty"
+    ">= 5.0.0 < 7.0.0": "/_xpack/ml/anomaly_detectors/_stats"
+    ">= 7.0.0": "/_ml/anomaly_detectors/_stats"
 
 ml_trained_models:
   subdir: "commercial"
   versions:
-    ">= 7.10.0": "/_ml/trained_models?pretty"
+    ">= 7.10.0": "/_ml/trained_models"
 
 ml_trained_models_stats:
   subdir: "commercial"
   versions:
-    ">= 7.10.0": "/_ml/trained_models/_stats?pretty"
+    ">= 7.10.0": "/_ml/trained_models/_stats"
 
 nodes_shutdown_status:
+  tags: light
   subdir: "commercial"
   versions:
-    ">= 7.15.0": "/_nodes/shutdown?pretty"
+    ">= 7.15.0": "/_nodes/shutdown"
 
 rollup_jobs:
   subdir: "commercial"
@@ -462,45 +481,47 @@ rollup_index_caps:
 searchable_snapshots_cache_stats:
   subdir: "commercial"
   versions:
-    ">= 7.13.0": "/_searchable_snapshots/cache/stats?pretty&human"
+    ">= 7.13.0": "/_searchable_snapshots/cache/stats?human"
 
 security_priv:
   subdir: "commercial"
   versions:
-    ">= 6.5.0 < 7.0.0": "/_xpack/security/privilege?pretty"
-    ">= 7.0.0": "/_security/privilege?pretty"
+    ">= 6.5.0 < 7.0.0": "/_xpack/security/privilege"
+    ">= 7.0.0": "/_security/privilege"
 
 security_roles:
   subdir: "commercial"
   versions:
-    ">= 2.0.0 < 5.0.0": "/_shield/role?pretty"
-    ">= 5.0.0 < 7.0.0": "/_xpack/security/role?pretty"
-    ">= 7.0.0": "/_security/role?pretty"
+    ">= 2.0.0 < 5.0.0": "/_shield/role"
+    ">= 5.0.0 < 7.0.0": "/_xpack/security/role"
+    ">= 7.0.0": "/_security/role"
 
 security_role_mappings:
   subdir: "commercial"
   versions:
-    ">= 5.0.0 < 7.0.0": "/_xpack/security/role_mapping?pretty"
-    ">= 7.0.0": "/_security/role_mapping?pretty"
+    ">= 5.0.0 < 7.0.0": "/_xpack/security/role_mapping"
+    ">= 7.0.0": "/_security/role_mapping"
 
 security_users:
   subdir: "commercial"
   versions:
-    ">= 2.0.0 < 5.0.0": "/_shield/user?pretty"
-    ">= 5.0.0 < 7.0.0": "/_xpack/security/user?pretty"
-    ">= 7.0.0": "/_security/user?pretty"
+    ">= 2.0.0 < 5.0.0": "/_shield/user"
+    ">= 5.0.0 < 7.0.0": "/_xpack/security/user"
+    ">= 7.0.0": "/_security/user"
 
 slm_policies:
+  tags: light
   subdir: "commercial"
   versions:
-    ">= 7.4.0": "/_slm/policy?pretty&human"
+    ">= 7.4.0": "/_slm/policy?human"
 
 slm_stats:
   subdir: "commercial"
   versions:
-    ">= 7.5.0": "/_slm/stats?pretty"
+    ">= 7.5.0": "/_slm/stats"
 
 slm_status:
+  tags: light
   subdir: "commercial"
   versions:
     ">= 7.6.0": "/_slm/status"
@@ -508,14 +529,14 @@ slm_status:
 transform:
   subdir: "commercial"
   versions:
-    ">= 7.2.0 < 7.5.0": "/_data_frame/transforms?pretty"
-    ">= 7.5.0": "/_transform?pretty"
+    ">= 7.2.0 < 7.5.0": "/_data_frame/transforms"
+    ">= 7.5.0": "/_transform"
 
 transform_stats:
   subdir: "commercial"
   versions:
-    ">= 7.2.0 < 7.5.0": "/_data_frame/transforms/_stats?pretty"
-    ">= 7.5.0": "/_transform/_stats?pretty"
+    ">= 7.2.0 < 7.5.0": "/_data_frame/transforms/_stats"
+    ">= 7.5.0": "/_transform/_stats"
 
 watcher_stats:
   subdir: "commercial"
@@ -534,10 +555,10 @@ watcher_stack:
 xpack:
   subdir: "commercial"
   versions:
-    ">= 5.0.0": "/_xpack/usage?pretty&human"
+    ">= 5.0.0": "/_xpack/usage?human"
 
 data_stream:
   subdir: "commercial"
   versions:
-    ">= 7.9.0 < 7.11.0": "/_data_stream?pretty"
-    ">= 7.11.0": "/_data_stream?pretty&expand_wildcards=all"
+    ">= 7.9.0 < 7.11.0": "/_data_stream"
+    ">= 7.11.0": "/_data_stream?expand_wildcards=all"

--- a/src/main/resources/logstash-rest.yml
+++ b/src/main/resources/logstash-rest.yml
@@ -16,20 +16,25 @@
 
 logstash_version:
   versions:
-    "> 0.0.0": "/?pretty"
+    "> 0.0.0": "/"
 
 logstash_node:
   versions:
-    "> 0.0.0": "/_node?pretty"
+    "> 0.0.0": "/_node"
 
 logstash_node_stats:
   versions:
-    "> 0.0.0": "/_node/stats?pretty"
+    "> 0.0.0": "/_node/stats"
 
 logstash_nodes_hot_threads:
   versions:
-    "> 0.0.0": "/_node/hot_threads?human=true&threads=10000"
+    "> 0.0.0": "/_node/hot_threads?threads=10000"
+
+logstash_nodes_hot_threads_human:
+  extension: .txt
+  versions:
+    "> 0.0.0": "/_node/hot_threads?human&threads=10000"
 
 logstash_plugins:
   versions:
-    "> 0.0.0": "/_node/plugins?pretty"
+    "> 0.0.0": "/_node/plugins"

--- a/src/test/java/co/elastic/support/diagnostics/TestDiagnosticService.java
+++ b/src/test/java/co/elastic/support/diagnostics/TestDiagnosticService.java
@@ -44,7 +44,8 @@ class TestDiagnosticService {
     @BeforeAll
     public void globalSetup() {
         mockServer = startClientAndServer(9880);
-        // mockserver by default is in verbose mode (useful when creating new test), move it to warning.
+        // mockserver by default is in verbose mode (useful when creating new test),
+        // move it to warning.
         ConfigurationProperties.disableSystemOut(true);
         ConfigurationProperties.logLevel("WARN");
     }
@@ -56,8 +57,8 @@ class TestDiagnosticService {
 
     @BeforeEach
     public void setup() throws IOException {
-         folder = new TemporaryFolder();
-         folder.create();
+        folder = new TemporaryFolder();
+        folder.create();
     }
 
     @AfterEach
@@ -82,7 +83,7 @@ class TestDiagnosticService {
         try {
             File outputDir = folder.newFolder();
             diagnosticInputs.outputDir = outputDir.toString();
-        } catch(IOException e) {
+        } catch (IOException e) {
             fail("Unable to create temp directory", e);
         }
         return diagnosticInputs;
@@ -92,8 +93,7 @@ class TestDiagnosticService {
         if (withHeaders) {
             return request().withHeaders(
                     new Header(headerKey1, headerVal1),
-                    new Header(headerKey2, headerVal2)
-            );
+                    new Header(headerKey2, headerVal2));
         } else {
             return request();
         }
@@ -103,29 +103,23 @@ class TestDiagnosticService {
         mockServer
                 .when(
                         myRequest(withHeaders)
-                                .withPath("/")
-                )
+                                .withPath("/"))
                 .respond(
                         response()
-                                .withBody("{\"version\": {\"number\": \"7.14.0\"}}")
-                );
+                                .withBody("{\"version\": {\"number\": \"7.14.0\"}}"));
         mockServer
                 .when(
                         myRequest(withHeaders)
-                                .withPath("/_nodes/os,process,settings,transport,http")
-                )
+                                .withPath("/_nodes/os,process,settings,transport,http"))
                 .respond(
                         response()
-                                .withBody("{}")
-                );
+                                .withBody("{}"));
         mockServer
                 .when(
-                        myRequest(withHeaders)
-                )
+                        myRequest(withHeaders))
                 .respond(
                         response()
-                                .withBody("some_response_body")
-                );
+                                .withBody("some_response_body"));
     }
 
     public HashMap<String, ZipEntry> zipFileContents(File result) throws IOException {
@@ -173,9 +167,8 @@ class TestDiagnosticService {
         diagConfig.extraHeaders = extraHeaders;
         DiagnosticService diag = new DiagnosticService();
 
-        try(
-            ResourceCache resourceCache = new ResourceCache();
-        ) {
+        try (
+                ResourceCache resourceCache = new ResourceCache();) {
             DiagnosticContext context = new DiagnosticContext(diagConfig, newDiagnosticInputs(), resourceCache, true);
             File result = diag.exec(context);
             checkResult(result, true);
@@ -190,10 +183,10 @@ class TestDiagnosticService {
 
         DiagnosticService diag = new DiagnosticService();
 
-        try(
-            ResourceCache resourceCache = new ResourceCache();
-        ) {
-            DiagnosticContext context = new DiagnosticContext(newDiagConfig(), newDiagnosticInputs(), resourceCache, true);
+        try (
+                ResourceCache resourceCache = new ResourceCache();) {
+            DiagnosticContext context = new DiagnosticContext(newDiagConfig(), newDiagnosticInputs(), resourceCache,
+                    true);
             File result = diag.exec(context);
             checkResult(result, true);
         } catch (DiagnosticException e) {
@@ -212,8 +205,9 @@ class TestDiagnosticService {
             public void run() {
                 DiagnosticService diag = new DiagnosticService();
 
-                try(ResourceCache resourceCache = new ResourceCache()) {
-                    DiagnosticContext context = new DiagnosticContext(newDiagConfig(), newDiagnosticInputs(), resourceCache, false);
+                try (ResourceCache resourceCache = new ResourceCache()) {
+                    DiagnosticContext context = new DiagnosticContext(newDiagConfig(), newDiagnosticInputs(),
+                            resourceCache, false);
                     File result = diag.exec(context);
                     results.put(i, result);
                 } catch (DiagnosticException e) {
@@ -227,7 +221,7 @@ class TestDiagnosticService {
         Arrays.setAll(threads, i -> new Thread(task.apply(i)));
         Arrays.stream(threads).forEach(Thread::start);
 
-        for (Thread t: threads) {
+        for (Thread t : threads) {
             try {
                 t.join(3000);
             } catch (InterruptedException e) {
@@ -249,7 +243,7 @@ class TestDiagnosticService {
                 HashMap<String, ZipEntry> other = zipFileContents(resultFiles.nextElement());
                 assertEquals(reference.keySet(), other.keySet());
                 reference.keySet().forEach((key) -> {
-                    if (!key.equals("manifest.json")) {
+                    if (!key.equals("manifest.json") && !key.equals("diagnostic_manifest.json")) {
                         assertEquals(reference.get(key).getSize(), other.get(key).getSize(), key);
                         assertEquals(reference.get(key).getCrc(), other.get(key).getCrc(), key);
                     }

--- a/src/test/java/co/elastic/support/diagnostics/commands/TestKibanaGetDetails.java
+++ b/src/test/java/co/elastic/support/diagnostics/commands/TestKibanaGetDetails.java
@@ -37,7 +37,7 @@ import static org.mockserver.model.HttpResponse.response;
 public class TestKibanaGetDetails {
 
     private ClientAndServer mockServer;
-    private RestClient httpRestClient, httpsRestClient;
+    private RestClient httpRestClient;
 
     @BeforeAll
     public void globalSetup() {
@@ -53,22 +53,22 @@ public class TestKibanaGetDetails {
     public void setup() {
 
         httpRestClient = RestClient.getClient(
-            "localhost",
-            9880,
-            "http",
-            "elastic",
-            "elastic",
-            "",
-            0,
-            "",
-            "",
-            "",
-            "",
-            true,
-            Collections.emptyMap(),
-           3000,
-           3000,
-           3000);
+                "localhost",
+                9880,
+                "http",
+                "elastic",
+                "elastic",
+                "",
+                0,
+                "",
+                "",
+                "",
+                "",
+                true,
+                Collections.emptyMap(),
+                3000,
+                3000,
+                3000);
     }
 
     @AfterEach
@@ -95,7 +95,6 @@ public class TestKibanaGetDetails {
         assertEquals(nodeProfiles.get(0).httpPort, 18648);
     }
 
-
     @Test
     public void testFindTargetNode() {
 
@@ -112,11 +111,11 @@ public class TestKibanaGetDetails {
         assertEquals(testedNodeProfiles.isDocker, true);
     }
 
-   /**
-    * Kibana is working in single mode, so the target node will be the only host stored on the nodeProfiles List
-    * if they are two nodes is an error.
-    *
-    */
+    /**
+     * Kibana is working in single mode, so the target node will be the only host
+     * stored on the nodeProfiles List
+     * if they are two nodes is an error.
+     */
     @Test
     public void testClusterFindTargetNode() {
         KibanaGetDetails testClass = new KibanaGetDetails();
@@ -148,13 +147,12 @@ public class TestKibanaGetDetails {
                 .when(
                         request()
                                 .withMethod("GET")
-                                .withPath("/api/stats")
-                )
+                                .withPath("/api/stats"))
                 .respond(
                         response()
-                            .withBody("{\"process\":{\"memory\":{\"heap\":{\"total_bytes\":470466560,\"used_bytes\":343398224,\"size_limit\":1740165498},\"resident_set_size_bytes\":587878400},\"pid\":32,\"event_loop_delay\":0.280181884765625,\"uptime_ms\":97230924},\"os\":{\"platform\":\"linux\",\"platform_release\":\"linux-4.15.0-1032-gcp\",\"load\":{\"1m\":1.37451171875,\"5m\":1.43408203125,\"15m\":1.34375},\"memory\":{\"total_bytes\":147879931904,\"free_bytes\":45620334592,\"used_bytes\":102259597312},\"uptime_ms\":18093713000,\"distro\":\"Centos\",\"distro_release\":\"Centos-7.8.2003\"},\"requests\":{\"disconnects\":0,\"total\":1,\"status_codes\":{\"302\":1}},\"concurrent_connections\":8,\"timestamp\":\"2021-01-06T01:35:11.324Z\",\"kibana\":{\"uuid\":\"a4f369ef-fecd-46b7-8b16-c6c3f885d9ec\",\"name\":\"13d5e793ea51\",\"index\":\".kibana\",\"host\":\"0.0.0.0\",\"locale\":\"en\",\"transport_address\":\"0.0.0.0:18648\",\"version\":\"7.9.0\",\"snapshot\":false,\"status\":\"green\"},\"last_updated\":\"2021-01-06T01:35:15.911Z\",\"collection_interval_ms\":5000,\"cluster_uuid\":\"RfBRUssssadN4WZssnnog\"}")
-                            .withStatusCode(401)
-                );
+                                .withBody(
+                                        "{\"process\":{\"memory\":{\"heap\":{\"total_bytes\":470466560,\"used_bytes\":343398224,\"size_limit\":1740165498},\"resident_set_size_bytes\":587878400},\"pid\":32,\"event_loop_delay\":0.280181884765625,\"uptime_ms\":97230924},\"os\":{\"platform\":\"linux\",\"platform_release\":\"linux-4.15.0-1032-gcp\",\"load\":{\"1m\":1.37451171875,\"5m\":1.43408203125,\"15m\":1.34375},\"memory\":{\"total_bytes\":147879931904,\"free_bytes\":45620334592,\"used_bytes\":102259597312},\"uptime_ms\":18093713000,\"distro\":\"Centos\",\"distro_release\":\"Centos-7.8.2003\"},\"requests\":{\"disconnects\":0,\"total\":1,\"status_codes\":{\"302\":1}},\"concurrent_connections\":8,\"timestamp\":\"2021-01-06T01:35:11.324Z\",\"kibana\":{\"uuid\":\"a4f369ef-fecd-46b7-8b16-c6c3f885d9ec\",\"name\":\"13d5e793ea51\",\"index\":\".kibana\",\"host\":\"0.0.0.0\",\"locale\":\"en\",\"transport_address\":\"0.0.0.0:18648\",\"version\":\"7.9.0\",\"snapshot\":false,\"status\":\"green\"},\"last_updated\":\"2021-01-06T01:35:15.911Z\",\"collection_interval_ms\":5000,\"cluster_uuid\":\"RfBRUssssadN4WZssnnog\"}")
+                                .withStatusCode(401));
 
         Map diagMap = JsonYamlUtils.readYamlFromClasspath(Constants.DIAG_CONFIG, true);
         Map restCalls = JsonYamlUtils.readYamlFromClasspath(Constants.KIBANA_REST, true);
@@ -162,16 +160,15 @@ public class TestKibanaGetDetails {
         Map<String, RestEntry> entries = builder.buildEntryMap(restCalls);
 
         KibanaGetDetails testClass = new KibanaGetDetails();
-        try(
-            ResourceCache resourceCache = new ResourceCache();
-        ) {
+        try (
+                ResourceCache resourceCache = new ResourceCache();) {
             DiagnosticContext context = new DiagnosticContext(
-                new DiagConfig(diagMap),
-                new DiagnosticInputs("testKibanaGetDetails"),
-                resourceCache,
-                true
-            );
+                    new DiagConfig(diagMap),
+                    new DiagnosticInputs("testKibanaGetDetails"),
+                    resourceCache,
+                    true);
             context.elasticRestCalls = entries;
+            context.fullElasticRestCalls = entries;
             resourceCache.addRestClient(Constants.restInputHost, httpRestClient);
             testClass.getStats(context);
         } catch (DiagnosticException e) {

--- a/src/test/java/co/elastic/support/rest/TestRestExecCalls.java
+++ b/src/test/java/co/elastic/support/rest/TestRestExecCalls.java
@@ -10,21 +10,16 @@ import co.elastic.support.diagnostics.commands.RunClusterQueries;
 import co.elastic.support.util.SystemProperties;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
-import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.junit.jupiter.api.*;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.matchers.Times;
 import org.mockserver.model.Header;
-import org.mockserver.model.Parameter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import org.mockserver.configuration.ConfigurationProperties;
 
@@ -36,263 +31,237 @@ import static org.mockserver.model.HttpResponse.response;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestRestExecCalls {
 
-    private final Logger logger = LoggerFactory.getLogger(TestRestExecCalls.class);
-    private ClientAndServer mockServer;
-    private RestClient httpRestClient, httpsRestClient;
-    private String temp = SystemProperties.userDir + SystemProperties.fileSeparator + "temp";
-    private File tempDir = new File(temp);
-    private String authStringEnc = new String(Base64.encodeBase64("elastic:elastic".getBytes()));
+        private ClientAndServer mockServer;
+        private RestClient httpRestClient, httpsRestClient;
+        private String temp = SystemProperties.userDir + SystemProperties.fileSeparator + "temp";
+        private File tempDir = new File(temp);
+        private String authStringEnc = new String(Base64.encodeBase64("elastic:elastic".getBytes()));
 
-    @BeforeAll
-    public void globalSetup() {
-        mockServer = startClientAndServer(9880);
-        // mockserver by default is in verboce mode (useful when creating new test), move it to warning.
-        ConfigurationProperties.disableSystemOut(true);
-        ConfigurationProperties.logLevel("WARN");
+        @BeforeAll
+        public void globalSetup() {
+                mockServer = startClientAndServer(9880);
+                // mockserver by default is in verboce mode (useful when creating new test),
+                // move it to warning.
+                ConfigurationProperties.disableSystemOut(true);
+                ConfigurationProperties.logLevel("WARN");
 
-    }
-
-    @AfterAll
-    public void globalTeardown() {
-        mockServer.stop();
-    }
-
-
-    @BeforeEach
-    public void setup() {
-        
-        httpRestClient = RestClient.getClient(
-            "localhost", 
-            9880, 
-            "http",
-            "elastic",
-            "elastic",
-            "",
-            0,
-            "",
-            "",
-            "",
-            "",
-            true,
-            Collections.emptyMap(),
-           3000,
-           3000,
-           3000);
-        httpsRestClient = RestClient.getClient(
-            "localhost", 
-            9880, 
-            "https",
-            "elastic",
-            "elastic",
-            "",
-            0,
-            "",
-            "",
-            "",
-            "",
-            true,
-            Collections.emptyMap(),
-           3000,
-           3000,
-           3000);
-
-        tempDir.mkdir();
-
-    }
-
-    @AfterEach
-    public void tearDown() {
-
-        mockServer.reset();
-        FileUtils.deleteQuietly(tempDir);
-
-    }
-
-    @Test
-    public void testSimpleQuery() {
-
-        mockServer
-                .when(
-                        request()
-                                .withMethod("GET")
-                                .withPath("/")
-                                .withHeader(new Header("Authorization", "Basic " + authStringEnc))
-                                .withQueryStringParameters(
-                                        new Parameter("pretty")
-                                )
-                )
-                .respond(
-                        response()
-                                .withBody("some_response_body")
-                );
-
-
-        RestResult result = httpRestClient.execQuery("/?pretty");
-        assertEquals(200, result.getStatus());
-        assertEquals("some_response_body", result.toString());
-    }
-
-    @Test
-    public void testSecuredQuery() {
-
-        String url = "/";
-
-        mockServer
-                .when(
-                        request()
-                                .withMethod("GET")
-                                .withPath("/")
-                                .withHeader(new Header("Authorization", "Basic " + authStringEnc))
-                )
-                .respond(
-                        response()
-                                .withBody("some_response_body")
-                );
-
-        RestResult result = httpRestClient.execQuery(url);
-        assertEquals(200, result.getStatus());
-        assertEquals("some_response_body", result.toString());
-
-    }
-
-    @Test
-    public void testHttpsQuery() {
-
-        String url = "/_nodes?pretty";
-        mockServer
-                .when(
-                        request()
-                                .withMethod("GET")
-                                .withPath("/_nodes")
-                                .withQueryStringParameter(new Parameter("pretty"))
-                                .withSecure(true)
-                                .withHeader(new Header("Authorization", "Basic " + authStringEnc))
-                )
-                .respond(
-                        response()
-                                .withBody("some_response_body")
-                );
-
-        RestResult result = httpsRestClient.execQuery(url);
-        assertEquals(200, result.getStatus());
-        assertEquals("some_response_body", result.toString());
-
-    }
-
-    @Test
-    public void testFailThenSucceed() {
-
-        RunClusterQueries cmd = new RunClusterQueries();
-        List<RestEntry> entries = new ArrayList<>();
-        entries.add(new RestEntry("nodes", "", ".json", true, "/_nodes?pretty", false));
-        mockServer
-                .when(
-                        request()
-                                .withMethod("GET")
-                                .withPath("/_nodes")
-                                .withQueryStringParameter(new Parameter("pretty")),
-                        Times.exactly(2)
-                )
-                .respond(
-                        response()
-                                .withBody("error_response_body")
-                                .withStatusCode(502)
-                );
-
-        mockServer
-                .when(
-                        request()
-                                .withMethod("GET")
-                                .withPath("/_nodes")
-                                .withQueryStringParameter(new Parameter("pretty")),
-                        Times.exactly(1)
-                )
-                .respond(
-                        response()
-                                .withBody("node_response_body")
-                                .withStatusCode(200)
-                );
-
-        String targetFilename = temp + SystemProperties.fileSeparator + "nodes.json";
-        int totalRetries = cmd.runQueries(httpRestClient, entries, temp, 3, 500);
-        assertEquals(2, totalRetries);
-        assertTrue( fileExistsWithText(targetFilename, "node_response_body"));
-
-
-    }
-
-    @Test
-    public void testRetryAllFail() {
-
-        RunClusterQueries cmd = new RunClusterQueries();
-        List<RestEntry> entries = new ArrayList<>();
-        entries.add(new RestEntry("nodes", "", ".json", true, "/_nodes?pretty", false));
-        mockServer
-                .when(
-                        request()
-                                .withMethod("GET")
-                                .withPath("/_nodes")
-                                .withQueryStringParameter(new Parameter("pretty")),
-                        Times.exactly(4)
-                )
-                .respond(
-                        response()
-                                .withBody("error_response_body")
-                                .withStatusCode(502)
-                );
-
-
-        String targetFilename = temp + SystemProperties.fileSeparator + "nodes.json";
-
-        int totalRetries = cmd.runQueries(httpRestClient, entries, temp, 3, 500);
-        assertEquals(4, totalRetries);
-        assertTrue( fileExistsWithText(targetFilename, "error_response_body"));
-
-    }
-
-
-    @Test
-    public void testAuthFailure() {
-
-        RunClusterQueries cmd = new RunClusterQueries();
-        List<RestEntry> entries = new ArrayList<>();
-        entries.add(new RestEntry("nodes", "", ".json", true, "/_nodes?pretty", false));
-
-        mockServer
-                .when(
-                        request()
-                                .withMethod("GET")
-                                .withPath("/_nodes")
-                                .withQueryStringParameter(new Parameter("pretty")),
-                        Times.exactly(1)
-                )
-                .respond(
-                        response()
-                                .withBody("autherror_response_body")
-                                .withStatusCode(401)
-                );
-
-        int totalRetries = cmd.runQueries(httpRestClient, entries, temp, 3, 500);
-        assertEquals(0, totalRetries);
-
-        String targetFilename = temp + SystemProperties.fileSeparator + "nodes.json";
-        assertTrue( fileExistsWithText(targetFilename, "autherror_response_body"));
-
-    }
-
-
-    private boolean fileExistsWithText(String filename, String compare){
-        try {
-            String fileContents = FileUtils.readFileToString(new File(filename), "UTF8");
-            if (! fileContents.contains(compare) ){
-                return false;
-            }
-        } catch (IOException e) {
-            return false;
         }
 
-        return true;
-    }
+        @AfterAll
+        public void globalTeardown() {
+                mockServer.stop();
+        }
 
+        @BeforeEach
+        public void setup() {
+
+                httpRestClient = RestClient.getClient(
+                                "localhost",
+                                9880,
+                                "http",
+                                "elastic",
+                                "elastic",
+                                "",
+                                0,
+                                "",
+                                "",
+                                "",
+                                "",
+                                true,
+                                Collections.emptyMap(),
+                                3000,
+                                3000,
+                                3000);
+                httpsRestClient = RestClient.getClient(
+                                "localhost",
+                                9880,
+                                "https",
+                                "elastic",
+                                "elastic",
+                                "",
+                                0,
+                                "",
+                                "",
+                                "",
+                                "",
+                                true,
+                                Collections.emptyMap(),
+                                3000,
+                                3000,
+                                3000);
+
+                tempDir.mkdir();
+
+        }
+
+        @AfterEach
+        public void tearDown() {
+
+                mockServer.reset();
+                FileUtils.deleteQuietly(tempDir);
+
+        }
+
+        @Test
+        public void testSimpleQuery() {
+
+                mockServer
+                                .when(
+                                                request()
+                                                                .withMethod("GET")
+                                                                .withPath("/")
+                                                                .withHeader(new Header("Authorization",
+                                                                                "Basic " + authStringEnc)))
+                                .respond(
+                                                response()
+                                                                .withBody("some_response_body"));
+
+                RestResult result = httpRestClient.execQuery("/");
+                assertEquals(200, result.getStatus());
+                assertEquals("some_response_body", result.toString());
+        }
+
+        @Test
+        public void testSecuredQuery() {
+
+                String url = "/";
+
+                mockServer
+                                .when(
+                                                request()
+                                                                .withMethod("GET")
+                                                                .withPath("/")
+                                                                .withHeader(new Header("Authorization",
+                                                                                "Basic " + authStringEnc)))
+                                .respond(
+                                                response()
+                                                                .withBody("some_response_body"));
+
+                RestResult result = httpRestClient.execQuery(url);
+                assertEquals(200, result.getStatus());
+                assertEquals("some_response_body", result.toString());
+
+        }
+
+        @Test
+        public void testHttpsQuery() {
+
+                String url = "/_nodes";
+                mockServer
+                                .when(
+                                                request()
+                                                                .withMethod("GET")
+                                                                .withPath("/_nodes")
+                                                                .withSecure(true)
+                                                                .withHeader(new Header("Authorization",
+                                                                                "Basic " + authStringEnc)))
+                                .respond(
+                                                response()
+                                                                .withBody("some_response_body"));
+
+                RestResult result = httpsRestClient.execQuery(url);
+                assertEquals(200, result.getStatus());
+                assertEquals("some_response_body", result.toString());
+
+        }
+
+        @Test
+        public void testFailThenSucceed() {
+
+                RunClusterQueries cmd = new RunClusterQueries();
+                List<RestEntry> entries = new ArrayList<>();
+                entries.add(new RestEntry("nodes", "", ".json", true, "/_nodes", false));
+                mockServer
+                                .when(
+                                                request()
+                                                                .withMethod("GET")
+                                                                .withPath("/_nodes"),
+                                                Times.exactly(2))
+                                .respond(
+                                                response()
+                                                                .withBody("error_response_body")
+                                                                .withStatusCode(502));
+
+                mockServer
+                                .when(
+                                                request()
+                                                                .withMethod("GET")
+                                                                .withPath("/_nodes"),
+                                                Times.exactly(1))
+                                .respond(
+                                                response()
+                                                                .withBody("node_response_body")
+                                                                .withStatusCode(200));
+
+                String targetFilename = temp + SystemProperties.fileSeparator + "nodes.json";
+                int totalRetries = cmd.runQueries(httpRestClient, entries, temp, 3, 500);
+                assertEquals(2, totalRetries);
+                assertTrue(fileExistsWithText(targetFilename, "node_response_body"));
+
+        }
+
+        @Test
+        public void testRetryAllFail() {
+
+                RunClusterQueries cmd = new RunClusterQueries();
+                List<RestEntry> entries = new ArrayList<>();
+                entries.add(new RestEntry("nodes", "", ".json", true, "/_nodes", false));
+                mockServer
+                                .when(
+                                                request()
+                                                                .withMethod("GET")
+                                                                .withPath("/_nodes"),
+                                                Times.exactly(4))
+                                .respond(
+                                                response()
+                                                                .withBody("error_response_body")
+                                                                .withStatusCode(502));
+
+                String targetFilename = temp + SystemProperties.fileSeparator + "nodes.json";
+
+                int totalRetries = cmd.runQueries(httpRestClient, entries, temp, 3, 500);
+                assertEquals(4, totalRetries);
+                assertTrue(fileExistsWithText(targetFilename, "error_response_body"));
+
+        }
+
+        @Test
+        public void testAuthFailure() {
+
+                RunClusterQueries cmd = new RunClusterQueries();
+                List<RestEntry> entries = new ArrayList<>();
+                entries.add(new RestEntry("nodes", "", ".json", true, "/_nodes", false));
+
+                mockServer
+                                .when(
+                                                request()
+                                                                .withMethod("GET")
+                                                                .withPath("/_nodes"),
+                                                Times.exactly(1))
+                                .respond(
+                                                response()
+                                                                .withBody("autherror_response_body")
+                                                                .withStatusCode(401));
+
+                int totalRetries = cmd.runQueries(httpRestClient, entries, temp, 3, 500);
+                assertEquals(0, totalRetries);
+
+                String targetFilename = temp + SystemProperties.fileSeparator + "nodes.json";
+                assertTrue(fileExistsWithText(targetFilename, "autherror_response_body"));
+
+        }
+
+        private boolean fileExistsWithText(String filename, String compare) {
+                try {
+                        String fileContents = FileUtils.readFileToString(new File(filename), "UTF8");
+                        if (!fileContents.contains(compare)) {
+                                return false;
+                        }
+                } catch (IOException e) {
+                        return false;
+                }
+
+                return true;
+        }
 
 }

--- a/src/test/resources/diags-test.yml
+++ b/src/test/resources/diags-test.yml
@@ -53,7 +53,7 @@ retries:
 rest-calls:
 
   common:
-    alias: "/_alias?pretty&human"
+    alias: "/_alias?human"
     cat_indices: "/_cat/indices?v"
 
   versions:
@@ -67,7 +67,7 @@ rest-calls:
 
     major-5:
       minor-0:
-        allocation_explain: "/_cluster/allocation/explain?pretty"
+        allocation_explain: "/_cluster/allocation/explain"
       minor-2:
         cat_indices: "_cat/indices?v&s=index"
 
@@ -75,21 +75,21 @@ rest-calls:
       minor-0:
         nodes_usage: "/_nodes/usage"
       minor-5:
-        security_priv: "/_xpack/security/privilege?pretty"
+        security_priv: "/_xpack/security/privilege"
 
 elastic-threads:
-  nodes: "/_nodes?pretty&human"
+  nodes: "/_nodes?human"
   nodes_hot_threads: "/_nodes/hot_threads?threads=10000"
 
 thread-dump:
   jstack: "jstack PID"
 
 logstash:
-  logstash_version: "/?pretty"
-  logstash_node: "/_node?pretty"
-  logstash_node_stats: "/_node/stats?pretty"
+  logstash_version: "/"
+  logstash_node: "/_node"
+  logstash_node_stats: "/_node/stats"
   logstash_nodes_hot_threads: "/_node/hot_threads?human=true&threads=10000"
-  logstash_plugins: "/_node/plugins?pretty"
+  logstash_plugins: "/_node/plugins"
 
 linuxOS:
   top: "top -b -n1"
@@ -131,5 +131,3 @@ winOS:
 winOS-dep:
   jps: "JAVA_HOME\\bin\\jps -l -m -v"
   jstack: "JAVA_HOME\\bin\\jstack PID"
-
-

--- a/src/test/resources/rest-diags.yml
+++ b/src/test/resources/rest-diags.yml
@@ -56,11 +56,10 @@ require-retry:
 
 rest-calls:
   common:
-    nodes: "/_nodes?pretty&human"
+    nodes: "/_nodes?human"
 
   versions:
     major-1:
     major-2:
     major-5:
     major-6:
-


### PR DESCRIPTION
This PR does a few things:

- Increments the version from 8.x to 9.0 due to the breaking change of dropping support for tar files
- It drops support for `.tar` and `.tar.gz` files, which also means we drop the `--archiveType` flag
- Adds a new, optional flag `--mode` that allows users to collect a minimal Elasticsearch diagnostic via `--mode light`
  - Kibana and Logstash diagnostics do not honor currently this parameter
- Adds a new `diagnostic_manifest.json` that provides more usable-as-JSON details captured diagnostic
- Removes all uses of `pretty` printing from _all_ collected JSON files
- Corrects the Logstash hot threads file to actually be JSON (by removing `human`) and adding a `.txt` version of the hot threads file
- Makes it so that `logstash-api` can actually be used by removing a `RuntimeException` that served no purpose
- My editor corrected many formatting irregularities, so reviewing without whitespace changes will help
- Uses `./` instead of `/` for the base zip file entries

### Checklist

- [x] I have verified that the APIs in this pull request do not return sensitive data
