### PR TITLE
Update Logstash report to include batch's byte_size p100 and lifetime

### DIFF
--- a/src/main/resources/logstash-diagnostic-templates/flow_metrics.html.ftlh
+++ b/src/main/resources/logstash-diagnostic-templates/flow_metrics.html.ftlh
@@ -159,6 +159,30 @@
         }
     }
 
+    const _batchByteSizeAverageRolling = (pipelineName) => {
+        try {
+            const a = data.stats.pipelines[pipelineName].batch.byte_size.average;
+            if (!a) return "N/A";
+            for (const k of ["last_1_minute", "last_5_minutes", "last_15_minutes"]) {
+                const v = a[k];
+                if (v !== null && v !== undefined && v !== "") return v;
+            }
+        } catch (e) {}
+        return "N/A";
+    }
+
+    const _batchEventCountAverageRolling = (pipelineName) => {
+        try {
+            const a = data.stats.pipelines[pipelineName].batch.event_count.average;
+            if (!a) return "N/A";
+            for (const k of ["last_1_minute", "last_5_minutes", "last_15_minutes"]) {
+                const v = a[k];
+                if (v !== null && v !== undefined && v !== "") return v;
+            }
+        } catch (e) {}
+        return "N/A";
+    }
+
     const createComparisonFormatter = (
         analysisWindow,
         flow,
@@ -757,10 +781,9 @@
             };
         }
 
-        const hasBatchP50 = _try(() => data.stats.pipelines[selectedPipeline.name].batch.event_count.p50) !== ""
-            || _try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.p50) !== "";
-        const hasBatchP90 = _try(() => data.stats.pipelines[selectedPipeline.name].batch.event_count.p90) !== ""
-            || _try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.p90) !== "";
+        const hasBatchP50 = _try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.p50) !== "";
+        const hasBatchP90 = _try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.p90) !== "";
+        const hasBatchMax = _try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.max) !== "";
 
         return (
             <Stack spacing={2}>
@@ -865,8 +888,9 @@
                                             <TableCell>Metric</TableCell>
                                             <TableCell align="right">Current</TableCell>
                                             <TableCell align="right">Average</TableCell>
-                                            {hasBatchP50 && <TableCell align="center" colSpan={3}>p50</TableCell>}
-                                            {hasBatchP90 && <TableCell align="center" colSpan={3}>p90</TableCell>}
+                                            {hasBatchP50 && <TableCell align="center" colSpan={4}>p50</TableCell>}
+                                            {hasBatchP90 && <TableCell align="center" colSpan={4}>p90</TableCell>}
+                                            {hasBatchMax && <TableCell align="center" colSpan={4}>max</TableCell>}
                                         </TableRow>
                                         <TableRow>
                                             <TableCell />
@@ -876,11 +900,19 @@
                                                 <TableCell align="right">1 min</TableCell>
                                                 <TableCell align="right">5 min</TableCell>
                                                 <TableCell align="right">15 min</TableCell>
+                                                <TableCell align="right">Lifetime</TableCell>
                                             </React.Fragment>}
                                             {hasBatchP90 && <React.Fragment>
                                                 <TableCell align="right">1 min</TableCell>
                                                 <TableCell align="right">5 min</TableCell>
                                                 <TableCell align="right">15 min</TableCell>
+                                                <TableCell align="right">Lifetime</TableCell>
+                                            </React.Fragment>}
+                                            {hasBatchMax && <React.Fragment>
+                                                <TableCell align="right">1 min</TableCell>
+                                                <TableCell align="right">5 min</TableCell>
+                                                <TableCell align="right">15 min</TableCell>
+                                                <TableCell align="right">Lifetime</TableCell>
                                             </React.Fragment>}
                                         </TableRow>
                                     </TableHead>
@@ -888,31 +920,47 @@
                                         <TableRow>
                                             <TableCell component="th" scope="row">Event count</TableCell>
                                             <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.event_count.current)}</TableCell>
-                                            <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.event_count.average.lifetime)}</TableCell>
+                                            <TableCell align="right">{_batchEventCountAverageRolling(selectedPipeline.name)}</TableCell>
                                             {hasBatchP50 && <React.Fragment>
                                                 <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.event_count.p50.last_1_minute)}</TableCell>
                                                 <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.event_count.p50.last_5_minutes)}</TableCell>
                                                 <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.event_count.p50.last_15_minutes)}</TableCell>
+                                                <TableCell align="right">N/A</TableCell>
                                             </React.Fragment>}
                                             {hasBatchP90 && <React.Fragment>
                                                 <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.event_count.p90.last_1_minute)}</TableCell>
                                                 <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.event_count.p90.last_5_minutes)}</TableCell>
                                                 <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.event_count.p90.last_15_minutes)}</TableCell>
+                                                <TableCell align="right">N/A</TableCell>
+                                            </React.Fragment>}
+                                            {hasBatchMax && <React.Fragment>
+                                                <TableCell align="right">N/A</TableCell>
+                                                <TableCell align="right">N/A</TableCell>
+                                                <TableCell align="right">N/A</TableCell>
+                                                <TableCell align="right">N/A</TableCell>
                                             </React.Fragment>}
                                         </TableRow>
                                         <TableRow>
                                             <TableCell component="th" scope="row">Byte size</TableCell>
                                             <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.current)}</TableCell>
