### PR TITLE
[Gradle] `chmod +x` scripts meant for execution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,6 +135,14 @@ val distZip by tasks.registering(Zip::class) {
         exclude("share_ad_job_state/tests/**")
     }
 
+    // Gradle's Zip task does not preserve source file permissions, so the
+    // executable bit on shell scripts must be set explicitly.
+    filesMatching("*.sh") {
+        permissions {
+            unix("0755")
+        }
+    }
+
     // Root docs
     from(".") {
         include("LICENSE.txt", "NOTICE.txt", "README.md")


### PR DESCRIPTION
Gradle strips the executable bit from the shell files when it puts them into the zip file. This adds the bit back.

Thanks to @aaronleder-elastic for pointing out that this was missing in 9.4.0.
