### PR TITLE
Renaming the inference endpoint to drop the ml portion

### DIFF
--- a/src/main/resources/elastic-rest.yml
+++ b/src/main/resources/elastic-rest.yml
@@ -419,6 +419,11 @@ ilm_status:
   versions:
     ">= 6.6.0": "/_ilm/status"
 
+inference:
+  subdir: "commercial"
+  versions:
+    ">= 8.11.0": "/_inference"
+
 logstash_pipeline:
   subdir: "commercial"
   versions:
@@ -450,11 +455,6 @@ ml_dataframe_stats:
   subdir: "commercial"
   versions:
     ">= 7.3.0": "/_ml/data_frame/analytics/_stats"
-
-ml_inference:
-  subdir: "commercial"
-  versions:
-    ">= 8.11.0": "/_inference"
 
 ml_info:
   subdir: "commercial"


### PR DESCRIPTION
### Checklist

- [x] I have verified that the APIs in this pull request do not return sensitive data

The inference API is no longer part of the ml team so I'm removing the `ml_` prefix and moved the section so it's alphabetical.
