### PR TITLE
Add per request functionality to add HTTP request headers

### DIFF
--- a/src/main/java/co/elastic/support/diagnostics/commands/BaseQuery.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/BaseQuery.java
@@ -78,6 +78,8 @@ public abstract class BaseQuery implements Command {
                     }
                 }
                 String fileName = subdir + SystemProperties.fileSeparator + entry.getName() + entry.getExtension();
+                restClient.setCurrentRestEntry(entry);
+                logger.debug("Execute RestClient: {} with extra headers: {}", entry.getName(), entry.getExtraHeaders());
                 RestResult restResult = restClient.execQuery(entry.getUrl(), fileName);
                 if (restResult.isValid()) {
                     logger.info(Constants.CONSOLE, "Results written to: {}", fileName);

--- a/src/main/java/co/elastic/support/diagnostics/commands/RunClusterQueries.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/RunClusterQueries.java
@@ -35,6 +35,10 @@ public class RunClusterQueries extends BaseQuery {
             entries.addAll(context.elasticRestCalls.values());
             RestClient client;
             client = context.resourceCache.getRestClient(Constants.restInputHost);
+
+            // Set headers for each RestEntry
+            entries.forEach(client::setCurrentRestEntry);
+
 /*            if(ResourceCache.resourceExists(Constants.restTargetHost)){
                 client = ResourceCache.getRestClient(Constants.restTargetHost);
             }

--- a/src/main/java/co/elastic/support/diagnostics/commands/RunLogstashQueries.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/RunLogstashQueries.java
@@ -47,6 +47,8 @@ public class RunLogstashQueries extends BaseQuery {
             Map<String, RestEntry> entries = builder.buildEntryMap(restCalls);
 
             List<RestEntry> queries = new ArrayList<>();
+            // Set headers for each RestEntry
+            queries.forEach(client::setCurrentRestEntry);
             queries.addAll(entries.values());
             runQueries(client, queries, context.tempDir, 0, 0);
 

--- a/src/main/java/co/elastic/support/rest/RestClient.java
+++ b/src/main/java/co/elastic/support/rest/RestClient.java
@@ -54,6 +54,9 @@ public class RestClient implements Closeable {
 
     private Map<String, String> extraHeaders;
 
+    private Map<String, RestEntry> restEntries;
+    private RestEntry currentRestEntry;
+
     public RestClient(CloseableHttpClient client, HttpHost httpHost, HttpClientContext context,
             Map<String, String> extraHeaders) {
         this.client = client;

--- a/src/main/java/co/elastic/support/rest/RestClient.java
+++ b/src/main/java/co/elastic/support/rest/RestClient.java
@@ -114,6 +114,15 @@ public class RestClient implements Closeable {
                 httpRequest.addHeader(entry.getKey(), entry.getValue());
             }
         }
+
+        // Then, add (or overwrite) with the per-call extra headers if RestEntry is provided
+        if (currentRestEntry != null && currentRestEntry.getExtraHeaders() != null) {
+            logger.debug("Adding extra headers from currentRestEntry: {}", currentRestEntry.getExtraHeaders());
+            for (Map.Entry<String, String> entry : currentRestEntry.getExtraHeaders().entrySet()) {
+                httpRequest.setHeader(entry.getKey(), entry.getValue());
+            }
+        }
+
         try {
             return client.execute(httpHost, httpRequest, httpContext);
         } catch (HttpHostConnectException e) {

--- a/src/main/java/co/elastic/support/rest/RestClient.java
+++ b/src/main/java/co/elastic/support/rest/RestClient.java
@@ -79,6 +79,11 @@ public class RestClient implements Closeable {
         return execRequest(httpGet);
     }
 
+    public void setCurrentRestEntry(RestEntry restEntry) {
+        this.currentRestEntry = restEntry;
+        logger.debug("Setting currentRestEntry with headers: {}", restEntry != null ? restEntry.getExtraHeaders() : "null");
+    }
+
     private HttpResponse execRequest(HttpRequestBase httpRequest) {
         if (extraHeaders != null) {
             for (Map.Entry<String, String> entry : extraHeaders.entrySet()) {

--- a/src/main/java/co/elastic/support/rest/RestClient.java
+++ b/src/main/java/co/elastic/support/rest/RestClient.java
@@ -79,6 +79,10 @@ public class RestClient implements Closeable {
         return execRequest(httpGet);
     }
 
+    public void setRestEntries(Map<String, RestEntry> restEntries) {
+        this.restEntries = restEntries;
+    }
+
     public void setCurrentRestEntry(RestEntry restEntry) {
         this.currentRestEntry = restEntry;
         logger.debug("Setting currentRestEntry with headers: {}", restEntry != null ? restEntry.getExtraHeaders() : "null");

--- a/src/main/java/co/elastic/support/rest/RestClient.java
+++ b/src/main/java/co/elastic/support/rest/RestClient.java
@@ -41,6 +41,7 @@ import java.io.Closeable;
 import java.io.FileInputStream;
 import java.io.UnsupportedEncodingException;
 import java.security.KeyStore;
+import java.util.Arrays;
 import java.util.Map;
 
 public class RestClient implements Closeable {
@@ -122,6 +123,8 @@ public class RestClient implements Closeable {
                 httpRequest.setHeader(entry.getKey(), entry.getValue());
             }
         }
+
+        logger.debug("Executing request with headers: " + Arrays.toString(httpRequest.getAllHeaders()) + " url " + httpRequest);
 
         try {
             return client.execute(httpHost, httpRequest, httpContext);

--- a/src/main/java/co/elastic/support/rest/RestClient.java
+++ b/src/main/java/co/elastic/support/rest/RestClient.java
@@ -66,17 +66,37 @@ public class RestClient implements Closeable {
     }
 
     public RestResult execQuery(String url) {
-        return new RestResult(execGet(url), url);
+        HttpRequestBase request = new HttpGet(url);
+
+        if (currentRestEntry != null && currentRestEntry.getExtraHeaders() != null) {
+            for (Map.Entry<String, String> header : currentRestEntry.getExtraHeaders().entrySet()) {
+                request.addHeader(header.getKey(), header.getValue());
+            }
+        }
+        logger.debug("Executing query: {} with currentRestEntry headers: {}", url, currentRestEntry != null ? currentRestEntry.getExtraHeaders() : "null");
+
+        return new RestResult(execGet(url, currentRestEntry), url);
     }
 
     public RestResult execQuery(String url, String fileName) {
-        return new RestResult(execGet(url), fileName, url);
+        HttpRequestBase request = new HttpGet(url);
+
+        if (currentRestEntry != null && currentRestEntry.getExtraHeaders() != null) {
+            for (Map.Entry<String, String> header : currentRestEntry.getExtraHeaders().entrySet()) {
+                request.addHeader(header.getKey(), header.getValue());
+            }
+        }
+        logger.debug("Executing query: {} with fileName: {} and currentRestEntry headers: {}", url, fileName, currentRestEntry != null ? currentRestEntry.getExtraHeaders() : "null");
+        return new RestResult(execGet(url, currentRestEntry), fileName, url);
     }
 
-    public HttpResponse execGet(String query) {
+    public HttpResponse execGet(String query, RestEntry restEntry) {
+        setCurrentRestEntry(restEntry);
         HttpGet httpGet = new HttpGet(query);
         logger.debug(query);
-        return execRequest(httpGet);
+        HttpResponse response = execRequest(httpGet);
+        setCurrentRestEntry(null);
+        return response;
     }
 
     public void setRestEntries(Map<String, RestEntry> restEntries) {
@@ -105,26 +125,44 @@ public class RestClient implements Closeable {
         }
     }
 
-    public HttpResponse execPost(String uri, String payload) {
+    public HttpResponse execPost(String uri, String payload, RestEntry restEntry) {
         try {
+            setCurrentRestEntry(restEntry);
             HttpPost httpPost = new HttpPost(uri);
             StringEntity entity = new StringEntity(payload);
             httpPost.setEntity(entity);
             httpPost.setHeader("Accept", "application/json");
             httpPost.setHeader("Content-type", "application/json");
             logger.debug(uri + SystemProperties.fileSeparator + payload);
-            return execRequest(httpPost);
+            HttpResponse response = execRequest(httpPost);
+            setCurrentRestEntry(null);
+            return response;
         } catch (UnsupportedEncodingException e) {
             logger.error(Constants.CONSOLE, "Error with json body.", e);
             throw new RuntimeException("Could not complete post request.");
         }
     }
 
-    public HttpResponse execDelete(String uri) {
+    public HttpResponse execDelete(String uri, RestEntry restEntry) {
+        setCurrentRestEntry(restEntry);
         HttpDelete httpDelete = new HttpDelete(uri);
         logger.debug(uri);
+        HttpResponse response = execRequest(httpDelete);
+        setCurrentRestEntry(null);
+        return response;
+    }
 
-        return execRequest(httpDelete);
+    // Add these methods to maintain backwards compatibility
+    public HttpResponse execGet(String query) {
+        return execGet(query, null);
+    }
+
+    public HttpResponse execPost(String uri, String payload) {
+        return execPost(uri, payload, null);
+    }
+
+    public HttpResponse execDelete(String uri) {
+        return execDelete(uri, null);
     }
 
     public void close() {

--- a/src/main/java/co/elastic/support/rest/RestEntry.java
+++ b/src/main/java/co/elastic/support/rest/RestEntry.java
@@ -49,6 +49,14 @@ public class RestEntry {
         this.spaceAware = spaceAware;
     }
 
+    public Map<String, String> getExtraHeaders() {
+        return extraHeaders;
+    }
+
+    public void setExtraHeaders(Map<String, String> extraHeaders) {
+        this.extraHeaders = extraHeaders;
+    }
+
     public RestEntry copyWithNewUrl(String url, String subdir) {
         return new RestEntry(name, subdir, extension, retry, url, showErrors, pageableFieldName, spaceAware);
     }

--- a/src/main/java/co/elastic/support/rest/RestEntry.java
+++ b/src/main/java/co/elastic/support/rest/RestEntry.java
@@ -7,6 +7,7 @@
 package co.elastic.support.rest;
 
 import lombok.Getter;
+import java.util.Map;
 
 @Getter
 public class RestEntry {
@@ -21,6 +22,7 @@ public class RestEntry {
     private final String pageableFieldName;
     private final boolean pageable;
     private final boolean spaceAware;
+    private Map<String, String> extraHeaders;
 
     public RestEntry(String name, String subdir, String extension, boolean retry, String url, boolean showErrors) {
         this(name, subdir, extension, retry, url, showErrors, null, false);

--- a/src/main/java/co/elastic/support/rest/RestEntryConfig.java
+++ b/src/main/java/co/elastic/support/rest/RestEntryConfig.java
@@ -74,20 +74,31 @@ public class RestEntryConfig {
             if (semver.satisfies(urlVersion.getKey())) {
                 if (urlVersion.getValue() instanceof String) {
                     return new RestEntry(name, subdir, extension, retry, (String) urlVersion.getValue(), showErrors);
-                    // We allow it to be String,String or String,Map(url,paginate,spaceaware)
+
                 } else if (urlVersion.getValue() instanceof Map) {
                     Map<String, Object> info = (Map<String, Object>) urlVersion.getValue();
-
                     String url = (String) ObjectUtils.defaultIfNull(info.get("url"), null);
-
                     if (url == null) {
                         throw new RuntimeException("Undefined URL for REST entry (route)");
                     }
-
                     String pageableFieldName = (String) ObjectUtils.defaultIfNull(info.get("paginate"), null);
                     boolean spaceAware = (boolean) ObjectUtils.defaultIfNull(info.get("spaceaware"), false);
 
-                    return new RestEntry(name, subdir, extension, retry, url, showErrors, pageableFieldName, spaceAware);
+                    // Construct the RestEntry object first
+                    RestEntry restEntry = new RestEntry(name, subdir, extension, retry, url, showErrors, pageableFieldName, spaceAware);
+
+                    // Logic for handling extra-headers, if they exist, after RestEntry is created
+                    if (info.containsKey("extra-headers")) {
+                        Object extraHeadersObj = info.get("extra-headers");
+                        if (extraHeadersObj instanceof Map) {
+                            Map<String, String> extraHeaders = (Map<String, String>) extraHeadersObj;
+                            // Add the extra headers to the restEntry (assuming this method is present on RestEntry)
+                            restEntry.setExtraHeaders(extraHeaders);
+                        }
+                    }
+
+                    // Return the constructed RestEntry with (potentially) extra headers
+                    return restEntry;
                 }
             }
         }

--- a/src/main/resources/kibana-rest.yml
+++ b/src/main/resources/kibana-rest.yml
@@ -44,14 +44,20 @@ kibana_data_views:
 # https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/common/detection_engine/rule_monitoring/api/detection_engine_health/README.md
 kibana_detection_engine_health_cluster:
   versions:
-    ">= 8.8.2": "/internal/detection_engine/health/_cluster"
+    ">= 8.8.2":
+      url: "/internal/detection_engine/health/_cluster"
+      extra-headers:
+        elastic-api-version: "1"
 
 # Calculates health of Detection Engine and returns a health snapshot.
 # Scope: all detection rules in the current/default Kibana space.
 # https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/common/detection_engine/rule_monitoring/api/detection_engine_health/README.md
 kibana_detection_engine_health_space:
   versions:
-    ">= 8.8.2": "/internal/detection_engine/health/_space"
+    ">= 8.8.2":
+      url: "/internal/detection_engine/health/_space"
+      extra-headers:
+        elastic-api-version: "1"
 
 kibana_detection_engine_privileges:
   versions:
@@ -71,7 +77,10 @@ kibana_detection_engine_rules_prebuilt_status:
   versions:
     ">= 7.10.0 < 7.15.0": "/api/detection_engine/prepackaged"
     ">= 7.15.0 < 8.9.0": "/api/detection_engine/rules/prepackaged/_status"
-    ">= 8.9.0": "/internal/detection_engine/prebuilt_rules/status"
+    ">= 8.9.0":
+      url: "/internal/detection_engine/prebuilt_rules/status"
+      extra-headers:
+        elastic-api-version: "1"
 
 kibana_fleet_agents:
   versions:
@@ -96,7 +105,10 @@ kibana_fleet_agent_status:
 
 kibana_fleet_agents_current_upgrades:
   versions:
-    ">= 8.3.0": "/api/fleet/agents/current_upgrades"
+    ">= 8.3.0":
+      url: "/api/fleet/agents/current_upgrades"
+      extra-headers:
+        elastic-api-version: "2023-10-31"
 
 kibana_lists_privileges:
   versions:


### PR DESCRIPTION
### Feature statement

Adds functionality to configure headers on a per request statement
Syntax example:
```
<requestname>:
  versions:
    ">= <stackversion>":
      url: "<api url"
      extra-headers:
        <header1>: "<header1value"
        <header2>: "<header2value" 
```

### Checklist

- [x] I have verified that the existing global header functionality in `config/diags.yml` from #519 still works
e.g.
```
extra-headers:
  elastic-api-version: "2023-10-31"
```
- [x] I have verified that the local headers in `{kibana|elastic|logstash}-rest.yaml` overwrite the global header functionality


Fixes elastic/support-diagnostics#657


