### PR TITLE
[Logstash] Add Health Report API output

### DIFF
--- a/src/main/resources/logstash-rest.yml
+++ b/src/main/resources/logstash-rest.yml
@@ -38,3 +38,7 @@ logstash_nodes_hot_threads_human:
 logstash_plugins:
   versions:
     "> 0.0.0": "/_node/plugins"
+
+logstash_health_report:
+  versions:
+    "> 8.16.0": "/_health_report"


### PR DESCRIPTION
Following https://github.com/elastic/logstash/pull/16520 and consequent https://www.elastic.co/guide/en/logstash/current/health-report-pipeline-flow-worker-utilization.html, I'm adding this API.

FYI @robbavey / @jsvd - I'm adding this API to the Support Diagnostic tool.
Is there any other way to leverage it's output? Should we add something to the Flow visualizer or our Logstash Visualizer?


### Checklist

- [X] I have verified that the APIs in this pull request do not return sensitive data
