### PR TITLE
Add profiling status API to ES diagnostics

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -460,6 +460,12 @@ nodes_shutdown_status:
   versions:
     ">= 7.15.0": "/_nodes/shutdown"
 
+profiling_status:
+  tags: light
+  subdir: "commercial"
+  versions:
+    ">= 8.9.0": "/_profiling/status"
+
 rollup_jobs:
   subdir: "commercial"
   versions:


### PR DESCRIPTION
With this commit we add a new API call to gather the status of Universal Profiling in the diagnostic dump. The API is always available in the default distribution even if the Universal Profiling plugin is disabled, so it is always safe to call.

### Checklist

- [x] I have verified that the APIs in this pull request do not return sensitive data
