### PR TITLE
Adding APIs for synthetics

### DIFF
--- a/src/main/java/co/elastic/support/diagnostics/commands/RunKibanaQueries.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/RunKibanaQueries.java
@@ -61,6 +61,7 @@ public class RunKibanaQueries extends BaseQuery {
             "kibana_security_endpoint_metadata",
             "kibana_security_endpoint_trusted_apps",
             "kibana_security_exception_list",
+            "kibana_synthetics_monitors",
         }
     );
 
@@ -116,7 +117,8 @@ public class RunKibanaQueries extends BaseQuery {
 
         if (
             action.getName().equals("kibana_fleet_agents") ||
-            action.getName().equals("kibana_fleet_agent_policies")
+            action.getName().equals("kibana_fleet_agent_policies") ||
+            action.getName().equals("kibana_synthetics_monitors")
         ) {
             perPageField = "perPage";
         } else if (

--- a/src/main/resources/kibana-rest.yml
+++ b/src/main/resources/kibana-rest.yml
@@ -143,9 +143,30 @@ kibana_status:
   versions:
     ">= 5.0.0": "/api/status"
 
+kibana_synthetics_monitor_filters:
+  versions:
+    ">= 8.12.0": "/internal/synthetics/monitor/filters"
+
+# Disabled pending review
+#kibana_synthetics_monitors:
+#  versions:
+#    ">= 8.12.0": "/internal/synthetics/service/monitors"
+
+kibana_synthetics_private_locations:
+  versions:
+    ">= 8.12.0": "/api/synthetics/private_locations"
+
 kibana_task_manager_health:
   versions:
     ">= 7.11.0": "/api/task_manager/_health"
+
+kibana_uptime_locations:
+  versions:
+    ">= 8.12.0": "/internal/uptime/service/locations"
+
+kibana_uptime_settings:
+  versions:
+    ">= 8.12.0": "/api/uptime/settings"
 
 kibana_user:
   versions:


### PR DESCRIPTION
Adding following API calls from `8.12.0` (we may be able to set a lower minimum version if no sensitive data is returned) :
```
GET kbn:/internal/uptime/service/locations
GET kbn:/api/synthetics/private_locations
GET kbn:/api/uptime/settings
GET kbn:/internal/synthetics/monitor/filters
```

Additionally code for this API was added and API is disabled on purpose pending review that API does not include sensitive information :
```
GET kbn:/internal/synthetics/service/monitors?perPage=100&page=1
```

### Checklist

- [x] Review from dev required related to inclusion of sensitive data
