### PR TITLE
[Maven] Move property directly to where it is used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <log4j.version>2.24.3</log4j.version>
-        <maven.compiler.proc>full</maven.compiler.proc>
     </properties>
 
     <dependencies>
@@ -271,6 +270,7 @@
                     <fork>true</fork>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <proc>full</proc>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
This moves the `maven.compiler.proc` property to the equivalent `proc` element under the maven compiler plugin.

This has no functional change on the build other than to simplify understanding as the property is not used by anything else.

### Checklist

- [x] I have verified that the APIs in this pull request do not return sensitive data
