### PR TITLE
Upgrade Javadoc plugin to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -431,7 +431,7 @@
                 <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                     <id>attach-javadocs</id>


### PR DESCRIPTION
Building the diagnostic analyzer fails on newer JDKs when running the Javadoc task. Upgrading the Javadoc plugin to the current version 3.5.0 fixes the build. As per
https://maven.apache.org/plugins/maven-javadoc-plugin/summary.html, that version of the plugin is still compatible with JDK 8.

### Checklist

- [x] I have verified that the APIs in this pull request do not return sensitive data
