### PR TITLE
[Transform] Add basic stats

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -548,6 +548,11 @@ transform_stats:
     ">= 7.2.0 < 7.5.0": "/_data_frame/transforms/_stats"
     ">= 7.5.0": "/_transform/_stats"
 
+transform_basic_stats:
+  subdir: "commercial"
+  versions:
+    ">= 8.13.0": "/_transform/_stats?basic=true"
+
 watcher_stats:
   subdir: "commercial"
   versions:


### PR DESCRIPTION
Basic Stats was introduced in 8.13.0.  It is faster than Transform Stats and will skip checkpointing and other supporting API calls, making it return results more reliably.

### Checklist

- [X] I have verified that the APIs in this pull request do not return sensitive data

------------------------------

Testing:


Ran changes against 8.14 snapshot:
```zsh
local-diagnostics-20240404-210020 git:(main) ✗ ls commercial/transform*
commercial/transform_basic_stats.json  commercial/transform_stats.json
commercial/transform.json
```
```zsh
➜  local-diagnostics-20240404-210020 git:(main) ✗ cat commercial/transform_basic_stats.json | jq '.'
{
  "count": 1,
  "transforms": [
    {
      "id": "last-log-from-clientip",
      "state": "stopped",
      "stats": {
        "pages_processed": 0,
        "documents_processed": 0,
        "documents_indexed": 0,
        "documents_deleted": 0,
        "trigger_count": 0,
        "index_time_in_ms": 0,
        "index_total": 0,
        "index_failures": 0,
        "search_time_in_ms": 0,
        "search_total": 0,
        "search_failures": 0,
        "processing_time_in_ms": 0,
        "processing_total": 0,
        "delete_time_in_ms": 0,
        "exponential_avg_checkpoint_duration_ms": 0,
        "exponential_avg_documents_indexed": 0,
        "exponential_avg_documents_processed": 0
      },
      "checkpointing": {
        "last": {
          "checkpoint": 0
        }
      },
      "health": {
        "status": "green"
      }
    }
  ]
}
```
On version 8.12:

```zsh
➜  local-diagnostics-20240404-214214 git:(main) ✗ ls commercial/transform*
commercial/transform.json  commercial/transform_stats.json
```
