### PR TITLE
make cat node output header to be more understandable to both AI and human

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -73,7 +73,7 @@ cat_nodes:
   subdir: "cat"
   versions:
     ">= 0.9.0 < 6.0.0": "/_cat/nodes?v&h=n,nodeId,m,i,r,d,hp,rp,cpu,load_1m,load_5m,load_15m,"
-    ">= 6.0.0": "/_cat/nodes?v&h=n,nodeId,i,v,r,m,d,dup,hp,cpu,load_1m,load_5m,load_15m,iic,sfc,sqc,scc&s=n"
+    ">= 6.0.0": "/_cat/nodes?v&h=n,nodeId,i,v,role,m,d,dup,hp,cpu,load_1m,load_5m,load_15m,iic,sfc,sqc,scc&s=n"
 
 cat_pending_tasks:
   extension: ".txt"


### PR DESCRIPTION
### Checklist

- [ ] I have verified that the APIs in this pull request do not return sensitive data

When the output header appears as `role`, chatGPT can decipher what `himrst` means.

```
n                     nodeId m ip           role
tiebreaker-0000000008 lwjY   - 10.46.32.101 mv
instance-0000000001   dNbR   - 10.46.32.174 himrst
instance-0000000000   Xcwh   * 10.46.32.122 himrst
```