### PR TITLE
[Proposal] Collect Elasticsearch slow logs alongside existing logs

### DIFF
--- a/src/main/java/co/elastic/support/diagnostics/commands/CollectLogs.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CollectLogs.java
@@ -84,6 +84,12 @@ public  class CollectLogs implements Command {
             logListing = sysCmd.runCommand(logStatement).trim();
             fileList = extractFilesFromList(logListing, fileList, 3);
 
+            logStatement = logCalls.get("slowlog");
+            logStatement = logStatement.replace("{{CLUSTERNAME}}", clusterName);
+            logStatement = logStatement.replace("{{LOGPATH}}", logDir);
+            logListing = sysCmd.runCommand(logStatement).trim();
+            fileList = extractFilesFromList(logListing, fileList, 2);
+
             sysCmd.copyLogs(fileList, logDir, targetDir );
 
         } catch (Exception e) {

--- a/src/main/resources/diags.yml
+++ b/src/main/resources/diags.yml
@@ -68,6 +68,7 @@ linuxOS:
     elastic: "ls -alt {{LOGPATH}} | grep -e '{{CLUSTERNAME}}.log' -e '{{CLUSTERNAME}}_server.json' | awk '{print $9}'"
     elastic-arc: "ls -alt {{LOGPATH}} | grep '{{CLUSTERNAME}}-.*-1.log.gz' | awk '{print $9}'"
     gc: "ls -alt {{LOGPATH}} |  awk '/gc/ {print $9}'"
+    slowlog: "ls -alt {{LOGPATH}} | grep 'slowlog.json' | awk '{print $9}'"
     kibana: "ls -alt /var/log/kibana/ |  awk '/.json|.log/ {print $9}'"
     kibana-default-path: "/var/log/kibana/"
 
@@ -88,6 +89,7 @@ macOS:
     elastic: "ls -alt {{LOGPATH}} | grep -e '{{CLUSTERNAME}}.log' -e '{{CLUSTERNAME}}_server.json' | awk '{print $9}'"
     elastic-arc: "ls -alt {{LOGPATH}} | grep '{{CLUSTERNAME}}-.*-1.log.gz' | awk '{print $9}'"
     gc: "ls -alt {{LOGPATH}} |  awk '/gc/ {print $9}'"
+    slowlog: "ls -alt {{LOGPATH}} | grep 'slowlog.json' | awk '{print $9}'"
     kibana: "ls -alt /var/log/kibana/ |  awk '/.json|.log/ {print $9}'"
     kibana-default-path: "/var/log/kibana/"
 
@@ -107,6 +109,7 @@ winOS:
     elastic: "dir /b  /l /o:-d /a:-d {{LOGPATH}}\\{{CLUSTERNAME}}.log"
     elastic-arc: "dir /b  /l /o:-d /a:-d {{LOGPATH}}\\{{CLUSTERNAME}}-*.log.gz"
     gc: "dir /l /b /o:-d /a:-d {{LOGPATH}}\\gc.log.*"
+    slowlog: "dir /b  /l /o:-d /a:-d {{LOGPATH}}\\*slowlog.json"
 
 docker-container-ids: "{{dockerPath}} ps -q"
 


### PR DESCRIPTION
Adds slowlog entries to the per-OS log command maps in diags.yml and wires CollectLogs.java to fetch and copy the matching slowlog files. Collected by default, consistent with existing elastic/gc log handling.