### PR TITLE
Do not get the whole pipeline definition in the Logstash API output

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -404,7 +404,7 @@ ilm_status:
 logstash_pipeline:
   subdir: "commercial"
   versions:
-    ">= 7.12.0": "/_logstash/pipeline"
+    ">= 7.12.0": "/_logstash/pipeline?filter_path=**,-*.pipeline"
 
 ml_anomaly_detectors:
   subdir: "commercial"


### PR DESCRIPTION
Do not get the whole pipeline definition in the Logstash API output.
Only return the Pipeline metadata & params

### Checklist

- [x] I have verified that the APIs in this pull request do not return sensitive data
