### PR TITLE
Upgrade commons-compress to 1.26.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.24.0</version>
+            <version>1.26.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Upgrade org.apache.commins:commons-compress to the current latest version (1.26.2) to avoid CVE-2024-25710. Even though I don't believe that the CVE affects this project, it's still better to upgrade to a non-vulnerable version.

### Checklist

- [x] I have verified that the APIs in this pull request do not return sensitive data
