### PR TITLE
fix: use sha-256 for generating release checksums (#454)

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Add output files to the Github release
       shell: bash
       run: |
-        gh release upload $TAG target/diagnostics-${TAG:1}-dist.zip target/diagnostics-${TAG:1}-dist.zip.sha1
+        gh release upload $TAG target/diagnostics-${TAG:1}-dist.zip target/diagnostics-${TAG:1}-dist.zip.sha256
       env:
         GITHUB_TOKEN: ${{ github.TOKEN }}
         TAG: ${{ github.event.release.tag_name }}

--- a/pom.xml
+++ b/pom.xml
@@ -349,7 +349,7 @@
                         </fileSet>
                     </fileSets>
                     <algorithms>
-                        <algorithm>SHA-1</algorithm>
+                        <algorithm>SHA-256</algorithm>
                     </algorithms>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Fixes #454 