-                                            <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.average.lifetime)}</TableCell>
+                                            <TableCell align="right">{_batchByteSizeAverageRolling(selectedPipeline.name)}</TableCell>
                                             {hasBatchP50 && <React.Fragment>
                                                 <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.p50.last_1_minute)}</TableCell>
                                                 <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.p50.last_5_minutes)}</TableCell>
                                                 <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.p50.last_15_minutes)}</TableCell>
+                                                <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.p50.lifetime)}</TableCell>
                                             </React.Fragment>}
                                             {hasBatchP90 && <React.Fragment>
                                                 <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.p90.last_1_minute)}</TableCell>
                                                 <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.p90.last_5_minutes)}</TableCell>
                                                 <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.p90.last_15_minutes)}</TableCell>
+                                                <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.p90.lifetime)}</TableCell>
+                                            </React.Fragment>}
+                                            {hasBatchMax && <React.Fragment>
+                                                <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.max.last_1_minute)}</TableCell>
+                                                <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.max.last_5_minutes)}</TableCell>
+                                                <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.max.last_15_minutes)}</TableCell>
+                                                <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.max.lifetime)}</TableCell>
                                             </React.Fragment>}
                                         </TableRow>
                                     </TableBody>

--- a/src/main/resources/logstash-diagnostic-templates/flow_metrics.html.ftlh
+++ b/src/main/resources/logstash-diagnostic-templates/flow_metrics.html.ftlh
@@ -159,21 +159,18 @@
         }
     }
 
-    const _batchByteSizeAverageRolling = (pipelineName) => {
-        try {
-            const a = data.stats.pipelines[pipelineName].batch.byte_size.average;
-            if (!a) return "N/A";
-            for (const k of ["last_1_minute", "last_5_minutes", "last_15_minutes"]) {
-                const v = a[k];
-                if (v !== null && v !== undefined && v !== "") return v;
-            }
-        } catch (e) {}
-        return "N/A";
-    }
+    const BatchMetricType = Object.freeze({
+        BYTE_SIZE: 'byte_size',
+        EVENT_COUNT: 'event_count',
+    });
 
-    const _batchEventCountAverageRolling = (pipelineName) => {
+    /**
+    * @param {string} pipelineName
+    * @param {string} metricType One of BatchMetricType.BYTE_SIZE or BatchMetricType.EVENT_COUNT.
+    */
+    const _batchAverageRollingFor = (pipelineName, metricType) => {
         try {
-            const a = data.stats.pipelines[pipelineName].batch.event_count.average;
+            const a = data.stats.pipelines[pipelineName].batch[metricType].average;
             if (!a) return "N/A";
             for (const k of ["last_1_minute", "last_5_minutes", "last_15_minutes"]) {
                 const v = a[k];
@@ -920,7 +917,7 @@
                                         <TableRow>
                                             <TableCell component="th" scope="row">Event count</TableCell>
                                             <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.event_count.current)}</TableCell>
-                                            <TableCell align="right">{_batchEventCountAverageRolling(selectedPipeline.name)}</TableCell>
+                                            <TableCell align="right">{_batchAverageRollingFor(selectedPipeline.name, BatchMetricType.EVENT_COUNT)}</TableCell>
                                             {hasBatchP50 && <React.Fragment>
                                                 <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.event_count.p50.last_1_minute)}</TableCell>
                                                 <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.event_count.p50.last_5_minutes)}</TableCell>
@@ -943,7 +940,7 @@
                                         <TableRow>
                                             <TableCell component="th" scope="row">Byte size</TableCell>
                                             <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.current)}</TableCell>
-                                            <TableCell align="right">{_batchByteSizeAverageRolling(selectedPipeline.name)}</TableCell>
+                                            <TableCell align="right">{_batchAverageRollingFor(selectedPipeline.name, BatchMetricType.BYTE_SIZE)}</TableCell>
                                             {hasBatchP50 && <React.Fragment>
                                                 <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.p50.last_1_minute)}</TableCell>
                                                 <TableCell align="right">{_try(() => data.stats.pipelines[selectedPipeline.name].batch.byte_size.p50.last_5_minutes)}</TableCell>


### PR DESCRIPTION
Updates the report generated when taking Logstash diags to include the max percentile just for batch's byte_size. Furthermore, adds the lifetime window for all batch relates metrics (byte_size and event_count).

### Checklist

- [x] I have verified that the APIs in this pull request do not return sensitive data

## What the PR does?
Updates the HTML template file used to generate the report bundled with Logstash diagnostic to add the lifetime window column for all percentiles of batch structure metric.
In the same table add a new percentile, p100 or max which is available only for batch's byte_size metric.


Following a set of snapshots of the updated section:

<img width="1720" height="849" alt="Screenshot 2026-04-16 at 10 52 04" src="https://github.com/user-attachments/assets/f8f845fa-7f1f-4165-95b9-fe3fb2a48b39" />


- Closes https://github.com/elastic/logstash/issues/19008