### PR TITLE
[Buildkite Action] Reject Late Commits

### DIFF
--- a/.github/workflows/buildkite-pr-command.yml
+++ b/.github/workflows/buildkite-pr-command.yml
@@ -1,7 +1,8 @@
 # Lets a maintainer run Buildkite CI on a pull request on demand -- including fork
 # PRs, which Buildkite won't build automatically -- by commenting
 # "buildkite test this <sha>", naming the exact commit (>=7 hex chars) to build.
-# The named commit must match the PR's current head and must predate the comment.
+# The named commit must match the PR's current head and must have been pushed to
+# GitHub before the comment.
 # Only commenters with write access can trigger it; no fork code runs here (REST API only).
 # Requires a repo secret BUILDKITE_API_TOKEN scoped to `write_builds`.
 name: "Buildkite: build this PR on demand"
@@ -62,11 +63,30 @@ jobs:
             *) echo "::error::Requested commit ${REQUESTED} does not match the current PR head ${HEAD_SHA}."; exit 1 ;;
           esac
 
-          # The head commit must pre-date the comment (look it up in the head repo so fork
-          # commits resolve reliably). Refuse anything created at/after the request.
-          COMMIT_DATE=$(gh api "repos/${HEAD_REPO_FULL}/commits/${HEAD_SHA}" --jq '.commit.committer.date')
-          if [ "$(date -u -d "$COMMIT_DATE" +%s)" -ge "$(date -u -d "$COMMENT_CREATED_AT" +%s)" ]; then
-            echo "::error::Head commit ${HEAD_SHA} (${COMMIT_DATE}) is not earlier than the comment (${COMMENT_CREATED_AT})."
+          # Determine when GitHub *received* this commit by finding the matching PushEvent.
+          # We use the server-set PushEvent.created_at rather than the commit's own
+          # author/committer date.
+          # We retry briefly because the Events API is eventually-consistent and can lag.
+          # HEAD_SHA came from the API and is a bare hex string, so jq interpolation is safe.
+          PUSHED_AT=""
+          for attempt in 1 2 3; do
+            PUSHED_AT=$(gh api --paginate "repos/${HEAD_REPO_FULL}/events" \
+              --jq ".[] | select(.type==\"PushEvent\") | select(.payload.head==\"${HEAD_SHA}\" or (.payload.commits[]?.sha==\"${HEAD_SHA}\")) | .created_at" \
+              | head -n1)
+            [ -n "$PUSHED_AT" ] && break
+            sleep 10
+          done
+
+          # Fail closed: if we cannot find a push event we cannot prove the commit predates
+          # the comment, so we refuse to build it. (Re-comment once the push is indexed.)
+          if [ -z "$PUSHED_AT" ]; then
+            echo "::error::No push event found for ${HEAD_SHA} in ${HEAD_REPO_FULL}. The push may not be indexed yet or is outside the events window. Please re-comment once the push is visible."
+            exit 1
+          fi
+
+          # Refuse a commit pushed at or after the comment was posted.
+          if [ "$(date -u -d "$PUSHED_AT" +%s)" -ge "$(date -u -d "$COMMENT_CREATED_AT" +%s)" ]; then
+            echo "::error::Commit ${HEAD_SHA} was pushed at ${PUSHED_AT}, which is not earlier than the comment (${COMMENT_CREATED_AT}). Refusing to build a commit pushed after the request."
             exit 1
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,8 @@ handled by
 [`.github/workflows/buildkite-pr-command.yml`](.github/workflows/buildkite-pr-command.yml),
 which only triggers a build for commenters with write/maintain/admin access to
 this repository, and refuses to build if the hash is missing, malformed, does
-not match the PR's current head commit, or names a commit created after the
-comment.
+not match the PR's current head commit, or names a commit that was **pushed to
+GitHub at/after the comment**.
 
 Fork PRs naturally must be checked before running builds.
 


### PR DESCRIPTION
This ensures the action will not fire against the user-controlled commit date and instead relies on the server-side date.