### PR TITLE
Correct password parameter in contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ This is a tool used by the Elastic Support team to collect the necessary data to
   ```
 - Using the `Run` menu and select `Edit Configurations...`. Use the `+` to add an `Application` configuration.
   - Main class: `co.elastic.support.diagnostics.DiagnosticApp`
-  - Program arguments (example): `-o ~/tmp/diag-output -h localhost -u elastic --ptp changeme`. Put whatever arguments you would like to run the application with as default.
+  - Program arguments (example): `-o ~/tmp/diag-output -h localhost -u elastic --passwordText changeme`. Put whatever arguments you would like to run the application with as default.
 
 ### Releasing to Maven Central
 


### PR DESCRIPTION
The contribution guide mentioned the unrecognized parameter `-ptp` to specify a password for testing. With this commit we change this to the currently supported parameter `--passwordText` (there is no short variant of this parameter available).

### Checklist

- [x] I have verified that the APIs in this pull request do not return sensitive data
