### PR TITLE
Add ML memory statistics to the collected diagnostics data

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -439,6 +439,11 @@ ml_info:
     ">= 6.3.0 < 7.0.0": "/_xpack/ml/info"
     ">= 7.0.0": "/_ml/info"
 
+ml_memory_stats:
+  subdir: "commercial"
+  versions:
+    ">= 8.2.0": "/_ml/memory/_stats"
+
 ml_stats:
   subdir: "commercial"
   versions:


### PR DESCRIPTION
This PR adds [machine learning memory usage collection](https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-ml-get-memory-stats) to the diagnostics bundle. 

### Checklist

- [x] I have verified that the APIs in this pull request do not return sensitive data
