### PR TITLE
fix: preserve exception cause in RestClient error handling

### DIFF
--- a/src/main/java/co/elastic/support/rest/RestClient.java
+++ b/src/main/java/co/elastic/support/rest/RestClient.java
@@ -121,7 +121,7 @@ public class RestClient implements Closeable {
                 client.close();
             }
         } catch (Exception e) {
-            logger.error("Error occurred closing client connection.");
+            logger.error("Error occurred closing client connection.", e);
         }
     }
 

--- a/src/main/java/co/elastic/support/rest/RestClient.java
+++ b/src/main/java/co/elastic/support/rest/RestClient.java
@@ -86,10 +86,10 @@ public class RestClient implements Closeable {
             return client.execute(httpHost, httpRequest, httpContext);
         } catch (HttpHostConnectException e) {
             logger.error("Host connection error.", e);
-            throw new RuntimeException("Host connection");
+            throw new RuntimeException("Host connection failed", e);
         } catch (Exception e) {
             logger.error("Unexpected Execution Error", e);
-            throw new RuntimeException(e.getMessage());
+            throw new RuntimeException("Unexpected error during HTTP execution", e);
         }
     }
 
@@ -104,7 +104,7 @@ public class RestClient implements Closeable {
             return execRequest(httpPost);
         } catch (UnsupportedEncodingException e) {
             logger.error(Constants.CONSOLE, "Error with json body.", e);
-            throw new RuntimeException("Could not complete post request.");
+            throw new RuntimeException("Could not complete post request.", e);
         }
     }
 

--- a/src/test/java/co/elastic/support/rest/TestRestExecCalls.java
+++ b/src/test/java/co/elastic/support/rest/TestRestExecCalls.java
@@ -31,6 +31,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -187,6 +189,31 @@ public class TestRestExecCalls {
 
         String targetFilename = temp + SystemProperties.fileSeparator + "nodes.json";
         assertTrue(fileExistsWithText(targetFilename, "autherror_response_body"));
+    }
+
+    @Test
+    public void testConnectionRefusedPreservesCause() {
+        RestClient unreachableClient = RestClient.getClient(
+            "localhost",
+            19999,
+            "http",
+            "elastic",
+            "elastic",
+            "",
+            0,
+            "",
+            "",
+            "",
+            "",
+            true,
+            Collections.emptyMap(),
+            1000,
+            1000,
+            1000);
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                        () -> unreachableClient.execGet("/"));
+        assertNotNull(ex.getCause(), "RuntimeException must preserve original cause");
     }
 
     private boolean fileExistsWithText(String filename, String compare) {


### PR DESCRIPTION
Wrapping original exceptions as causes in RuntimeException constructors across execRequest() and execPost() to retain full stack traces for debugging.