### PR TITLE
Add dedicated retention cap for archived index/search slowlogs

### DIFF
--- a/src/main/java/co/elastic/support/diagnostics/DiagConfig.java
+++ b/src/main/java/co/elastic/support/diagnostics/DiagConfig.java
@@ -11,7 +11,7 @@ import co.elastic.support.BaseConfig;
 import java.util.Map;
 
 public class DiagConfig extends BaseConfig {
-    public int callRetries, pauseRetries, maxLogs, maxGcLogs;
+    public int callRetries, pauseRetries, maxLogs, maxGcLogs, maxSlowLogs;
 
     public DiagConfig(Map configuration) {
         super(configuration);
@@ -24,6 +24,7 @@ public class DiagConfig extends BaseConfig {
         Map<String, Integer> logSettings = (Map<String, Integer>) configuration.get("log-settings");
         maxGcLogs = logSettings.get("maxGcLogs");
         maxLogs = logSettings.get("maxLogs");
+        maxSlowLogs = logSettings.get("maxSlowLogs");
     }
 
     public Map<String, Map<String, String>> getSysCalls(String key){

--- a/src/main/java/co/elastic/support/diagnostics/commands/CollectLogs.java
+++ b/src/main/java/co/elastic/support/diagnostics/commands/CollectLogs.java
@@ -84,6 +84,16 @@ public  class CollectLogs implements Command {
             logListing = sysCmd.runCommand(logStatement).trim();
             fileList = extractFilesFromList(logListing, fileList, 3);
 
+	    logStatement = logCalls.get("slowlog-search");
+	    logStatement = logStatement.replace("{{LOGPATH}}", logDir);
+	    logListing = sysCmd.runCommand(logStatement).trim();
+	    fileList = extractFilesFromList(logListing, fileList, context.diagsConfig.maxSlowLogs - 1);
+
+	    logStatement = logCalls.get("slowlog-index");
+	    logStatement = logStatement.replace("{{LOGPATH}}", logDir);
+	    logListing = sysCmd.runCommand(logStatement).trim();
+	    fileList = extractFilesFromList(logListing, fileList, context.diagsConfig.maxSlowLogs - 1);
+
             sysCmd.copyLogs(fileList, logDir, targetDir );
 
         } catch (Exception e) {

--- a/src/main/resources/diags.yml
+++ b/src/main/resources/diags.yml
@@ -19,6 +19,7 @@
 log-settings:
   maxLogs: 3
   maxGcLogs: 3
+  maxSlowLogs: 3
 
 # Uncomment only if modifying defaults
 rest-config:
@@ -68,6 +69,8 @@ linuxOS:
     elastic: "ls -alt {{LOGPATH}} | grep -e '{{CLUSTERNAME}}.log' -e '{{CLUSTERNAME}}_server.json' | awk '{print $9}'"
     elastic-arc: "ls -alt {{LOGPATH}} | grep '{{CLUSTERNAME}}-.*-1.log.gz' | awk '{print $9}'"
     gc: "ls -alt {{LOGPATH}} |  awk '/gc/ {print $9}'"
+    slowlog-search: "ls -alt {{LOGPATH}} | grep '_index_search_slowlog' | awk '{print $9}'"
+    slowlog-index:  "ls -alt {{LOGPATH}} | grep '_index_indexing_slowlog' | awk '{print $9}'" 
     kibana: "ls -alt /var/log/kibana/ |  awk '/.json|.log/ {print $9}'"
     kibana-default-path: "/var/log/kibana/"
 
@@ -88,6 +91,8 @@ macOS:
     elastic: "ls -alt {{LOGPATH}} | grep -e '{{CLUSTERNAME}}.log' -e '{{CLUSTERNAME}}_server.json' | awk '{print $9}'"
     elastic-arc: "ls -alt {{LOGPATH}} | grep '{{CLUSTERNAME}}-.*-1.log.gz' | awk '{print $9}'"
     gc: "ls -alt {{LOGPATH}} |  awk '/gc/ {print $9}'"
+    slowlog-search: "ls -alt {{LOGPATH}} | grep '_index_search_slowlog' | awk '{print $9}'"
+    slowlog-index:  "ls -alt {{LOGPATH}} | grep '_index_indexing_slowlog' | awk '{print $9}'"
     kibana: "ls -alt /var/log/kibana/ |  awk '/.json|.log/ {print $9}'"
     kibana-default-path: "/var/log/kibana/"
 
@@ -107,6 +112,8 @@ winOS:
     elastic: "dir /b  /l /o:-d /a:-d {{LOGPATH}}\\{{CLUSTERNAME}}.log"
     elastic-arc: "dir /b  /l /o:-d /a:-d {{LOGPATH}}\\{{CLUSTERNAME}}-*.log.gz"
     gc: "dir /l /b /o:-d /a:-d {{LOGPATH}}\\gc.log.*"
+    slowlog-search: "dir /l /b /o:-d /a:-d {{LOGPATH}}\\*_index_search_slowlog*"
+    slowlog-index:  "dir /l /b /o:-d /a:-d {{LOGPATH}}\\*_index_indexing_slowlog*"
 
 docker-container-ids: "{{dockerPath}} ps -q"
 


### PR DESCRIPTION
Closes #1046

Slowlogs were not previously collected with their own retention cap, meaning archived search/indexing slowlogs competed with general *.log.gz archives under the shared maxLogs cap and could be evicted by unrelated log rotation. This adds a dedicated maxSlowLogs setting (default 3) and collects index_search_slowlog and
index_indexing_slowlog archives independently, following the same pattern already used for maxGcLogs.

Live slowlog files are already collected today with no opt-in flag, so this keeps the same always-on behavior and only changes the retention of archived files, rather than introducing a new flag.

Verified manually against a running 8.15.0 node: created 5 dummy search slowlog archives, confirmed only the 3 most recent were collected.

### Checklist

- [x] I have verified that the APIs in this pull request do not return sensitive data
