### PR TITLE
Workaround for the semver issue with pre-release versions

### DIFF
--- a/src/main/java/co/elastic/support/diagnostics/commands/CheckElasticsearchVersion.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CheckElasticsearchVersion.java
@@ -89,6 +89,8 @@ public class CheckElasticsearchVersion implements Command {
         String result = res.toString();
         JsonNode root = JsonYamlUtils.createJsonNodeFromString(result);
         String version = root.path("version").path("number").asText();
-        return new Semver(version);
+        // Workaround for the semver issue with pre-release versions
+        // https://github.com/semver4j/semver4j/issues/307
+        return new Semver(version).withClearedPreRelease();
     }
 }

--- a/src/main/java/co/elastic/support/diagnostics/commands/CheckKibanaVersion.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CheckKibanaVersion.java
@@ -107,7 +107,9 @@ public class CheckKibanaVersion implements Command {
         logger.info(Constants.CONSOLE, String.format("Kibana Version is :%s", version));
 
         try {
-            return new Semver(version);
+            // Workaround for the semver issue with pre-release versions
+            // https://github.com/semver4j/semver4j/issues/307
+            return new Semver(version).withClearedPreRelease();
         } catch (SemverException ex) {
             throw new DiagnosticException(
                     String.format("Kibana version format is wrong - unable to continue. (%s)", version));

--- a/src/test/java/co/elastic/support/diagnostics/commands/TestCheckKibanaVersion.java
+++ b/src/test/java/co/elastic/support/diagnostics/commands/TestCheckKibanaVersion.java
@@ -105,9 +105,9 @@ public class TestCheckKibanaVersion {
 
     @Test
     public void testQueriesForKibanaWhenStatsWithRC() throws DiagnosticException {
-        initializeKibanaStats("8.0.0-rc2");
+        initializeKibanaStats("9.0.0-beta1");
         Semver version = new CheckKibanaVersion().getKibanaVersion(httpRestClient);
-        assertEquals("8.0.0-rc2", version.getVersion());
+        assertEquals("9.0.0", version.getVersion());
     }
 
     @Test


### PR DESCRIPTION
We came across an issue with failing tests in ECE when the tool is used against pre-release ECE stack versions (e.g. "9.0.0-beta1"). 
We tracked it down to [this semver defect](https://github.com/semver4j/semver4j/issues/307). 

The PR workarounds the problem by removing the pre-release part from version. 
It should not affect the usual workflow though but it can help us to reduce the number of failing tests in CI pipelines until the root cause get fixed.

Closes https://github.com/elastic/support-diagnostics/issues/795

### Checklist

- [] I have verified that the APIs in this pull request do not return sensitive data

Rel: https://elasticco.atlassian.net/browse/CP-10456