### PR TITLE
Remove leading `./` from zip entries

### DIFF
--- a/src/main/java/co/elastic/support/util/ArchiveUtils.java
+++ b/src/main/java/co/elastic/support/util/ArchiveUtils.java
@@ -30,7 +30,7 @@ public class ArchiveUtils {
       try (
             FileOutputStream fout = new FileOutputStream(filename);
             ZipArchiveOutputStream taos = new ZipArchiveOutputStream(fout)) {
-         archiveResultsZip(archiveFileName, taos, srcDir, ".", true);
+         archiveResultsZip(archiveFileName, taos, srcDir, null, true);
          logger.info(Constants.CONSOLE, "Archive: " + filename + " was created");
          return file;
       } catch (IOException ioe) {
@@ -44,7 +44,7 @@ public class ArchiveUtils {
          File file,
          String path,
          boolean append) {
-      String relPath = path + "/" + file.getName();
+      String relPath = (path == null ? "" : path + "/") + file.getName();
 
       try {
          if (append) {

--- a/src/test/java/co/elastic/support/diagnostics/TestDiagnosticService.java
+++ b/src/test/java/co/elastic/support/diagnostics/TestDiagnosticService.java
@@ -131,10 +131,11 @@ class TestDiagnosticService {
 
             while (entries.hasMoreElements()) {
                 ZipEntry entry = entries.nextElement();
+                assertFalse(entry.getName().startsWith("./"), entry.getName());
 
                 if (!entry.isDirectory()) {
                     // Add file path without leading directory
-                    contents.put(entry.getName().replaceFirst("^(\\.\\/.+\\/)(.+)", "$2"), entry);
+                    contents.put(entry.getName().replaceFirst("^(.+\\/)(.+)", "$2"), entry);
                 }
             }
 


### PR DESCRIPTION
The leading `.` on zip entry names is ignored by (at least) the Mac OS
`unzip` utility which means that every file appears to have an absolute
path, so unpacking a diagnostics bundle emits a warning for every entry:

    warning:  stripped absolute path spec from ...

There's no need to prefix every entry name with `./`, so this commit
removes the prefix to avoid these warnings.