### PR TITLE
Make failure error more obvious

### DIFF
--- a/src/main/java/co/elastic/support/diagnostics/DiagnosticApp.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagnosticApp.java
@@ -52,7 +52,7 @@ public class DiagnosticApp {
         } catch (ShowHelpException she){
             SystemUtils.quitApp();
         } catch (Exception e) {
-            logger.error(Constants.CONSOLE,"Fatal error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
+            logger.error(Constants.CONSOLE,"\nFATAL ERROR occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
             logger.error( e);
         }
     }

--- a/src/main/java/co/elastic/support/diagnostics/DiagnosticApp.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagnosticApp.java
@@ -52,8 +52,7 @@ public class DiagnosticApp {
         } catch (ShowHelpException she){
             SystemUtils.quitApp();
         } catch (Exception e) {
-            logger.error(Constants.CONSOLE,"\nFATAL ERROR occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
-            logger.error( e);
+            logger.error(Constants.CONSOLE,"FATAL ERROR occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG, e);
         }
     }
 

--- a/src/main/java/co/elastic/support/monitoring/MonitoringExportApp.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringExportApp.java
@@ -42,7 +42,7 @@ public class MonitoringExportApp {
         } catch (ShowHelpException she){
             SystemUtils.quitApp();
         } catch (Exception e) {
-            logger.error(Constants.CONSOLE, "\nFATAL ERROR occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
+            logger.error(Constants.CONSOLE, "FATAL ERROR occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG, e);
         }
     }
 }

--- a/src/main/java/co/elastic/support/monitoring/MonitoringExportApp.java
+++ b/src/main/java/co/elastic/support/monitoring/MonitoringExportApp.java
@@ -42,7 +42,7 @@ public class MonitoringExportApp {
         } catch (ShowHelpException she){
             SystemUtils.quitApp();
         } catch (Exception e) {
-            logger.error(Constants.CONSOLE, "Fatal error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
+            logger.error(Constants.CONSOLE, "\nFATAL ERROR occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
         }
     }
 }

--- a/src/main/java/co/elastic/support/scrub/ScrubApp.java
+++ b/src/main/java/co/elastic/support/scrub/ScrubApp.java
@@ -46,7 +46,7 @@ public class ScrubApp {
         } catch (ShowHelpException she){
             SystemUtils.quitApp();
         } catch (Exception e) {
-            logger.error(Constants.CONSOLE,  "\nFATAL ERROR occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
+            logger.error(Constants.CONSOLE,  "FATAL ERROR occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG, e);
         }
     }
 

--- a/src/main/java/co/elastic/support/scrub/ScrubApp.java
+++ b/src/main/java/co/elastic/support/scrub/ScrubApp.java
@@ -46,7 +46,7 @@ public class ScrubApp {
         } catch (ShowHelpException she){
             SystemUtils.quitApp();
         } catch (Exception e) {
-            logger.error(Constants.CONSOLE,  "Fatal error occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
+            logger.error(Constants.CONSOLE,  "\nFATAL ERROR occurred: {}. {}", e.getMessage(), Constants.CHECK_LOG);
         }
     }
 


### PR DESCRIPTION
👋 howdy, team! 

We have users uploading empty (other than `diagnostics.log`) diagnostics to Support. AFAICT most come via the `Fatal error occurred` code path. This PR updates light console formatting to make this failure more obvious to users unfamiliar with our diagnostic (via a line-break and all-caps) so that they can rectify errors before uploading to reduce resolution time. 

TIA! 🙏