### PR TITLE
Fix Logstash Flow metrics viewer

### DIFF
--- a/src/main/resources/logstash-diagnostic-templates/flow_metrics.html.ftlh
+++ b/src/main/resources/logstash-diagnostic-templates/flow_metrics.html.ftlh
@@ -14,7 +14,7 @@
             src="https://unpkg.com/react@18.2.0/umd/react.production.min.js"></script>
     <script src="https://unpkg.com/react-dom@18.2.0/umd/react-dom.production.min.js"></script>
     <script crossorigin="anonymous"
-            src="https://cdn.jsdelivr.net/npm/@mui/material@5.13.7/umd/material-ui.development.js"></script>
+            src="https://cdn.jsdelivr.net/npm/@mui/material@5.13.7/umd/material-ui.production.min.js"></script>
     <script crossorigin="anonymous"
             src="https://unpkg.com/babel-standalone@6.26.0/babel.min.js"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"

--- a/src/main/resources/logstash-diagnostic-templates/flow_metrics.html.ftlh
+++ b/src/main/resources/logstash-diagnostic-templates/flow_metrics.html.ftlh
@@ -13,6 +13,7 @@
     <script crossorigin="anonymous"
             src="https://unpkg.com/react@18.2.0/umd/react.production.min.js"></script>
     <script src="https://unpkg.com/react-dom@18.2.0/umd/react-dom.production.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@mui/material@5.13.7/umd/material-ui.development.js"></script>
     <script crossorigin="anonymous"
             src="https://unpkg.com/@mui/material@5.13.7/umd/material-ui.production.min.js"></script>
     <script crossorigin="anonymous"

--- a/src/main/resources/logstash-diagnostic-templates/flow_metrics.html.ftlh
+++ b/src/main/resources/logstash-diagnostic-templates/flow_metrics.html.ftlh
@@ -13,9 +13,8 @@
     <script crossorigin="anonymous"
             src="https://unpkg.com/react@18.2.0/umd/react.production.min.js"></script>
     <script src="https://unpkg.com/react-dom@18.2.0/umd/react-dom.production.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@mui/material@5.13.7/umd/material-ui.development.js"></script>
     <script crossorigin="anonymous"
-            src="https://unpkg.com/@mui/material@5.13.7/umd/material-ui.production.min.js"></script>
+            src="https://cdn.jsdelivr.net/npm/@mui/material@5.13.7/umd/material-ui.development.js"></script>
     <script crossorigin="anonymous"
             src="https://unpkg.com/babel-standalone@6.26.0/babel.min.js"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"


### PR DESCRIPTION
Prior to this commit, the Logstash Flow Metrics viewer was failing to render with 

```
Uncaught ReferenceError: MaterialUI is not defined
    at <anonymous>:9:19
    at i (babel.min.js:24:29679)
    at r (babel.min.js:24:30188)
    at o (babel.min.js:24:30596)
    at u (babel.min.js:24:30969)
    at f (babel.min.js:1:1812)
    at babel.min.js:1:6287
```

error.

### Checklist

- [x] I have verified that the APIs in this pull request do not return sensitive data
